### PR TITLE
Add fresh factual content to Math Galaxy and Descubre Chile

### DIFF
--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -130,8 +130,11 @@ const TOPICS=[
   ]},
   {id:'volcanes',icon:'🌋',name:'Volcanes de Chile',stories:[
     {t:'🌋 Cinturón de Fuego',p:'Chile está en el Cinturón de Fuego del Pacífico, una zona con muchos volcanes y terremotos. Hay más de 2.000 volcanes en Chile, y unos 90 están activos.',f:'El Nevado Ojos del Salado es el volcán más alto del mundo (6.891 m).'}
-  ]
-};
+  ]},
+  {id:'animales',icon:'🦙',name:'Fauna Local',stories:[
+    {t:'🦙 Vicuñas y Guanacos',p:'Son camélidos sudamericanos que habitan en los Andes. La vicuña vive a gran altitud y tiene una lana muy fina y valiosa.',f:'El guanaco es más grande y puede correr a casi 60 km/h.'}
+  ]}
+];
 let curTopic=null;
 
 function renderTopics(){
@@ -249,7 +252,10 @@ const QB={
     {q:'¿Qué volcán es uno de los más activos del sur?',a:'Villarrica',o:['Villarrica','Osorno','Llaima','Calbuco'], tier:'intermediate'},
     {q:'¿Cuál es el ancho promedio de Chile?',a:'177 km',o:['177 km','500 km','10 km','1.000 km'], tier:'expert'},
     {q:'¿Cuál es el archipiélago chileno famoso por sus iglesias de madera?',a:'Chiloé',o:['Chiloé','Juan Fernández','Galápagos','Malvinas'], tier:'advanced'},
-    {q:'¿En qué zona de Chile están los salares y géiseres?',a:'Norte',o:['Norte','Centro','Sur','Patagonia'], tier:'intermediate'}
+    {q:'¿En qué zona de Chile están los salares y géiseres?',a:'Norte',o:['Norte','Centro','Sur','Patagonia'], tier:'intermediate'},
+    {q:'¿Qué país comparte la cordillera de los Andes con Chile en la frontera este?',a:'Argentina',o:['Argentina','Perú','Bolivia','Brasil'], tier:'intermediate'},
+    {q:'¿Dónde se encuentran los glaciares milenarios como el Glaciar Grey?',a:'Patagonia',o:['Patagonia','Atacama','Valles Centrales','Isla de Pascua'], tier:'intermediate'},
+    {q:'¿A qué distancia de la costa está aproximadamente Isla de Pascua?',a:'3.700 km',o:['3.700 km','500 km','1.000 km','10.000 km'], tier:'advanced'}
   ],
   indigenous:[
     {q:'¿Qué significa "Mapuche"?',a:'Gente de la tierra',o:['Gente de la tierra','Guerreros de montaña','Hijos del sol','Guardianes del bosque'], tier:'beginner'},
@@ -266,7 +272,10 @@ const QB={
     {q:'¿De qué país era el padre de O\'Higgins?',a:'Irlanda',o:['Irlanda','España','Inglaterra','Francia'], tier:'advanced'},
     {q:'¿Qué pueblo originario resistió la conquista española?',a:'Mapuche',o:['Mapuche','Inca','Azteca','Maya'], tier:'beginner'},
     {q:'¿Junto a qué río se fundó Santiago?',a:'Mapocho',o:['Mapocho','Bío Bío','Loa','Maipo'], tier:'beginner'},
-    {q:'¿Qué cerro está en el centro de Santiago donde se fundó la ciudad?',a:'Santa Lucía',o:['Santa Lucía','San Cristóbal','Aconcagua','Manquehue'], tier:'advanced'}
+    {q:'¿Qué cerro está en el centro de Santiago donde se fundó la ciudad?',a:'Santa Lucía',o:['Santa Lucía','San Cristóbal','Aconcagua','Manquehue'], tier:'advanced'},
+    {q:'¿En qué año se fundó Santiago?',a:'1541',o:['1541','1810','1492','1600'], tier:'intermediate'},
+    {q:'¿En qué fecha ocurrió la Primera Junta de Gobierno?',a:'18 de septiembre de 1810',o:['18 de septiembre de 1810','12 de febrero de 1818','21 de mayo de 1879','1 de enero de 1800'], tier:'advanced'},
+    {q:'¿Qué país gobernó Chile antes de su independencia?',a:'España',o:['España','Inglaterra','Francia','Portugal'], tier:'beginner'}
   ],
   culture:[
     {q:'¿Qué lleva la empanada de pino?',a:'Carne, cebolla, huevo, aceitunas',o:['Carne, cebolla, huevo, aceitunas','Pollo con queso','Porotos con arroz','Pescado con limón'], tier:'beginner'},
@@ -303,6 +312,12 @@ const QB={
     {q:'¿Aproximadamente cuántos volcanes hay en Chile?',a:'Más de 2.000',o:['Más de 2.000','Unos 100','Alrededor de 50','Menos de 10'], tier:'intermediate'},
     {q:'¿Cuántos volcanes activos tiene Chile aproximadamente?',a:'Unos 90',o:['Unos 90','1.000','5','Ninguno'], tier:'expert'},
     {q:'¿Cuál es el volcán más alto del mundo ubicado en Chile?',a:'Nevado Ojos del Salado',o:['Nevado Ojos del Salado','Villarrica','Osorno','Llaima'], tier:'expert'}
+  ],
+  animales:[
+    {q:'¿Qué tipo de animales son las vicuñas y guanacos?',a:'Camélidos sudamericanos',o:['Camélidos sudamericanos','Roedores grandes','Aves andinas','Reptiles de altura'], tier:'intermediate'},
+    {q:'¿Dónde habita principalmente la vicuña?',a:'A gran altitud en los Andes',o:['A gran altitud en los Andes','En la costa del Pacífico','En los bosques del sur','En la selva lluviosa'], tier:'intermediate'},
+    {q:'¿Qué animal tiene una de las lanas más finas y valiosas?',a:'La vicuña',o:['La vicuña','La oveja común','El guanaco','El zorro'], tier:'advanced'},
+    {q:'¿A qué velocidad puede correr un guanaco?',a:'Casi 60 km/h',o:['Casi 60 km/h','Unos 10 km/h','Más de 100 km/h','30 km/h'], tier:'expert'}
   ]
 };
 
@@ -432,4 +447,5 @@ function dcInit(){
 document.addEventListener('DOMContentLoaded', dcInit);
 
 // === NEW CONTENT ADDED 2026-03-23 by Content Guardian Agent ===
+// Math Galaxy – 12 new problems added to generators
 // Descubre Chile – 1 new topic + 10 new quiz questions

--- a/js/math-galaxy.js
+++ b/js/math-galaxy.js
@@ -144,8 +144,19 @@ function generateDistractors(correct, count, min, max) {
    ================================================================ */
 
 function genCadet() {
-  const types = ['count', 'add', 'shape', 'bigger', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'moon_shape'];
+  const types = ['count', 'add', 'shape', 'bigger', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'moon_shape', 'alien_count', 'satellite_add', 'sun_shape'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'alien_count') {
+    const n = rand(1, 10);
+    return { label: 'Aliens', text: '👽'.repeat(n), hint: 'How many aliens?', answer: n, options: generateDistractors(n, 3, 1, 10), mode: 'choice' };
+  }
+  if (type === 'satellite_add') {
+    const a = rand(1, 5), b = rand(1, 5);
+    return { label: 'Satellite Math', text: `${a} 🛰️ + ${b} 🛰️ = ?`, hint: 'Add the satellites!', answer: a + b, options: generateDistractors(a + b, 3, 1, 10), mode: 'choice' };
+  }
+  if (type === 'sun_shape') {
+    return { label: 'Space Shapes', text: '☀️', hint: 'What shape is the sun?', answer: 'Circle', options: shuffle(['Circle', 'Square', 'Triangle', 'Star']), mode: 'choice' };
+  }
   if (type === 'astronaut_count') {
     const n = rand(1, 10);
     return { label: 'Astronauts', text: '👨‍🚀'.repeat(n), hint: 'How many astronauts?', answer: n, options: generateDistractors(n, 3, 1, 10), mode: 'choice' };
@@ -189,8 +200,21 @@ function genCadet() {
 }
 
 function genExplorer() {
-  const types = ['add', 'sub', 'missing', 'compare', 'double', 'alien_add', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'comet_compare'];
+  const types = ['add', 'sub', 'missing', 'compare', 'double', 'alien_add', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'comet_compare', 'meteor_sub', 'moon_pattern', 'rocket_compare'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'meteor_sub') {
+    const a = rand(6, 15), b = rand(1, a - 1);
+    return { label: 'Meteor Dash', text: `${a} ☄️ - ${b} ☄️ = ?`, hint: 'Subtract the meteors', answer: a - b, options: generateDistractors(a - b, 3, 1, 15), mode: 'choice' };
+  }
+  if (type === 'moon_pattern') {
+    return { label: 'Moon Pattern', text: '🌕 🌑 🌕 🌑 ?', hint: 'Which moon is next?', answer: '🌕', options: shuffle(['🌕', '🌑', '🌗', '🌙']), mode: 'choice' };
+  }
+  if (type === 'rocket_compare') {
+    const a = rand(10, 40), b = rand(10, 40);
+    if (a === b) return genExplorer();
+    const sym = a > b ? '>' : '<';
+    return { label: 'Rocket Fleet', text: `${a} 🚀  ◻  ${b} 🚀`, hint: 'Which is greater?', answer: sym, options: shuffle(['>', '<', '=']), mode: 'choice' };
+  }
   if (type === 'ufo_sub') {
     const a = rand(5, 12), b = rand(1, a - 1);
     return { label: 'UFO Escape', text: `${a} 🛸 - ${b} 🛸 = ?`, hint: 'Subtract the flying UFOs', answer: a - b, options: generateDistractors(a - b, 3, 1, 15), mode: 'choice' };
@@ -225,8 +249,20 @@ function genExplorer() {
 }
 
 function genPilot() {
-  const types = ['mult', 'div', 'frac_visual', 'word', 'missing_mult', 'comet_mult', 'asteroid_div', 'star_word', 'alien_mult', 'satellite_div', 'telescope_frac'];
+  const types = ['mult', 'div', 'frac_visual', 'word', 'missing_mult', 'comet_mult', 'asteroid_div', 'star_word', 'alien_mult', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'rocket_word'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'planet_mult') {
+    const a = rand(3, 9), b = rand(3, 9);
+    return { label: 'Planet Math', text: `${a} 🪐 × ${b} = ?`, hint: 'Total planets?', answer: a * b, options: generateDistractors(a * b, 3, 5, 90), mode: 'choice' };
+  }
+  if (type === 'ufo_div') {
+    const b = rand(2, 8), ans = rand(2, 8);
+    return { label: 'UFO Landing', text: `${b * ans} 🛸 ÷ ${b} = ?`, hint: 'Divide the UFOs', answer: ans, options: generateDistractors(ans, 3, 1, 10), mode: 'choice' };
+  }
+  if (type === 'rocket_word') {
+    const fuel = rand(6, 15), perShip = rand(2, 4);
+    return { label: 'Fleet Supply', text: `A fleet needs ${perShip} fuel units per ship. For ${fuel} ships?`, hint: 'Multiply to find total fuel.', answer: fuel * perShip, options: generateDistractors(fuel * perShip, 3, 10, 60), mode: 'choice' };
+  }
   if (type === 'alien_mult') {
     const a = rand(4, 9), b = rand(2, 6);
     return { label: 'Alien Multiply', text: `${a} 👾 × ${b} = ?`, hint: 'Total aliens?', answer: a * b, options: generateDistractors(a * b, 3, 5, 60), mode: 'choice' };
@@ -259,8 +295,31 @@ function genPilot() {
 }
 
 function genCommander() {
-  const types = ['big_add', 'big_mult', 'fraction_add', 'decimal', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops'];
+  const types = ['big_add', 'big_mult', 'fraction_add', 'decimal', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'comet_ops') {
+    const a = rand(20, 50), b = rand(4, 9), c = rand(2, 6);
+    const ans = a + (b * c);
+    return { label: 'Comet Path', text: `${a} ☄️ + ${b} ☄️ × ${c} = ?`, hint: 'Multiply first!', answer: ans, options: generateDistractors(ans, 3, 20, 100), mode: 'choice' };
+  }
+  if (type === 'star_decimal') {
+    const a = (rand(20, 99) / 10).toFixed(1);
+    const b = (rand(20, 99) / 10).toFixed(1);
+    const ans = (parseFloat(a) + parseFloat(b)).toFixed(1);
+    const opts = [ans];
+    while (opts.length < 4) {
+      const fake = (parseFloat(ans) + (rand(-40, 40) / 10)).toFixed(1);
+      if (!opts.includes(fake) && parseFloat(fake) > 0 && fake !== ans) opts.push(fake);
+    }
+    return { label: 'Star Mass', text: `${a} ⭐ + ${b} ⭐ = ?`, hint: 'Add the decimals.', answer: ans, options: shuffle(opts), mode: 'choice' };
+  }
+  if (type === 'asteroid_pct') {
+    const pcts = [10, 20, 25, 50];
+    const p = pcts[rand(0, pcts.length - 1)];
+    const mass = rand(50, 200) * 2;
+    const ans = mass * (p / 100);
+    return { label: 'Asteroid Ore', text: `${p}% of ${mass} tons`, hint: 'Find the percentage.', answer: ans, options: generateDistractors(ans, 3, 10, mass), mode: 'choice' };
+  }
   if (type === 'nebula_dec') {
     const a = (rand(10, 50) / 10).toFixed(1);
     const b = (rand(10, 50) / 10).toFixed(1);
@@ -452,3 +511,4 @@ document.addEventListener('DOMContentLoaded', initUserUI);
 
 // === NEW CONTENT ADDED 2026-03-23 by Content Guardian Agent ===
 // Math Galaxy – 12 new problems added to generators
+// Descubre Chile – 1 new topic + 10 new quiz questions


### PR DESCRIPTION
- `math-galaxy.js`: Added 3 new uniquely generated questions to `genCadet()`, `genExplorer()`, `genPilot()`, and `genCommander()` for a total of 12 new questions covering space-themed arithmetic, fractions, decimals, and logic.
- `descubre-chile.js`: Fixed a preexisting syntax error in the `TOPICS` array. Added the `animales` topic with 4 quiz questions. Added 3 new factual questions to `geography` and 3 to `history` quiz banks.
- Verified additions comply with `content-guidelines.md` rules and successfully tested for restricted keywords. Validated JS syntax with `node -c`.

---
*PR created automatically by Jules for task [10783246794601844915](https://jules.google.com/task/10783246794601844915) started by @rozavala*