### PR TITLE
🎨 Palette: Improve Accessibility for Modal Pickers

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Missing ARIA Labels on Navigation and Action Buttons
 **Learning:** Icon-only navigation and action buttons (e.g., `.back-btn` with a simple "←" text content, `.profile-edit-btn` with "✏️", and generic `.close-modal` buttons with "✕") are widely used throughout the app suite but consistently lack `aria-label` attributes. This leaves screen readers unable to announce their purpose correctly.
 **Action:** Always provide descriptive `aria-label`s for buttons where the text content is purely an icon, emoji, or symbol (such as `aria-label="Go back"` or `aria-label="Edit Profile"`).
+## 2024-05-18 - Dynamically Created Interactive Elements using Divs
+**Learning:** Some custom pickers (e.g., age, color, and emoji pickers in profile forms) use dynamically generated `<div>` elements as interactive options without semantic roles or keyboard focusability, violating basic accessibility principles.
+**Action:** Always use native `<button type="button">` elements for interactive options when building or refactoring custom selection groups to ensure keyboard accessibility, focus visibility, and screen reader compatibility. Include clear `aria-label`s, particularly for color or icon selections.

--- a/css/index.css
+++ b/css/index.css
@@ -302,6 +302,7 @@
     }
     .emoji-option:hover { transform: scale(1.15); border-color: rgba(255,255,255,0.2); }
     .emoji-option.selected { border-color: var(--purple); box-shadow: 0 0 20px var(--purple-glow); transform: scale(1.15); }
+    .emoji-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
 
     /* Age picker */
     .age-picker {
@@ -326,6 +327,7 @@
     }
     .age-option:hover { border-color: rgba(255,255,255,0.2); color: var(--text-primary); transform: translateY(-1px); }
     .age-option.selected { border-color: var(--purple); color: var(--purple); background: rgba(167,139,250,0.08); box-shadow: 0 0 16px var(--purple-glow); }
+    .age-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
     .age-option .age-num { font-size: 1.1rem; display: block; }
     .age-option .age-label { font-size: 0.65rem; color: var(--text-muted); font-weight: 600; }
 
@@ -345,6 +347,7 @@
     }
     .color-option:hover { transform: scale(1.2); }
     .color-option.selected { border-color: #fff; box-shadow: 0 0 16px rgba(255,255,255,0.3); transform: scale(1.2); }
+    .color-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
 
     .modal-actions {
       display: flex;

--- a/js/index.js
+++ b/js/index.js
@@ -1106,7 +1106,9 @@
       const el = document.getElementById('age-picker');
       el.innerHTML = '';
       AGE_OPTIONS.forEach(opt => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select age ${opt.label}`);
         btn.className = 'age-option' + (selectedAge === opt.age ? ' selected' : '');
         btn.innerHTML = `<span class="age-num">${opt.label}</span>`;
         btn.onclick = () => { selectedAge = opt.age; renderAgePicker(); };
@@ -1118,7 +1120,9 @@
       const el = document.getElementById('emoji-picker');
       el.innerHTML = '';
       AVATARS.forEach(a => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select avatar ${a}`);
         btn.className = 'emoji-option' + (a === selectedEmoji ? ' selected' : '');
         btn.textContent = a;
         btn.onclick = () => { selectedEmoji = a; renderEmojiPicker(); };
@@ -1129,7 +1133,9 @@
       const el = document.getElementById('color-picker');
       el.innerHTML = '';
       COLORS.forEach(c => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select color ${c}`);
         btn.className = 'color-option' + (c === selectedColor ? ' selected' : '');
         btn.style.background = c;
         btn.onclick = () => { selectedColor = c; renderColorPicker(); };
@@ -1288,7 +1294,9 @@ function createProfile() {
       const el = document.getElementById('edit-age-picker');
       el.innerHTML = '';
       AGE_OPTIONS.forEach(opt => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select age ${opt.label}`);
         btn.className = 'age-option' + (editAge === opt.age ? ' selected' : '');
         btn.innerHTML = `<span class="age-num">${opt.label}</span>`;
         btn.onclick = () => { editAge = opt.age; _renderEditAgePicker(); };
@@ -1300,7 +1308,9 @@ function createProfile() {
       const el = document.getElementById('edit-emoji-picker');
       el.innerHTML = '';
       AVATARS.forEach(a => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select avatar ${a}`);
         btn.className = 'emoji-option' + (a === editEmoji ? ' selected' : '');
         btn.textContent = a;
         btn.onclick = () => { editEmoji = a; _renderEditEmojiPicker(); _updateEditPreview(); };
@@ -1312,7 +1322,9 @@ function createProfile() {
       const el = document.getElementById('edit-color-picker');
       el.innerHTML = '';
       COLORS.forEach(c => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select color ${c}`);
         btn.className = 'color-option' + (c === editColor ? ' selected' : '');
         btn.style.background = c;
         btn.onclick = () => { editColor = c; _renderEditColorPicker(); _updateEditPreview(); };


### PR DESCRIPTION
# 🎨 Palette: Improve Accessibility for Modal Pickers

**💡 What:** Converted the non-semantic `<div>` elements used for the Age, Avatar, and Color pickers inside the "Add Profile" and "Edit Profile" modals into native `<button type="button">` elements.

**🎯 Why:** Previously, these options were not focusable via keyboard and provided no context to screen readers because they were just `<div>`s.

**♿ Accessibility:**
- Changed `.age-option`, `.emoji-option`, and `.color-option` from `<div>` to `<button>`.
- Added descriptive `aria-label` attributes to each button (e.g., `aria-label="Select avatar 🦊"`).
- Added `:focus-visible` styles to ensure keyboard navigation outlines are clearly visible.

**📸 Verification:**
- Playwright scripts ran to verify the visual display didn't break.
- Confirmed the `:focus-visible` ring applies successfully when navigating the pickers.

A new entry was added to the Palette journal documenting the learning that custom pickers shouldn't use non-semantic div elements.

---
*PR created automatically by Jules for task [7799944261444783799](https://jules.google.com/task/7799944261444783799) started by @rozavala*