### PR TITLE
🎨 Palette: Add aria-labels to generic cancel buttons in modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
         <div class="color-picker" id="color-picker" role="group" aria-labelledby="label-color"></div>
       </div>
       <div class="modal-actions">
-        <button class="btn-cancel" onclick="closeModal()">Cancel</button>
+        <button class="btn-cancel" aria-label="Cancel profile creation" onclick="closeModal()">Cancel</button>
         <button class="btn-create" onclick="createProfile()">Let's Go! 🚀</button>
       </div>
     </div>
@@ -306,7 +306,7 @@
       />
       <p id="pin-error" style="color:#EF4444;font-size:0.8rem;font-weight:700;margin-top:8px;display:none;">Incorrect PIN</p>
       <div class="modal-actions" style="margin-top:20px;">
-        <button class="btn-cancel" onclick="closePinModal()">Cancel</button>
+        <button class="btn-cancel" aria-label="Cancel pin entry" onclick="closePinModal()">Cancel</button>
         <button class="btn-create" onclick="submitPin()">Unlock 🔓</button>
       </div>
     </div>
@@ -341,7 +341,7 @@
       <div class="edit-actions">
         <button class="btn-delete-profile" onclick="deleteEditingProfile()">🗑 Delete</button>
         <div class="edit-actions-right">
-          <button class="btn-cancel" onclick="closeEditModal()">Cancel</button>
+          <button class="btn-cancel" aria-label="Cancel editing profile" onclick="closeEditModal()">Cancel</button>
           <button class="btn-create" onclick="saveEditProfile()">Save ✓</button>
         </div>
       </div>


### PR DESCRIPTION
# DAILY UX UPDATE [2026-04-03] — Palette Agent

**Task completed:** Added descriptive `aria-label` attributes to generic "Cancel" buttons across `index.html` modals.

**Details:**
- **What:** Modified three `<button class="btn-cancel">` elements in `index.html` to include specific `aria-label`s ("Cancel profile creation", "Cancel pin entry", "Cancel editing profile").
- **Why:** The generic text "Cancel" lacks context for screen reader users navigating interactively. Adding descriptive `aria-label`s clarifies exactly what action is being cancelled without changing the visual design, improving overall accessibility.
- **Accessibility:** Improves compliance by providing context-specific labels for generic action buttons. Verified changes using a Playwright script.

---
*PR created automatically by Jules for task [8877768831917054879](https://jules.google.com/task/8877768831917054879) started by @rozavala*