### PR TITLE
Add new content to Math Galaxy and Descubre Chile apps

### DIFF
--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -100,6 +100,10 @@ const TOPICS=[
     {t:'🌎 La forma de Chile',p:'Chile se extiende por más de 4.300 km de norte a sur, pero en promedio solo tiene 177 km de ancho.',f:'Si pusieras a Chile sobre Europa, llegaría desde Noruega hasta el Sahara.'},
     {t:'🗻 Los Andes',p:'Los poderosos Andes recorren toda la frontera este. Algunos picos superan los 6.000 metros.',f:'Chile tiene más de 2.000 volcanes, ¡y unos 90 están activos!'}
   ]},
+  {id:'antartica',icon:'🧊',name:'La Antártica Chilena',stories:[
+    {t:'❄️ El Continente Blanco',p:'La Antártica es el lugar más frío, seco y ventoso del planeta. Gran parte de ella está cubierta de hielo durante todo el año.',f:'En la Antártica no viven osos polares, ¡pero sí hay muchos pingüinos!'},
+    {t:'🏔️ Territorio Chileno Antártico',p:'Chile tiene bases científicas y militares en la Antártica, donde investigadores estudian el clima, la flora y la fauna del lugar.',f:'Villa Las Estrellas es un poblado en la Antártica donde viven familias e incluso hay una escuela.'}
+  ]},
   {id:'indigenous',icon:'🪶',name:'Pueblos originarios',stories:[
     {t:'🪶 Los Mapuche',p:'Los Mapuche ("gente de la tierra") son el pueblo originario más grande de Chile. Nunca fueron conquistados por España.',f:'Defendieron sus tierras por más de 300 años, desde 1536 hasta 1883.'},
     {t:'🗿 Rapa Nui',p:'Isla de Pascua está a 3.700 km de la costa. Los Rapa Nui tallaron casi 1.000 estatuas Moai gigantes.',f:'Nadie sabe con certeza cómo movieron los Moai.'},
@@ -270,7 +274,16 @@ const QB={
     {q:'¿A qué distancia de la costa está aproximadamente Isla de Pascua?',a:'3.700 km',o:['3.700 km','500 km','1.000 km','10.000 km'], tier:'advanced'},
     {q:'¿En qué hemisferio se encuentra Chile?',a:'Hemisferio Sur',o:['Hemisferio Sur','Hemisferio Norte','Hemisferio Oriental','En el Ecuador'], tier:'beginner'},
     {q:'¿Cuál es la capital de Chile?',a:'Santiago',o:['Santiago','Valparaíso','Concepción','Antofagasta'], tier:'beginner'},
-    {q:'¿Qué país está al norte de Chile?',a:'Perú',o:['Perú','Argentina','Bolivia','Brasil'], tier:'intermediate'}
+    {q:'¿Qué país está al norte de Chile?',a:'Perú',o:['Perú','Argentina','Bolivia','Brasil'], tier:'intermediate'},
+    {q:'¿Cuál es el lago más grande de Chile?',a:'Lago General Carrera',o:['Lago General Carrera','Lago Llanquihue','Lago Villarrica','Lago Ranco'], tier:'advanced'},
+    {q:'¿Qué cordillera recorre la costa chilena?',a:'Cordillera de la Costa',o:['Cordillera de la Costa','Cordillera de los Andes','Cordillera Frontal','Cordillera Domeyko'], tier:'intermediate'},
+    {q:'¿En qué región se encuentra el desierto de Atacama?',a:'Norte Grande',o:['Norte Grande','Zona Central','Patagonia','Sur'], tier:'beginner'}
+  ],
+  antartica:[
+    {q:'¿Qué animal es común encontrar en la Antártica?',a:'Pingüino',o:['Pingüino','Oso Polar','León','Mono'], tier:'beginner'},
+    {q:'¿Cómo se llama el poblado chileno en la Antártica que tiene una escuela?',a:'Villa Las Estrellas',o:['Villa Las Estrellas','Punta Arenas','Puerto Williams','Base Prat'], tier:'advanced'},
+    {q:'¿Cuál es la característica principal del clima antártico?',a:'Frío y seco',o:['Frío y seco','Caluroso y húmedo','Lluvioso','Templado'], tier:'beginner'},
+    {q:'¿Qué estudian principalmente los científicos en la Antártica?',a:'El clima y la fauna',o:['El clima y la fauna','La agricultura','Los bosques','La minería de oro'], tier:'intermediate'}
   ],
   indigenous:[
     {q:'¿Qué pueblo originario desarrolló la cerámica con diseños geométricos?',a:'Los Diaguitas',o:['Los Diaguitas','Los Mapuches','Los Chonos','Los Selknam'], tier:'advanced'},
@@ -296,7 +309,10 @@ const QB={
     {q:'¿Qué país gobernó Chile antes de su independencia?',a:'España',o:['España','Inglaterra','Francia','Portugal'], tier:'beginner'},
     {q:'¿Qué cordillera tuvo que cruzar el Ejército de los Andes?',a:'Cordillera de los Andes',o:['Cordillera de los Andes','Cordillera de la Costa','Los Alpes','Los Pirineos'], tier:'intermediate'},
     {q:'¿Qué héroe naval comandó la Esmeralda?',a:'Arturo Prat',o:['Arturo Prat','Manuel Baquedano','Bernardo O\'Higgins','José Miguel Carrera'], tier:'intermediate'},
-    {q:'¿En qué ciudad ocurrió el Combate Naval el 21 de mayo?',a:'Iquique',o:['Iquique','Valparaíso','Antofagasta','Arica'], tier:'advanced'}
+    {q:'¿En qué ciudad ocurrió el Combate Naval el 21 de mayo?',a:'Iquique',o:['Iquique','Valparaíso','Antofagasta','Arica'], tier:'advanced'},
+    {q:'¿Qué batalla selló la independencia de Chile en 1818?',a:'Batalla de Maipú',o:['Batalla de Maipú','Batalla de Chacabuco','Combate Naval de Iquique','Batalla de Rancagua'], tier:'expert'},
+    {q:'¿Quién fue el primer Director Supremo de Chile?',a:'Bernardo O\'Higgins',o:['Bernardo O\'Higgins','José Miguel Carrera','Manuel Bulnes','Pedro de Valdivia'], tier:'intermediate'},
+    {q:'¿En qué siglo se fundó la ciudad de Santiago?',a:'Siglo XVI (16)',o:['Siglo XVI (16)','Siglo XVIII (18)','Siglo XIX (19)','Siglo XV (15)'], tier:'advanced'}
   ],
   culture:[
     {q:'¿Qué lleva la empanada de pino?',a:'Carne, cebolla, huevo, aceitunas',o:['Carne, cebolla, huevo, aceitunas','Pollo con queso','Porotos con arroz','Pescado con limón'], tier:'beginner'},

--- a/js/math-galaxy.js
+++ b/js/math-galaxy.js
@@ -142,8 +142,19 @@ function generateDistractors(correct, count, min, max) {
    ================================================================ */
 
 function genCadet() {
-  const types = ['count', 'add', 'shape', 'bigger', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'moon_shape', 'alien_count', 'satellite_add', 'sun_shape', 'robot_add', 'meteor_count', 'earth_shape', 'ufo_count', 'telescope_add', 'star_shape'];
+  const types = ['count', 'add', 'shape', 'bigger', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'moon_shape', 'alien_count', 'satellite_add', 'sun_shape', 'robot_add', 'meteor_count', 'earth_shape', 'ufo_count', 'telescope_add', 'star_shape', 'rover_count', 'satellite_shape', 'comet_add'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'rover_count') {
+    const n = rand(2, 8);
+    return { label: 'Counting Rovers', text: '🚙'.repeat(n), hint: 'How many rovers?', answer: n, options: generateDistractors(n, 3, 1, 10), mode: 'choice' };
+  }
+  if (type === 'satellite_shape') {
+    return { label: 'Satellite Shapes', text: '🛰️', hint: 'What shape are the solar panels?', answer: 'Rectangle', options: shuffle(['Rectangle', 'Circle', 'Triangle', 'Star']), mode: 'choice' };
+  }
+  if (type === 'comet_add') {
+    const a = rand(1, 4), b = rand(1, 4);
+    return { label: 'Comet Math', text: `${a} ☄️ + ${b} ☄️ = ?`, hint: 'Add the comets!', answer: a + b, options: generateDistractors(a + b, 3, 1, 10), mode: 'choice' };
+  }
   if (type === 'ufo_count') {
     const n = rand(1, 10);
     return { label: 'UFO Watch', text: '🛸'.repeat(n), hint: 'How many UFOs?', answer: n, options: generateDistractors(n, 3, 1, 10), mode: 'choice' };
@@ -220,8 +231,21 @@ function genCadet() {
 }
 
 function genExplorer() {
-  const types = ['add', 'sub', 'missing', 'compare', 'double', 'alien_add', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'comet_compare', 'meteor_sub', 'moon_pattern', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare'];
+  const types = ['add', 'sub', 'missing', 'compare', 'double', 'alien_add', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'comet_compare', 'meteor_sub', 'moon_pattern', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare', 'rover_sub', 'rover_pattern', 'telescope_compare'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'rover_sub') {
+    const a = rand(6, 12), b = rand(1, a - 1);
+    return { label: 'Rover Repair', text: `${a} 🚙 - ${b} 🚙 = ?`, hint: 'Subtract the rovers', answer: a - b, options: generateDistractors(a - b, 3, 1, 15), mode: 'choice' };
+  }
+  if (type === 'rover_pattern') {
+    return { label: 'Rover Pattern', text: '🚙 🛰️ 🚙 🛰️ ?', hint: 'Who is next?', answer: '🚙', options: shuffle(['🚙', '🛰️', '🤖', '🛸']), mode: 'choice' };
+  }
+  if (type === 'telescope_compare') {
+    const a = rand(10, 25), b = rand(10, 25);
+    if (a === b) return genExplorer();
+    const sym = a > b ? '>' : '<';
+    return { label: 'Telescope Array', text: `${a} 🔭  ◻  ${b} 🔭`, hint: 'Which is greater?', answer: sym, options: shuffle(['>', '<', '=']), mode: 'choice' };
+  }
   if (type === 'comet_sub') {
     const a = rand(6, 15), b = rand(1, a - 1);
     return { label: 'Comet Subtraction', text: `${a} ☄️ - ${b} ☄️ = ?`, hint: 'Subtract the comets', answer: a - b, options: generateDistractors(a - b, 3, 1, 15), mode: 'choice' };
@@ -295,8 +319,20 @@ function genExplorer() {
 }
 
 function genPilot() {
-  const types = ['mult', 'div', 'frac_visual', 'word', 'missing_mult', 'comet_mult', 'asteroid_div', 'star_word', 'alien_mult', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'rocket_word', 'robot_mult', 'meteor_div', 'alien_word', 'astronaut_mult', 'rocket_div', 'moon_frac'];
+  const types = ['mult', 'div', 'frac_visual', 'word', 'missing_mult', 'comet_mult', 'asteroid_div', 'star_word', 'alien_mult', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'rocket_word', 'robot_mult', 'meteor_div', 'alien_word', 'astronaut_mult', 'rocket_div', 'moon_frac', 'rover_mult', 'rover_div', 'planet_word'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'rover_mult') {
+    const a = rand(3, 7), b = rand(4, 8);
+    return { label: 'Rover Mission', text: `${a} 🚙 × ${b} = ?`, hint: 'Total rovers?', answer: a * b, options: generateDistractors(a * b, 3, 10, 60), mode: 'choice' };
+  }
+  if (type === 'rover_div') {
+    const b = rand(2, 6), ans = rand(3, 8);
+    return { label: 'Rover Groups', text: `${b * ans} 🚙 ÷ ${b} = ?`, hint: 'Divide the rovers', answer: ans, options: generateDistractors(ans, 3, 1, 15), mode: 'choice' };
+  }
+  if (type === 'planet_word') {
+    const planets = rand(4, 9), moonsPerPlanet = rand(2, 5);
+    return { label: 'Planetary Moons', text: `There are ${planets} planets. Each has ${moonsPerPlanet} moons.`, hint: 'Multiply for total moons.', answer: planets * moonsPerPlanet, options: generateDistractors(planets * moonsPerPlanet, 3, 5, 50), mode: 'choice' };
+  }
   if (type === 'astronaut_mult') {
     const a = rand(4, 9), b = rand(3, 8);
     return { label: 'Crew Multiplication', text: `${a} 👨‍🚀 × ${b} = ?`, hint: 'Total astronauts?', answer: a * b, options: generateDistractors(a * b, 3, 10, 80), mode: 'choice' };
@@ -364,8 +400,37 @@ function genPilot() {
 }
 
 function genCommander() {
-  const types = ['big_add', 'big_mult', 'fraction_add', 'decimal', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'robot_ops', 'ufo_decimal', 'rocket_pct', 'blackhole_add', 'asteroid_decimal', 'supernova_pct'];
+  const types = ['big_add', 'big_mult', 'fraction_add', 'decimal', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'robot_ops', 'ufo_decimal', 'rocket_pct', 'blackhole_add', 'asteroid_decimal', 'supernova_pct', 'rover_ops', 'telescope_pct', 'satellite_decimal'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'rover_ops') {
+    const a = rand(15, 40), b = rand(3, 8), c = rand(2, 5);
+    const ans = a + (b * c);
+    return { label: 'Rover Route', text: `${a} 🚙 + ${b} 🚙 × ${c} = ?`, hint: 'Multiply first!', answer: ans, options: generateDistractors(ans, 3, 20, 100), mode: 'choice' };
+  }
+  if (type === 'telescope_pct') {
+    const pcts = [10, 20, 25, 50];
+    const p = pcts[rand(0, pcts.length - 1)];
+    const power = rand(40, 120) * 5;
+    const ans = power * (p / 100);
+    return { label: 'Telescope Focus', text: `${p}% of ${power} zoom`, hint: 'Find the percentage.', answer: ans, options: generateDistractors(ans, 3, 10, power), mode: 'choice' };
+  }
+  if (type === 'satellite_decimal') {
+    const a = (rand(20, 80) / 10).toFixed(1);
+    const b = (rand(20, 80) / 10).toFixed(1);
+    const ans = (parseFloat(a) + parseFloat(b)).toFixed(1);
+    const opts = [ans];
+    let attempts = 0;
+    while (opts.length < 4 && attempts < 15) {
+      attempts++;
+      const fake = (parseFloat(ans) + (rand(-30, 30) / 10)).toFixed(1);
+      if (!opts.includes(fake) && parseFloat(fake) > 0 && fake !== ans) opts.push(fake);
+    }
+    while (opts.length < 4) {
+      let fallback = (parseFloat(ans) + (opts.length + 1) * 1.1).toFixed(1);
+      if (!opts.includes(fallback)) opts.push(fallback);
+    }
+    return { label: 'Satellite Orbit', text: `${a} au + ${b} au = ?`, hint: 'Add the distances.', answer: ans, options: shuffle(opts), mode: 'choice' };
+  }
   if (type === 'blackhole_add') {
     const a = rand(100, 999), b = rand(100, 999);
     return { label: 'Mass Addition', text: `${a} + ${b} = ?`, hint: 'Add the large numbers.', answer: a + b, options: generateDistractors(a + b, 3, 200, 2000), mode: 'choice' };


### PR DESCRIPTION
# DAILY DOCS UPDATE [2026-03-23] — Documentation Guardian Agent 
# Task completed: Added 12 new math questions across 4 tiers in Math Galaxy, added 1 new "La Antártica Chilena" topic to Descubre Chile with 4 questions, and 6 new questions to existing history and geography topics.

- math-galaxy.js: Added 3 new question types to each of the four generator functions (genCadet, genExplorer, genPilot, genCommander), totaling 12 new math questions.
- descubre-chile.js: Added a new "La Antártica Chilena" topic with stories and 4 questions. Added 3 new questions to history and 3 new questions to geography.
- Content was reviewed against the 5-point checklist in content-guidelines.md to ensure absolute factual neutrality.

---
*PR created automatically by Jules for task [17608683260864150922](https://jules.google.com/task/17608683260864150922) started by @rozavala*