### PR TITLE
🎨 Palette: Make custom form pickers fully accessible

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -4,3 +4,6 @@
 ## 2024-05-18 - Missing ARIA Labels on Navigation and Action Buttons
 **Learning:** Icon-only navigation and action buttons (e.g., `.back-btn` with a simple "←" text content, `.profile-edit-btn` with "✏️", and generic `.close-modal` buttons with "✕") are widely used throughout the app suite but consistently lack `aria-label` attributes. This leaves screen readers unable to announce their purpose correctly.
 **Action:** Always provide descriptive `aria-label`s for buttons where the text content is purely an icon, emoji, or symbol (such as `aria-label="Go back"` or `aria-label="Edit Profile"`).
+## 2024-05-18 - Accessible Form Picker Options
+**Learning:** Custom form elements like age, emoji, and color pickers in `.modal-field` containers were built using `<div>`s, which lack inherent semantic meaning, focus states, and screen reader announcements. This meant keyboard users couldn't navigate them and screen readers didn't know what they were.
+**Action:** Always implement individual picker options as semantic `<button type="button">` elements. Add descriptive `aria-label`s to each and ensure `:focus-visible` styles are provided so that they are fully accessible to all users.

--- a/css/index.css
+++ b/css/index.css
@@ -301,6 +301,7 @@
       transition: all 0.2s ease;
     }
     .emoji-option:hover { transform: scale(1.15); border-color: rgba(255,255,255,0.2); }
+    .emoji-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
     .emoji-option.selected { border-color: var(--purple); box-shadow: 0 0 20px var(--purple-glow); transform: scale(1.15); }
 
     /* Age picker */
@@ -325,6 +326,7 @@
       line-height: 1.3;
     }
     .age-option:hover { border-color: rgba(255,255,255,0.2); color: var(--text-primary); transform: translateY(-1px); }
+    .age-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
     .age-option.selected { border-color: var(--purple); color: var(--purple); background: rgba(167,139,250,0.08); box-shadow: 0 0 16px var(--purple-glow); }
     .age-option .age-num { font-size: 1.1rem; display: block; }
     .age-option .age-label { font-size: 0.65rem; color: var(--text-muted); font-weight: 600; }
@@ -344,6 +346,7 @@
       transition: all 0.2s ease;
     }
     .color-option:hover { transform: scale(1.2); }
+    .color-option:focus-visible { outline: 2px solid var(--purple); outline-offset: 2px; }
     .color-option.selected { border-color: #fff; box-shadow: 0 0 16px rgba(255,255,255,0.3); transform: scale(1.2); }
 
     .modal-actions {

--- a/js/index.js
+++ b/js/index.js
@@ -1125,7 +1125,9 @@
       const el = document.getElementById('age-picker');
       el.innerHTML = '';
       AGE_OPTIONS.forEach(opt => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select age ${opt.label}`);
         btn.className = 'age-option' + (selectedAge === opt.age ? ' selected' : '');
         btn.innerHTML = `<span class="age-num">${opt.label}</span>`;
         btn.onclick = () => { selectedAge = opt.age; renderAgePicker(); };
@@ -1137,7 +1139,9 @@
       const el = document.getElementById('emoji-picker');
       el.innerHTML = '';
       AVATARS.forEach(a => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select avatar ${a}`);
         btn.className = 'emoji-option' + (a === selectedEmoji ? ' selected' : '');
         btn.textContent = a;
         btn.onclick = () => { selectedEmoji = a; renderEmojiPicker(); };
@@ -1148,7 +1152,9 @@
       const el = document.getElementById('color-picker');
       el.innerHTML = '';
       COLORS.forEach(c => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select color ${c}`);
         btn.className = 'color-option' + (c === selectedColor ? ' selected' : '');
         btn.style.background = c;
         btn.onclick = () => { selectedColor = c; renderColorPicker(); };
@@ -1307,7 +1313,9 @@ function createProfile() {
       const el = document.getElementById('edit-age-picker');
       el.innerHTML = '';
       AGE_OPTIONS.forEach(opt => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select age ${opt.label}`);
         btn.className = 'age-option' + (editAge === opt.age ? ' selected' : '');
         btn.innerHTML = `<span class="age-num">${opt.label}</span>`;
         btn.onclick = () => { editAge = opt.age; _renderEditAgePicker(); };
@@ -1319,7 +1327,9 @@ function createProfile() {
       const el = document.getElementById('edit-emoji-picker');
       el.innerHTML = '';
       AVATARS.forEach(a => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select avatar ${a}`);
         btn.className = 'emoji-option' + (a === editEmoji ? ' selected' : '');
         btn.textContent = a;
         btn.onclick = () => { editEmoji = a; _renderEditEmojiPicker(); _updateEditPreview(); };
@@ -1331,7 +1341,9 @@ function createProfile() {
       const el = document.getElementById('edit-color-picker');
       el.innerHTML = '';
       COLORS.forEach(c => {
-        const btn = document.createElement('div');
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.setAttribute('aria-label', `Select color ${c}`);
         btn.className = 'color-option' + (c === editColor ? ' selected' : '');
         btn.style.background = c;
         btn.onclick = () => { editColor = c; _renderEditColorPicker(); _updateEditPreview(); };

--- a/test.py
+++ b/test.py
@@ -1,0 +1,42 @@
+from playwright.sync_api import sync_playwright
+import glob
+import time
+
+def run_cuj(page):
+    # Navigate to the app
+    page.goto("http://localhost:8000/index.html")
+    page.wait_for_timeout(1000)
+
+    # Click the "Add Player" card to open the Add Modal
+    page.click('.add-card')
+    page.wait_for_selector('.age-option', state='visible')
+    page.wait_for_timeout(1000)
+
+    # Use keyboard navigation to focus the first age option
+    # First, focus the new-name input, then tab to the age option
+    page.focus('#new-name')
+    page.wait_for_timeout(500)
+    page.keyboard.press('Tab')
+    page.wait_for_timeout(500)
+
+    # Take screenshot of the focus state
+    page.screenshot(path="/home/jules/verification/screenshots/verification.png")
+    page.wait_for_timeout(1000)
+
+    # Verify elements are buttons and have aria-labels
+    age_btn = page.query_selector('.age-option')
+    print("Age Button element tag:", age_btn.evaluate("el => el.tagName"))
+    print("Age Button aria-label:", age_btn.get_attribute('aria-label'))
+
+if __name__ == "__main__":
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        context = browser.new_context(
+            record_video_dir="/home/jules/verification/videos"
+        )
+        page = context.new_page()
+        try:
+            run_cuj(page)
+        finally:
+            context.close()  # MUST close context to save the video
+            browser.close()


### PR DESCRIPTION
🎨 Palette: [Accessible Form Picker Options]

💡 What: Changed the custom `div`-based form pickers (age, emoji, color) to use semantic `<button type="button">` elements. Added descriptive `aria-label`s to each option. Added `:focus-visible` styles to these elements in the CSS.
🎯 Why: Previously, these interactive picker options were built using generic `<div>`s without inherent semantic meaning, focus states, or screen reader announcements, leaving keyboard users unable to navigate them and screen readers unable to announce them.
📸 Before/After: Verified via Playwright.
♿ Accessibility: Ensures full keyboard accessibility and screen reader support for the profile creation and editing modals.

---
*PR created automatically by Jules for task [5755757787023577772](https://jules.google.com/task/5755757787023577772) started by @rozavala*