### PR TITLE
fix: Resolve Sports Arena and Learning Checks integration issues

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -153,6 +153,13 @@ function getPlayerStats(userName) {
     if ((as.totalStars || 0) > 0) { totalStars += as.totalStars; appsWithStars++; }
   } catch {}
 
+  // Sports Arena
+  try {
+    const sa = JSON.parse(localStorage.getItem(`zs_sports_${key}`)) || {};
+    appStats.sports = sa;
+    if ((sa.totalStars || 0) > 0) { totalStars += sa.totalStars; appsWithStars++; }
+  } catch {}
+
   return { totalStars, appsWithStars, appStats };
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -218,7 +218,7 @@
           else if (app.name === 'Fe Explorador') hasProg = (data.totalStars || 0) > 0;
           else if (app.name === 'Guitar Jam') hasProg = (data.totalStars || 0) > 0;
           else if (app.name === 'Art Studio') hasProg = (data.totalStars || 0) > 0;
-          else if (app.name === 'Sports Arena') hasProg = (data.totalMatches || 0) + (data.totalActivities || 0) > 0;
+          else if (app.name === 'Sports Arena') hasProg = (data.matches || []).length + (data.activities || []).length > 0;
           
           if (!hasProg) noProgress.push(app);
         } catch { noProgress.push(app); }
@@ -339,11 +339,13 @@
 
         // Sports Arena stats
         try {
-          const sports = typeof SportsArena !== 'undefined' ? SportsArena.getStats() : null;
-          if (els.sports && sports && (sports.totalMatches + sports.totalActivities) > 0) {
+          const sa = appStats.sports || JSON.parse(localStorage.getItem(`zs_sports_${key}`)) || {};
+          const matchCount = (sa.matches || []).length;
+          const actCount = (sa.activities || []).length;
+          if (els.sports && (matchCount + actCount) > 0) {
             els.sports.innerHTML = `
               <span style="font-size:0.78rem; font-weight:700; color:var(--text-muted);">
-                ⭐ ${sports.totalStars} · ${sports.totalMatches} matches · ${sports.totalActivities} activities
+                ⭐ ${sa.totalStars || 0} · ${matchCount} matches · ${actCount} activities
               </span>
             `;
           }
@@ -418,6 +420,17 @@
             appRows += `<div class="dash-app-row"><span class="dash-app-icon">🎨</span>
               <span class="dash-app-name">Art Studio</span>
               <span class="dash-app-stat">⭐ ${as.totalStars} · ${artworks} artworks · ${lessons} lessons</span></div>`;
+          }
+        } catch {}
+
+        try {
+          const sa = JSON.parse(localStorage.getItem(`zs_sports_${key}`)) || {};
+          const matchCount = (sa.matches || []).length;
+          const actCount = (sa.activities || []).length;
+          if (matchCount + actCount > 0) {
+            appRows += `<div class="dash-app-row"><span class="dash-app-icon">🏓</span>
+              <span class="dash-app-name">Sports Arena</span>
+              <span class="dash-app-stat">⭐ ${sa.totalStars || 0} · ${matchCount} matches · ${actCount} activities</span></div>`;
           }
         } catch {}
 
@@ -1015,6 +1028,8 @@ function createProfile() {
       localStorage.removeItem(`zs_fe_${key}`);
       localStorage.removeItem(`zs_guitar_${key}`);
       localStorage.removeItem(`zs_art_${key}`);
+      localStorage.removeItem(`zs_sports_${key}`);
+      localStorage.removeItem(`zs_lcheck_${key}`);
       localStorage.removeItem(`zs_lastrank_${key}`);
 
       // Remove from Little Maestro index if present
@@ -1060,6 +1075,8 @@ function createProfile() {
         `zs_fe_`,
         `zs_guitar_`,
         `zs_art_`,
+        `zs_sports_`,
+        `zs_lcheck_`,
         `zs_lastrank_`,
       ];
 

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -11,7 +11,7 @@
      zs_schedule_override  → { [dayIndex]: ['piano','math',...] }  (parent overrides)
      zs_schedule_mode      → 'smart' | 'custom'
    
-   The hub's renderAppCards() calls AppSchedule.getVisibleApps()
+   The hub's renderAppCards() calls AppSchedule.getTodayApps()
    to decide which cards to show/hide.
    ================================================================ */
 
@@ -33,13 +33,13 @@ const AppSchedule = (() => {
   // ── Smart defaults: 4–5 apps per day, every app appears 3–4x/week ──
   // Days: 0=Sun, 1=Mon, 2=Tue, 3=Wed, 4=Thu, 5=Fri, 6=Sat
   const SMART_SCHEDULE = {
-    0: ['piano', 'chile', 'art', 'sports'],           // Sunday — relaxed: music, culture, creativity, outdoor
-    1: ['math', 'chess', 'guitar', 'sports'],          // Monday — logic + music + outdoor
+    0: ['piano', 'chile', 'art'],           // Sunday — relaxed: music, culture, creativity
+    1: ['math', 'chess', 'guitar'],          // Monday — logic + music
     2: ['piano', 'chile', 'art', 'math'],              // Tuesday — well-rounded
-    3: ['math', 'chess', 'guitar', 'sports'],          // Wednesday — strategy day
-    4: ['piano', 'art', 'chile', 'sports'],            // Thursday — creative + culture
+    3: ['math', 'chess', 'guitar'],          // Wednesday — strategy day
+    4: ['piano', 'art', 'chile'],            // Thursday — creative + culture
     5: ['math', 'guitar', 'chess', 'art'],             // Friday — challenge day
-    6: ['piano', 'chile', 'guitar', 'sports', 'art'],  // Saturday — big day, more apps
+    6: ['piano', 'chile', 'guitar', 'art'],  // Saturday — big day, more apps
   };
 
   // Faith is handled separately (faithVisible toggle) — if visible, always included

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -238,6 +238,7 @@
 <script src="js/auth.js"></script>
 <script src="js/sync.js"></script>
 <script src="js/nav.js"></script>
+<script src="js/sounds.js"></script>
 <script src="js/timer.js"></script>
 <script src="js/sports-arena.js"></script>
 <script>
@@ -273,7 +274,8 @@
 
   // ── Init ──
   document.addEventListener('DOMContentLoaded', () => {
-    if (typeof TimerManager !== 'undefined') TimerManager.start();
+    // TimerManager intentionally NOT started — Sports Arena is outdoor activity logging,
+    // not screen time. Timer is loaded but idle so lock overlay doesn't block access.
     updateMenuStats();
   });
 
@@ -690,7 +692,7 @@
       historyEl.innerHTML = '<div style="color:var(--text-muted); font-weight:600; font-size:0.9rem;">No matches recorded yet.</div>';
     } else {
       historyEl.innerHTML = recent.map(m => {
-        const sport = SportsArena.getAllSports().find(s => s.id === m.score1 > m.score2 ? m.sportId : m.sportId); // Fixed logic here
+        const sport = SportsArena.getAllSports().find(s => s.id === m.sportId);
         const date = new Date(m.date);
         const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
         const winner = m.winner === 'draw' ? 'Draw' : m.winner;


### PR DESCRIPTION
This PR resolves a series of 11 specific bugs and missing integration pieces found during an audit of the `Sports Arena` and `Learning Checks` apps. 

The most critical fixes involve resolving progress detection bugs, correctly removing and migrating `localStorage` keys for the new apps during profile editing, preventing the timer from starting inside the Sports Arena app (as outdoor activities should not count against screen time), correctly displaying Sports Arena statistics in the hub, and ensuring stars earned count towards the global explorer rank. All requested changes from the provided CLI prompt were implemented.

---
*PR created automatically by Jules for task [10581166786555205649](https://jules.google.com/task/10581166786555205649) started by @rozavala*