### PR TITLE
🎨 Palette: Modal and Overlay Accessibility Improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing ARIA Labels and Unassociated Form Labels in Custom Modals
+**Learning:** This application extensively uses custom modal implementations (`modal-field` wrapping an input and label). These custom components often lack semantic associations between labels and inputs, and use icon-only close buttons (`dash-close`) without ARIA labels. This presents a pattern of accessibility issues across all interactive overlay elements.
+**Action:** When implementing or editing modal or overlay components in this codebase, explicitly check for `<label for="...">` associations and `aria-label`s on icon-only interactive elements like close buttons.

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.html
+++ b/index.html
@@ -154,7 +154,7 @@
   <!-- Parent Dashboard Overlay -->
   <div class="dash-overlay" id="dash-overlay" onclick="if(event.target===this)closeDashboard()">
     <div class="dash-panel">
-      <h2>👨‍👩‍👧‍👦 Parent Dashboard <button class="dash-close" onclick="closeDashboard()">✕</button></h2>
+      <h2>👨‍👩‍👧‍👦 Parent Dashboard <button class="dash-close" aria-label="Close" onclick="closeDashboard()">✕</button></h2>
       <div id="dash-content"></div>
     </div>
   </div>
@@ -162,7 +162,7 @@
   <!-- Tareas del Hogar Overlay -->
   <div class="dash-overlay" id="chores-overlay" onclick="if(event.target===this)closeChores()">
     <div class="dash-panel">
-      <h2>🏠 Tareas del Hogar <button class="dash-close" onclick="closeChores()">✕</button></h2>
+      <h2>🏠 Tareas del Hogar <button class="dash-close" aria-label="Close" onclick="closeChores()">✕</button></h2>
       <div id="chores-content"></div>
     </div>
   </div>
@@ -170,7 +170,7 @@
   <!-- Parents Corner Overlay -->
   <div class="dash-overlay" id="parents-overlay" onclick="if(event.target===this)closeParentsCorner()">
     <div class="dash-panel">
-      <h2>🔒 Parents Corner <button class="dash-close" onclick="closeParentsCorner()">✕</button></h2>
+      <h2>🔒 Parents Corner <button class="dash-close" aria-label="Close" onclick="closeParentsCorner()">✕</button></h2>
       <div id="parents-content"></div>
       <div id="sync-section"></div>
     </div>
@@ -183,7 +183,7 @@
     <div class="modal">
       <h2>New Explorer 🌟</h2>
       <div class="modal-field">
-        <label>What's your name?</label>
+        <label for="new-name">What's your name?</label>
         <input type="text" id="new-name" maxlength="20" placeholder="e.g. Mateo" autocomplete="off">
       </div>
       <div class="modal-field">
@@ -216,6 +216,7 @@
       <input
         type="password"
         id="pin-input"
+        aria-label="Enter PIN"
         maxlength="8"
         inputmode="numeric"
         placeholder="····"
@@ -240,7 +241,7 @@
         <div class="edit-preview-name" id="edit-preview-name">Student</div>
       </div>
       <div class="modal-field">
-        <label>Name</label>
+        <label for="edit-name">Name</label>
         <input type="text" id="edit-name" maxlength="20" placeholder="Student name…" autocomplete="off">
       </div>
       <div class="modal-field">


### PR DESCRIPTION
**💡 What:** 
- Added `aria-label="Close"` to `dash-close` buttons in the parent, chores, and sync overlays.
- Added `for` attributes to `<label>` tags linked to `#new-name` and `#edit-name` inputs.
- Added `aria-label="Enter PIN"` to the `#pin-input` field for better screen reader context.

**🎯 Why:**
The custom modal implementations were missing semantic associations between labels and inputs, and the icon-only buttons had no accessible names. This made navigation difficult for users relying on screen readers or keyboard navigation.

**♿ Accessibility:**
Improves screen reader announcements for the primary form inputs used to create and edit profiles, and ensures the close buttons on overlays are properly identified.

---
*PR created automatically by Jules for task [15085782628932171478](https://jules.google.com/task/15085782628932171478) started by @rozavala*