### PR TITLE
🎨 Palette: Accessible Color Swatches and Brush Sizes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -7,3 +7,6 @@
 ## 2024-05-18 - Dynamically Created Interactive Elements using Divs
 **Learning:** Some custom pickers (e.g., age, color, and emoji pickers in profile forms) use dynamically generated `<div>` elements as interactive options without semantic roles or keyboard focusability, violating basic accessibility principles.
 **Action:** Always use native `<button type="button">` elements for interactive options when building or refactoring custom selection groups to ensure keyboard accessibility, focus visibility, and screen reader compatibility. Include clear `aria-label`s, particularly for color or icon selections.
+## 2024-04-04 - Accessible Color Swatch Pickers
+**Learning:** Color pickers and brush size pickers rendered as `<div>` elements are completely inaccessible to screen reader and keyboard users. Using `role="button"` and `tabindex="0"` on `<div>` elements is less robust than using native semantic buttons.
+**Action:** When creating custom pickers (e.g. colors, brushes), always use `<button type="button">` with descriptive `aria-label`s instead of styling `<div>`s to behave like buttons. This leverages native browser focus management and semantic accessibility.

--- a/art-studio.html
+++ b/art-studio.html
@@ -31,9 +31,9 @@
           </div>
           
           <div class="tool-section brush-section">
-            <button class="brush-size" data-size="3" style="--size: 6px;"></button>
-            <button class="brush-size active" data-size="8" style="--size: 12px;"></button>
-            <button class="brush-size" data-size="16" style="--size: 20px;"></button>
+            <button class="brush-size" data-size="3" style="--size: 6px;" aria-label="Small brush"></button>
+            <button class="brush-size active" data-size="8" style="--size: 12px;" aria-label="Medium brush"></button>
+            <button class="brush-size" data-size="16" style="--size: 20px;" aria-label="Large brush"></button>
           </div>
 
           <div class="tool-section tool-buttons">
@@ -76,9 +76,9 @@
             </div>
             
             <div class="tool-section brush-section">
-              <button class="brush-size" data-size="3" style="--size: 4px;"></button>
-              <button class="brush-size active" data-size="8" style="--size: 8px;"></button>
-              <button class="brush-size" data-size="16" style="--size: 14px;"></button>
+              <button class="brush-size" data-size="3" style="--size: 4px;" aria-label="Small brush"></button>
+              <button class="brush-size active" data-size="8" style="--size: 8px;" aria-label="Medium brush"></button>
+              <button class="brush-size" data-size="16" style="--size: 14px;" aria-label="Large brush"></button>
             </div>
 
             <div class="tool-section tool-buttons">

--- a/js/art-studio.js
+++ b/js/art-studio.js
@@ -189,13 +189,16 @@ const ArtStudio = (() => {
       const p = document.getElementById(id);
       if (!p) return;
       p.innerHTML = COLORS.map((c, i) => `
-        <div class="color-swatch ${i === 0 ? 'active' : ''}" 
+        <button type="button" class="color-swatch ${i === 0 ? 'active' : ''}"
              style="background: ${c}" 
-             onclick="ArtStudio.setColor('${c}', this)"></div>
+             aria-label="Select color ${c}"
+             onclick="ArtStudio.setColor('${c}', this)"></button>
       `).join('');
 
-      const eraser = document.createElement('div');
+      const eraser = document.createElement('button');
+      eraser.type = 'button';
       eraser.className = 'color-swatch';
+      eraser.setAttribute('aria-label', 'Eraser tool');
       eraser.innerHTML = '🧽';
       eraser.style.display = 'flex';
       eraser.style.alignItems = 'center';
@@ -534,7 +537,7 @@ const ArtStudio = (() => {
     if (step.type === 'grid') {
       const pal = document.getElementById('color-palette');
       const mondrianColors = ['#EF4444', '#3B82F6', '#FBBF24', '#000000', '#FFFFFF'];
-      pal.innerHTML = mondrianColors.map(c => `<div class="color-swatch" style="background:${c}" onclick="ArtStudio.setColor('${c}', this)"></div>`).join('');
+      pal.innerHTML = mondrianColors.map(c => `<button type="button" class="color-swatch" style="background:${c}" aria-label="Select color ${c}" onclick="ArtStudio.setColor('${c}', this)"></button>`).join('');
       setColor('#000000', pal.firstChild);
     } else if (currentStepIdx === 0) {
       setupPalette();
@@ -616,7 +619,7 @@ const ArtStudio = (() => {
     const pal = document.getElementById('mix-palette');
     const mixable = ['#EF4444', '#FBBF24', '#3B82F6', '#FFFFFF', '#000000'];
     pal.innerHTML = mixable.map(c => `
-      <div class="color-swatch" style="background:${c}" onclick="ArtStudio.pickMixColorFromPal('${c}')"></div>
+      <button type="button" class="color-swatch" style="background:${c}" aria-label="Select mix color ${c}" onclick="ArtStudio.pickMixColorFromPal('${c}')"></button>
     `).join('');
     updateMixingUI();
   }


### PR DESCRIPTION
🎨 Palette: Accessible Color Swatches and Brush Sizes

💡 **What:** 
- Converted the `.color-swatch` pickers (dynamically generated in `js/art-studio.js`) from `<div>` tags to semantic `<button type="button">` tags.
- Added descriptive `aria-label` attributes to the color swatches (e.g., "Select color #EF4444") and the eraser tool.
- Added descriptive `aria-label` attributes to the `.brush-size` buttons in `art-studio.html`.
- Updated `.Jules/palette.md` with a critical learning regarding the usage of native buttons for custom pickers.

🎯 **Why:** 
The color pickers and brush pickers were visually accessible but lacked the semantic tags and ARIA labels required for screen readers and comprehensive keyboard navigation. Transitioning to semantic buttons gives us browser-native focus states and screen reader announcements for free, greatly improving the inclusivity of the Art Studio application.

♿ **Accessibility:**
- Custom pickers now leverage native `<button>` focus management instead of inaccessible `<div>` tags.
- Icon-only interactive elements (eraser, brush sizes) now announce correctly via `aria-label`s.

---
*PR created automatically by Jules for task [4752096754561433631](https://jules.google.com/task/4752096754561433631) started by @rozavala*