### PR TITLE
🎨 Palette: Enhance accessibility of modals and icon-only close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,3 @@
-## 2024-05-18 - Missing ARIA Labels and Unassociated Form Labels in Custom Modals
-**Learning:** This application extensively uses custom modal implementations (`modal-field` wrapping an input and label). These custom components often lack semantic associations between labels and inputs, and use icon-only close buttons (`dash-close`) without ARIA labels. This presents a pattern of accessibility issues across all interactive overlay elements.
-**Action:** When implementing or editing modal or overlay components in this codebase, explicitly check for `<label for="...">` associations and `aria-label`s on icon-only interactive elements like close buttons.
+## 2024-05-24 - Accessibility Patterns in Custom Modals
+**Learning:** The custom modal implementations (e.g., using `modal-field`) in this app often lack semantic `<label for="...">` associations for inputs. In addition, the icon-only close buttons (e.g., `.dash-close`) often miss `aria-label`s. This presents a recurring pattern of accessibility issues across all interactive overlay elements.
+**Action:** Whenever implementing or editing modal or overlay components in this codebase, explicitly check for `<label for="...">` associations and `aria-label`s on icon-only interactive elements like close buttons to ensure full accessibility.

--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@
   <!-- Parent Dashboard Overlay -->
   <div class="dash-overlay" id="dash-overlay" onclick="if(event.target===this)closeDashboard()">
     <div class="dash-panel">
-      <h2>👨‍👩‍👧‍👦 Parent Dashboard <button class="dash-close" onclick="closeDashboard()">✕</button></h2>
+      <h2>👨‍👩‍👧‍👦 Parent Dashboard <button class="dash-close" aria-label="Close Parent Dashboard" onclick="closeDashboard()">✕</button></h2>
       <div id="dash-content"></div>
     </div>
   </div>
@@ -172,7 +172,7 @@
   <!-- Tareas del Hogar Overlay -->
   <div class="dash-overlay" id="chores-overlay" onclick="if(event.target===this)closeChores()">
     <div class="dash-panel">
-      <h2>🏠 Tareas del Hogar <button class="dash-close" onclick="closeChores()">✕</button></h2>
+      <h2>🏠 Tareas del Hogar <button class="dash-close" aria-label="Close Tareas del Hogar" onclick="closeChores()">✕</button></h2>
       <div id="chores-content"></div>
     </div>
   </div>
@@ -180,7 +180,7 @@
   <!-- Parents Corner Overlay -->
   <div class="dash-overlay" id="parents-overlay" onclick="if(event.target===this)closeParentsCorner()">
     <div class="dash-panel">
-      <h2>🔒 Parents Corner <button class="dash-close" onclick="closeParentsCorner()">✕</button></h2>
+      <h2>🔒 Parents Corner <button class="dash-close" aria-label="Close Parents Corner" onclick="closeParentsCorner()">✕</button></h2>
       <div id="parents-content"></div>
       <div id="sync-section"></div>
     </div>
@@ -193,7 +193,7 @@
     <div class="modal">
       <h2>Add New Player 🚀</h2>
       <div class="modal-field">
-        <label>Name</label>
+        <label for="new-name">Name</label>
         <input type="text" id="new-name" maxlength="20" placeholder="e.g. Mateo" autocomplete="off">
       </div>
       <div class="modal-field">
@@ -250,7 +250,7 @@
         <div class="edit-preview-name" id="edit-preview-name">Student</div>
       </div>
       <div class="modal-field">
-        <label>Name</label>
+        <label for="edit-name">Name</label>
         <input type="text" id="edit-name" maxlength="20" placeholder="Student name…" autocomplete="off">
       </div>
       <div class="modal-field">


### PR DESCRIPTION
💡 **What**: The UX enhancement added:
- Semantic `<label for="...">` associations for inputs inside `.modal-field` containers in `index.html`.
- Informative `aria-label` attributes to the `.dash-close` icon-only buttons across all overlay components in `index.html`.
- A new `.Jules/palette.md` document logging this accessibility issue pattern and setting guidelines to avoid it in future updates.

🎯 **Why**: The user problem it solves:
- Screen readers previously could not reliably read input field names when the user focused them because they were not explicitly linked to their corresponding `<label>`.
- Screen readers would simply announce "button" or the Unicode "✕" for the close buttons, providing poor context for users relying on assistive technologies.

📸 **Before/After**: The visual appearance remains exactly the same as intended. The changes strictly focus on semantic HTML attributes for accessibility underneath. 

♿ **Accessibility**: Significant improvements made:
- Added `aria-label`s to explicitly define the function of close buttons on modals and overlays.
- Ensured form inputs are semantically linked to their visible labels using the `for` attribute.

---
*PR created automatically by Jules for task [14413790254695440280](https://jules.google.com/task/14413790254695440280) started by @rozavala*