### PR TITLE
# DAILY DOCS UPDATE [2026-03-24] — Documentation Guardian Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ A core feature of the Zavala Serra Apps suite is helping kids develop healthy di
 - **Chores System (Sistema de Tareas)**: Cuando se acaba el tiempo, los niños pueden ganar tiempo extra (tokens) completando tareas del mundo real (ej. "Hacer la cama", "Leer 20 minutos"). Un PIN de padres es requerido para aprobar el tiempo extra.
 - **Privacidad Local (Local Privacy)**: Todos los datos, progresos y tiempos de uso se almacenan localmente en el dispositivo (`localStorage`). (All data and progress are stored locally on the device, ensuring maximum family privacy).
 
-## 🛠️ Key Features
+## 🛠️ Características Principales (Key Features)
 
-- **Personalized Profiles**: Kids can create their own explorers with custom avatars and colors.
-- **Unified Explorer Rank**: Earn ranks across the entire app suite (Cadet → Legend) by mastering different subjects.
-- **Age-Adaptive Difficulty**: Content automatically adjusts to each child's age for an appropriate challenge level.
-- **Progress Tracking**: All stars, levels, and scores are saved locally using `localStorage`.
-- **Parent Dashboard**: A secure area to monitor progress across all apps in the suite.
-- **Safe by Design**: No external API calls, no dynamic third-party content, and no user-generated features.
+- **Perfiles Personalizados (Personalized Profiles)**: Los niños pueden crear sus propios exploradores con avatares y colores personalizados. (Kids can create their own explorers with custom avatars and colors).
+- **Rango de Explorador Unificado (Unified Explorer Rank)**: Gana rangos en toda la suite (Cadete → Leyenda) al dominar diferentes materias. (Earn ranks across the entire app suite (Cadet → Legend) by mastering different subjects).
+- **Dificultad Adaptativa (Age-Adaptive Difficulty)**: El contenido se ajusta automáticamente a la edad de cada niño para un desafío adecuado. (Content automatically adjusts to each child's age for an appropriate challenge level).
+- **Seguimiento de Progreso (Progress Tracking)**: Todas las estrellas, niveles y puntuaciones se guardan localmente usando `localStorage`. (All stars, levels, and scores are saved locally using `localStorage`).
+- **Panel de Padres (Parent Dashboard)**: Un área segura para monitorear el progreso en todas las aplicaciones de la suite. (A secure area to monitor progress across all apps in the suite).
+- **Diseño Seguro (Safe by Design)**: Sin llamadas API externas, sin contenido dinámico de terceros y sin funciones generadas por el usuario. (No external API calls, no dynamic third-party content, and no user-generated features).
 
 ## 📜 Content Philosophy
 


### PR DESCRIPTION
Made the 'Key Features' section in README.md bilingual (Spanish first, followed by English) to comply with the family-facing content rules, improving the target audience's experience.

---
*PR created automatically by Jules for task [9751644308131825804](https://jules.google.com/task/9751644308131825804) started by @rozavala*