### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix stored XSS vulnerability in Art Studio gallery

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -11,3 +11,8 @@
 **Vulnerability:** User-provided profile fields, specifically `p.color`, were being injected directly into `style.cssText` or inline `style="..."` attributes without proper CSS context sanitization, allowing for potential CSS injection attacks, especially since data can be synced across devices.
 **Learning:** Even if data is visually styled or assumed to be just a hex code, directly injecting values from `localStorage` into `style` attributes or `cssText` without validation creates a vulnerability. `escHtml` is not sufficient for CSS contexts.
 **Prevention:** Always validate or sanitize color inputs before DOM injection using a strict format checker like `safeColor(c)` which enforces a valid hex code pattern and falls back to a default safe color.
+
+## 2026-10-27 - [Stored XSS in Art Studio Gallery]
+**Vulnerability:** User-provided artwork titles (`art.title`) were injected directly into `innerHTML` strings in `js/art-studio.js` when rendering the gallery (`renderGallery()`). Because artwork metadata is stored in user profiles which can be synced via CloudSync, this represented a stored XSS vulnerability.
+**Learning:** Any user-generated string input, even if localized to a specific app module like Art Studio, can be a stored XSS vector if rendered directly into the DOM, especially given the CloudSync synchronization capability.
+**Prevention:** Consistently apply `escHtml()` to sanitize all user-controlled inputs (such as artwork titles) before interpolating them into HTML strings used for DOM manipulation.

--- a/js/art-studio.js
+++ b/js/art-studio.js
@@ -681,8 +681,8 @@ const ArtStudio = (() => {
     if (p.gallery.length === 0) { grid.innerHTML = '<div class="placeholder-msg" style="grid-column: 1/-1"><h2>Your gallery is empty</h2><p>Draw something and save it!</p></div>'; return; }
     grid.innerHTML = p.gallery.map(art => `
       <div class="gallery-card" onclick="ArtStudio.viewArt(${art.id})">
-        <img src="${art.dataUrl}" class="gallery-thumb" alt="${art.title}">
-        <div class="gallery-info"><div class="gallery-title">${art.title}</div><div class="gallery-date">${new Date(art.date).toLocaleDateString()}</div></div>
+        <img src="${art.dataUrl}" class="gallery-thumb" alt="${escHtml(art.title)}">
+        <div class="gallery-info"><div class="gallery-title">${escHtml(art.title)}</div><div class="gallery-date">${new Date(art.date).toLocaleDateString()}</div></div>
       </div>
     `).join('');
   }


### PR DESCRIPTION
## 🚨 Severity: CRITICAL

## 💡 Vulnerability
A stored Cross-Site Scripting (XSS) vulnerability was found in `js/art-studio.js`. When rendering the gallery (`renderGallery()`), user-provided artwork titles (`art.title`) were directly interpolated into an HTML string and injected via `innerHTML`. Because this metadata is stored in `localStorage` and can be synced across devices via CloudSync, a maliciously crafted artwork title could be executed as a script on another device.

## 🎯 Impact
If exploited, a malicious script could run within the context of the app on other devices (e.g., the parent dashboard), potentially allowing an attacker to modify or exfiltrate sensitive profile data or configuration settings.

## 🔧 Fix
Applied the globally available `escHtml()` function to sanitize the `art.title` string before it is interpolated into the HTML string, preventing the browser from interpreting the title as executable markup or breaking out of HTML attributes.

## ✅ Verification
1.  Ran `node -c js/art-studio.js` to ensure the syntax was valid.
2.  Verified that `art.title` is successfully sanitized via `escHtml` during gallery rendering.
3.  Ran compliance checks successfully.

---
*PR created automatically by Jules for task [13585423319501232144](https://jules.google.com/task/13585423319501232144) started by @rozavala*