### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Missing ARIA Labels and Unassociated Form Labels in Custom Modals
 **Learning:** This application extensively uses custom modal implementations (`modal-field` wrapping an input and label). These custom components often lack semantic associations between labels and inputs, and use icon-only close buttons (`dash-close`) without ARIA labels. This presents a pattern of accessibility issues across all interactive overlay elements.
 **Action:** When implementing or editing modal or overlay components in this codebase, explicitly check for `<label for="...">` associations and `aria-label`s on icon-only interactive elements like close buttons.
+## 2024-05-18 - Missing ARIA Labels on Navigation and Action Buttons
+**Learning:** Icon-only navigation and action buttons (e.g., `.back-btn` with a simple "←" text content, `.profile-edit-btn` with "✏️", and generic `.close-modal` buttons with "✕") are widely used throughout the app suite but consistently lack `aria-label` attributes. This leaves screen readers unable to announce their purpose correctly.
+**Action:** Always provide descriptive `aria-label`s for buttons where the text content is purely an icon, emoji, or symbol (such as `aria-label="Go back"` or `aria-label="Edit Profile"`).

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -53,13 +53,13 @@
 
   <!-- LEARN: piece list -->
   <div class="screen" id="screen-learn">
-    <div class="learn-header"><button class="back-btn" onclick="goMenu()">←</button><div class="learn-title">Learn the Pieces</div></div>
+    <div class="learn-header"><button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button><div class="learn-title">Learn the Pieces</div></div>
     <div class="piece-grid" id="pieceGrid"></div>
   </div>
 
   <!-- LEARN: single piece lesson -->
   <div class="screen" id="screen-lesson">
-    <div class="learn-header"><button class="back-btn" onclick="showScreen('learn')">←</button><span id="lessonIcon" style="font-size:28px"></span><div class="learn-title" id="lessonTitle"></div></div>
+    <div class="learn-header"><button class="back-btn" aria-label="Go back" onclick="showScreen('learn')">←</button><span id="lessonIcon" style="font-size:28px"></span><div class="learn-title" id="lessonTitle"></div></div>
     <div class="lesson-info" id="lessonInfo"></div>
     <div class="board-wrap"><div class="board" id="learnBoard"></div></div>
     <div class="board-labels"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
@@ -69,7 +69,7 @@
 
   <!-- PUZZLE -->
   <div class="screen" id="screen-puzzle">
-    <div class="learn-header"><button class="back-btn" onclick="goMenu()">←</button><div class="learn-title">Puzzles</div></div>
+    <div class="learn-header"><button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button><div class="learn-title">Puzzles</div></div>
     <div class="puzzle-top"><div class="puzzle-badge" id="puzzleLabel"></div><div style="color:var(--gold);font-family:var(--font-display);font-weight:700" id="puzzleScore"></div></div>
     <div class="board-wrap"><div class="board" id="puzzleBoard"></div></div>
     <div class="board-labels"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
@@ -81,7 +81,7 @@
   <!-- PLAY -->
   <div class="screen" id="screen-play">
     <div class="play-top">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="play-status" id="playStatus">Your turn (White)</div>
     </div>
     <div class="play-info"><div>You (White) <span class="captured-row" id="capturedBlack"></span></div><div>Computer (Black) <span class="captured-row" id="capturedWhite"></span></div></div>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -63,7 +63,7 @@
   <!-- QUIZ -->
   <div class="tab-content" id="tab-quiz"><div id="quizArea"></div></div>
 </div>
-<div class="region-modal" id="regionModal" onclick="if(event.target===this)closeRegion()"><div class="region-card"><button class="close-modal" onclick="closeRegion()">✕</button><h2 id="rmTitle"></h2><div class="region-sub" id="rmSub"></div><div id="rmFacts"></div><div style="text-align:center;margin-top:16px"><button class="btn-red" onclick="closeRegion()">¡Entendido! ✓</button></div></div></div>
+<div class="region-modal" id="regionModal" onclick="if(event.target===this)closeRegion()"><div class="region-card"><button class="close-modal" aria-label="Close" onclick="closeRegion()">✕</button><h2 id="rmTitle"></h2><div class="region-sub" id="rmSub"></div><div id="rmFacts"></div><div style="text-align:center;margin-top:16px"><button class="btn-red" onclick="closeRegion()">¡Entendido! ✓</button></div></div></div>
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
 <script src="js/sync.js"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -93,7 +93,7 @@
 <body>
   <div class="header">
     <div class="header-left">
-      <a href="index.html" class="back-btn">←</a>
+      <a href="index.html" class="back-btn" aria-label="Go back">←</a>
       <div class="title">Fe Explorador ⛪</div>
     </div>
     <div class="stars-badge" id="star-count">⭐ 0</div>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -33,7 +33,7 @@
     <!-- SCREEN: Game (questions) -->
     <div class="screen" id="screen-game">
       <div class="game-header">
-        <button class="back-btn" onclick="GuessQuest.backToSelect()">←</button>
+        <button class="back-btn" aria-label="Go back" onclick="GuessQuest.backToSelect()">←</button>
         <div class="question-counter" id="question-counter">❓ 0 / 20</div>
         <div class="gq-stars" id="gq-stars">⭐ 0</div>
       </div>
@@ -60,7 +60,7 @@
     <!-- SCREEN: Guess (pick from candidates) -->
     <div class="screen" id="screen-guess">
       <div class="guess-header">
-        <button class="back-btn" onclick="GuessQuest.backToGame()">←</button>
+        <button class="back-btn" aria-label="Go back" onclick="GuessQuest.backToGame()">←</button>
         <h2>What do you think it is?</h2>
       </div>
       <div class="guess-grid" id="guess-grid">

--- a/js/index.js
+++ b/js/index.js
@@ -36,7 +36,7 @@
           <div class="profile-avatar" style="background:${safe.color}22;border-color:${safe.color}">${safe.avatar}</div>
           <div class="profile-name">${safe.name}</div>
           ${p.age ? `<div class="profile-age">Age ${p.age}</div>` : ''}
-          <button class="profile-edit-btn" data-index="${i}" title="Edit ${safe.name}" onclick="event.stopPropagation(); requestPinThen(() => openEditModal(${i}))">✏️</button>
+          <button class="profile-edit-btn" data-index="${i}" aria-label="Edit ${safe.name}" title="Edit ${safe.name}" onclick="event.stopPropagation(); requestPinThen(() => openEditModal(${i}))">✏️</button>
         `;
 
         card.onclick = (e) => {

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -31,7 +31,7 @@
     <!-- EXPERIMENT SCREEN -->
     <div class="screen" id="screen-experiment">
       <div class="exp-header">
-        <button class="back-btn" onclick="LabExplorer.backToTopics()">←</button>
+        <button class="back-btn" aria-label="Go back" onclick="LabExplorer.backToTopics()">←</button>
         <div class="exp-title" id="exp-title"></div>
         <div class="exp-stars" id="exp-stars">⭐ 0</div>
       </div>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -68,7 +68,7 @@
   <!-- ============ LOG A MATCH ============ -->
   <div class="screen" id="screen-log-match">
     <div class="section-header">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="section-title">📝 Log a Match</div>
     </div>
 
@@ -110,7 +110,7 @@
   <!-- ============ LOG AN ACTIVITY ============ -->
   <div class="screen" id="screen-log-activity">
     <div class="section-header">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="section-title">🏃 Log an Activity</div>
     </div>
 
@@ -136,7 +136,7 @@
   <!-- ============ TOURNAMENTS ============ -->
   <div class="screen" id="screen-tournaments">
     <div class="section-header">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="section-title">🏆 Tournaments</div>
     </div>
     <button class="btn-secondary" onclick="showScreen('new-tournament')" style="margin-bottom:16px;">+ New Tournament</button>
@@ -146,7 +146,7 @@
   <!-- ============ NEW TOURNAMENT ============ -->
   <div class="screen" id="screen-new-tournament">
     <div class="section-header">
-      <button class="back-btn" onclick="showScreen('tournaments')">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="showScreen('tournaments')">←</button>
       <div class="section-title">🏆 New Tournament</div>
     </div>
 
@@ -174,7 +174,7 @@
   <!-- ============ TOURNAMENT DETAIL ============ -->
   <div class="screen" id="screen-tournament-detail">
     <div class="section-header">
-      <button class="back-btn" onclick="showScreen('tournaments')">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="showScreen('tournaments')">←</button>
       <div class="section-title" id="tourney-detail-title">Tournament</div>
     </div>
     <div id="tourney-detail-content"></div>
@@ -183,7 +183,7 @@
   <!-- ============ STANDINGS & HISTORY ============ -->
   <div class="screen" id="screen-standings">
     <div class="section-header">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="section-title">📊 Standings & History</div>
     </div>
 
@@ -204,7 +204,7 @@
   <!-- ============ MANAGE SPORTS ============ -->
   <div class="screen" id="screen-manage-sports">
     <div class="section-header">
-      <button class="back-btn" onclick="goMenu()">←</button>
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
       <div class="section-title">⚙️ Manage Sports</div>
     </div>
     <div id="sports-list"></div>
@@ -729,7 +729,7 @@
           <span style="font-size:1.4rem;">${sport.icon}</span>
           <span style="flex:1; font-weight:700;">${escHtml(sport.name)}</span>
           <span style="font-size:0.75rem; color:var(--text-muted); font-weight:600;">${sport.scoreType}</span>
-          ${isCustom ? `<button onclick="removeCustomSportById('${sport.id}')" style="background:none; border:none; color:var(--red); cursor:pointer; font-size:1.1rem;">✕</button>` : ''}
+          ${isCustom ? `<button onclick="removeCustomSportById('${sport.id}')" aria-label="Delete sport" style="background:none; border:none; color:var(--red); cursor:pointer; font-size:1.1rem;">✕</button>` : ''}
         </div>`;
     });
   }

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -36,7 +36,7 @@
     <!-- SCREEN: READ -->
     <div class="screen" id="screen-read">
       <div class="exp-header">
-        <button class="back-btn" onclick="StoryExplorer.backToLibrary()">←</button>
+        <button class="back-btn" aria-label="Go back" onclick="StoryExplorer.backToLibrary()">←</button>
         <div class="exp-title" id="story-title">Story Title</div>
         <div class="exp-stars" id="story-stars">⭐ 0</div>
       </div>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -33,7 +33,7 @@
     <!-- SCREEN: MAP EXPLORER -->
     <div class="screen" id="screen-continent">
       <div class="exp-header">
-        <button class="back-btn" onclick="WorldExplorer.backToSelect()">←</button>
+        <button class="back-btn" aria-label="Go back" onclick="WorldExplorer.backToSelect()">←</button>
         <div class="exp-title" id="continent-title">Continent</div>
         <div class="exp-stars" id="world-stars">⭐ 0</div>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-label`s to `.back-btn` elements across multiple apps, the `.profile-edit-btn` in `index.js`, and the modal close/delete buttons in `descubre-chile.html` and `sports-arena.html`.
🎯 Why: Improves screen reader accessibility and general UX for icon-only interactive elements, ensuring all users can navigate the applications and identify actions correctly.
📸 Before/After: Visual presentation remains exactly the same, but the DOM now includes valid semantic `aria-label`s. Verified visually via Playwright.
♿ Accessibility: Directly addresses the missing accessible name issue for icon-only interactive elements like back buttons, close buttons, edit buttons, and delete buttons.

---
*PR created automatically by Jules for task [6057095180349767808](https://jules.google.com/task/6057095180349767808) started by @rozavala*