### PR TITLE
Fix Little Maestro audio, layout, and scrolling on iPad

### DIFF
--- a/css/little-maestro.css
+++ b/css/little-maestro.css
@@ -518,10 +518,10 @@
       flex-shrink: 0;
       background: var(--color-surface);
       border-bottom: 1px solid var(--color-border);
-      display: flex;
+      display: grid;
+      grid-template-columns: 1fr auto 1fr;
       align-items: center;
-      justify-content: space-between;
-      padding: 0 var(--space-lg);
+      padding: env(safe-area-inset-top) var(--space-lg) 0 var(--space-lg);
       z-index: 100;
     }
 
@@ -531,6 +531,7 @@
       align-items: center;
       gap: var(--space-sm);
       text-decoration: none;
+      justify-self: start;
     }
     .hdr-logo-icon { font-size: 22px; }
     .hdr-logo-text {
@@ -545,10 +546,8 @@
     .hdr-student {
       display: flex;
       align-items: center;
+      justify-content: center;
       gap: var(--space-sm);
-      position: absolute;
-      left: 50%;
-      transform: translateX(-50%);
       background: none;
       border: none;
       padding: 4px 10px;
@@ -583,6 +582,7 @@
       display: flex;
       align-items: center;
       gap: var(--space-md);
+      justify-self: end;
     }
     .hdr-stat {
       display: flex;
@@ -1019,6 +1019,9 @@
         color var(--t-micro),
         box-shadow var(--t-micro);
       user-select: none;
+      max-width: 150px;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     /* Connected — green */
@@ -6353,7 +6356,7 @@ body.theme--light #import-error-toast    { background: #FFFBF0; }
   }
 }
 
-</style>
+
 
 /* --- EMERGENCY IPAD LAYOUT OVERRIDES --- */
 @media (max-height: 850px) {

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
   <title>Little Maestro 🎹</title>
 
   <!-- PWA -->
@@ -7343,12 +7343,22 @@ const AudioEngine = (() => {
   }
 
   // ── init ──────────────────────────────────────────────────────────
+  let compressor;
   function init() {
     if (ctx) return;
     ctx = new (window.AudioContext || window.webkitAudioContext)();
     masterGain = ctx.createGain();
     masterGain.gain.setValueAtTime(0.5, ctx.currentTime);
-    masterGain.connect(ctx.destination);
+
+    compressor = ctx.createDynamicsCompressor();
+    compressor.threshold.setValueAtTime(-12, ctx.currentTime);
+    compressor.knee.setValueAtTime(10, ctx.currentTime);
+    compressor.ratio.setValueAtTime(4, ctx.currentTime);
+    compressor.attack.setValueAtTime(0.003, ctx.currentTime);
+    compressor.release.setValueAtTime(0.25, ctx.currentTime);
+
+    masterGain.connect(compressor);
+    compressor.connect(ctx.destination);
     _loadSoundfont();  // start loading piano samples in the background
   }
 
@@ -7525,15 +7535,32 @@ const AudioEngine = (() => {
 
   // ── playNoteInstant ───────────────────────────────────────────────
   // Single note, immediate playback — for key taps and flashcards
+  let _activeNotes = [];
   function playNoteInstant(noteName, velocity = 90) {
     init();
     if (_sfInstrument) {
       try {
         const masterVol = masterGain ? masterGain.gain.value : 0.7;
-        _sfInstrument.play(noteName, ctx.currentTime, {
+        // Cap single note gain at 0.7 to avoid clipping when combined
+        const maxGain = 0.7;
+        const gainVal = Math.min((velocity / 127) * masterVol * 1.0, maxGain);
+
+        const noteNode = _sfInstrument.play(noteName, ctx.currentTime, {
           duration: 0.6,
-          gain    : (velocity / 127) * masterVol * 1.0,
+          gain    : gainVal,
         });
+
+        // Track active notes for polyphony limiting (max 8)
+        _activeNotes.push({ node: noteNode, time: ctx.currentTime });
+
+        // Cleanup old notes from array and stop them if we exceed polyphony
+        _activeNotes = _activeNotes.filter(n => ctx.currentTime - n.time < 2.0);
+        if (_activeNotes.length > 8) {
+           const oldest = _activeNotes.shift();
+           if (oldest && oldest.node && typeof oldest.node.stop === 'function') {
+             try { oldest.node.stop(ctx.currentTime + 0.05); } catch(e) {}
+           }
+        }
       } catch(e) {}
       return;
     }
@@ -7971,9 +7998,13 @@ const MIDIManager = (() => {
           ? 'permission-denied'
           : 'disconnected';
         _logEvent(`MIDI error: ${errMsg}`);
-        _updateStatusUI();
-        _notifyStatusChange();
-        _updateMidiBanner();
+        try {
+          _updateStatusUI();
+          _notifyStatusChange();
+          _updateMidiBanner();
+        } catch(uiErr) {
+          if (typeof Debug !== 'undefined') Debug.error('[MIDI] Error updating UI: ', uiErr);
+        }
         // Retry even on error — user might grant permission later
         _scheduleRetry();
         return false;
@@ -9985,14 +10016,39 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Scroll highlighted note into view
         const target = _s.noteRefs.find(r => r.globalIdx === index);
-        if (target && target.vfNote.attrs && target.vfNote.attrs.el) {
-          const el = target.vfNote.attrs.el;
+        let el = target && target.vfNote && target.vfNote.attrs ? target.vfNote.attrs.el : null;
+
+        // Fallback to data-note-index attribute if VexFlow doesn't populate attrs.el
+        if (!el) {
+          const noteEls = document.querySelectorAll('#lesson-sheet-music [data-note-index]');
+          el = noteEls[index];
+        }
+
+        if (el) {
           const container = document.getElementById(_s.containerId);
           if (container && el.getBoundingClientRect) {
             const noteRect = el.getBoundingClientRect();
             const contRect = container.getBoundingClientRect();
-            if (noteRect.top < contRect.top || noteRect.bottom > contRect.bottom) {
-              el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+
+            // Check current note and lookahead notes (e.g., index + 2)
+            let needsScroll = (noteRect.top < contRect.top || noteRect.bottom > contRect.bottom);
+            if (!needsScroll) {
+               const lookaheadEls = document.querySelectorAll('#lesson-sheet-music [data-note-index]');
+               const lookaheadEl = lookaheadEls[index + 2];
+               if (lookaheadEl) {
+                  const laRect = lookaheadEl.getBoundingClientRect();
+                  if (laRect.bottom > contRect.bottom) {
+                     needsScroll = true;
+                  }
+               }
+            }
+
+            if (needsScroll) {
+               // Calculate relative Y and manual smooth scrollTo instead of scrollIntoView
+               const relativeY = (noteRect.top - contRect.top) + container.scrollTop;
+               // Scroll to place the note in the top third of the container
+               const targetScroll = Math.max(0, relativeY - (contRect.height / 3));
+               container.scrollTo({ top: targetScroll, behavior: 'smooth' });
             }
           }
         }


### PR DESCRIPTION
Addresses several related bug reports regarding Little Maestro on iPads:
1. Resolves a TypeError blocking initialization due to Web MIDI browser timing by wrapping early UI updates in a try/catch.
2. Fixes audio distortion/clipping through headphones by adding a `DynamicsCompressorNode`, capping per-note gain, and adding an 8-note polyphony limit for the Soundfont player.
3. Fixes overlapping layout issues on iPad by deleting a broken `</style>` tag, updating `#global-header` to use CSS grid to resolve the `.hdr-student` positioning overlapping, and truncating the MIDI text string badge.
4. Fixes non-scrolling sheet music on iPad WebKit by replacing `scrollIntoView` with a manual `scrollTo` logic referencing bounding box calculation, introducing an N+2 lookahead.

---
*PR created automatically by Jules for task [15639276848514495592](https://jules.google.com/task/15639276848514495592) started by @rozavala*