### PR TITLE
🎨 Palette: Add semantic accessibility to modal field pickers

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,16 +215,16 @@
         <input type="text" id="new-name" maxlength="20" placeholder="e.g. Mateo" autocomplete="off">
       </div>
       <div class="modal-field">
-        <label>How old are you?</label>
-        <div class="age-picker" id="age-picker"></div>
+        <label id="label-age">How old are you?</label>
+        <div class="age-picker" id="age-picker" role="group" aria-labelledby="label-age"></div>
       </div>
       <div class="modal-field">
-        <label>Avatar</label>
-        <div class="emoji-picker" id="emoji-picker"></div>
+        <label id="label-avatar">Avatar</label>
+        <div class="emoji-picker" id="emoji-picker" role="group" aria-labelledby="label-avatar"></div>
       </div>
       <div class="modal-field">
-        <label>Color</label>
-        <div class="color-picker" id="color-picker"></div>
+        <label id="label-color">Color</label>
+        <div class="color-picker" id="color-picker" role="group" aria-labelledby="label-color"></div>
       </div>
       <div class="modal-actions">
         <button class="btn-cancel" onclick="closeModal()">Cancel</button>
@@ -273,16 +273,16 @@
         <input type="text" id="edit-name" maxlength="20" placeholder="Student name…" autocomplete="off">
       </div>
       <div class="modal-field">
-        <label>Age</label>
-        <div class="age-picker" id="edit-age-picker"></div>
+        <label id="label-edit-age">Age</label>
+        <div class="age-picker" id="edit-age-picker" role="group" aria-labelledby="label-edit-age"></div>
       </div>
       <div class="modal-field">
-        <label>Avatar</label>
-        <div class="emoji-picker" id="edit-emoji-picker"></div>
+        <label id="label-edit-avatar">Avatar</label>
+        <div class="emoji-picker" id="edit-emoji-picker" role="group" aria-labelledby="label-edit-avatar"></div>
       </div>
       <div class="modal-field">
-        <label>Color</label>
-        <div class="color-picker" id="edit-color-picker"></div>
+        <label id="label-edit-color">Color</label>
+        <div class="color-picker" id="edit-color-picker" role="group" aria-labelledby="label-edit-color"></div>
       </div>
       <p id="edit-error" style="color:#EF4444;font-size:0.8rem;font-weight:700;display:none;"></p>
       <div class="edit-actions">

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -250,7 +250,7 @@ const AppSchedule = (() => {
     overlay.innerHTML = `
       <div class="dash-panel" style="max-width:400px;">
         <h2>📅 ${DAYS[dayIndex]} 
-          <button class="dash-close" onclick="document.getElementById('schedule-day-overlay').classList.remove('active')">✕</button>
+          <button class="dash-close" aria-label="Close" onclick="document.getElementById('schedule-day-overlay').classList.remove('active')">✕</button>
         </h2>
         <div style="font-size:0.85rem; color:var(--text-muted); margin-bottom:16px;">
           Pick which apps are available on ${DAYS[dayIndex]}s.<br>


### PR DESCRIPTION
💡 **What:** Added semantic ARIA labels and roles to custom group pickers (age, avatar, color) and an icon-only close button.
🎯 **Why:** Custom `.modal-field` implementations lack semantic `<label for="...>` associations because they do not wrap standard `<input>` elements. Screen readers could not determine what the color/emoji/age groups represented. Additionally, the icon-only schedule close button was missing an `aria-label`.
📸 **Before/After:** No visual changes.
♿ **Accessibility:**
- Custom pickers now have `role="group"` and `aria-labelledby="<label-id>"`.
- The `schedule.js` overlay close button now has `aria-label="Close"`.

---
*PR created automatically by Jules for task [11426130403290613156](https://jules.google.com/task/11426130403290613156) started by @rozavala*