### PR TITLE
⚡ Bolt: O(N) LocalStorage Parse Optimization in getNextChallenge

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,6 @@
 ## 2024-06-25 - AppStats Caching Gaps Lead to Redundant Parsing
 **Learning:** The previous optimization to cache `localStorage` objects inside the `getPlayerStats` function's returned `appStats` object missed new apps (`Lab Explorer`, `World Explorer`, `Story Explorer`, `Quest Adventure`). Because these apps weren't parsed inside `getPlayerStats()`, the dashboard rendering loop in `js/index.js` repeatedly fell back to `JSON.parse(localStorage.getItem(...))` on every row generation, breaking the O(N) optimization intent.
 **Action:** Always ensure any newly added apps in the suite are integrated into centralized state-aggregating functions (like `getPlayerStats`) to fully leverage the shared `localStorage` caching patterns.
+## 2026-03-31 - O(N) LocalStorage Parse Optimization in getNextChallenge
+**Learning:** Found a redundant synchronous parsing of localStorage inside the getNextChallenge function's rendering loop. This caused blocking JSON parsing for every visible app on the main hub every time the user dashboard loads.
+**Action:** Reused the cached appStats object returned by getPlayerStats() by matching the schedId key, eliminating O(N) redundant localStorage operations.

--- a/js/index.js
+++ b/js/index.js
@@ -281,10 +281,16 @@
         (app.schedId === 'faith' && user.faithVisible !== false)
       );
 
+      // ⚡ Bolt Optimization: Use cached `appStats` object returned by `getPlayerStats`
+      // instead of redundantly calling `JSON.parse(localStorage.getItem(...))` per user iteration.
+      // This eliminates O(N) blocking synchronous I/O operations from the main thread during rendering.
+      const stats = typeof getPlayerStats === 'function' ? getPlayerStats(user.name) : { appStats: {} };
+      const appStats = stats.appStats || {};
+
       const noProgress = [];
       visibleApps.forEach(app => {
         try {
-          const data = JSON.parse(localStorage.getItem(app.key)) || {};
+          const data = appStats[app.schedId] || JSON.parse(localStorage.getItem(app.key)) || {};
           let hasProg = false;
           if (app.name === 'Math Galaxy') hasProg = Object.keys(data).length > 0;
           else if (app.name === 'Descubre Chile') hasProg = Object.keys(data).filter(k => k!=='vr' && k!=='memBest').length > 0;


### PR DESCRIPTION
💡 What: Replaced direct `JSON.parse(localStorage)` calls inside the `visibleApps` iteration of `getNextChallenge` with a single cache lookup using `appStats[app.schedId]`.
🎯 Why: To prevent redundant synchronous blocking disk/storage parses during hot rendering of the hub.
📊 Impact: Eliminates ~10 blocking I/O calls from the main thread during index hub initial render and re-renders.
🔬 Measurement: Local test and validation with Playwright, verifying the `getNextChallenge` section successfully renders without any regression.

---
*PR created automatically by Jules for task [3102243754082855578](https://jules.google.com/task/3102243754082855578) started by @rozavala*