### PR TITLE
Improve error handling and remove offline check in media lookup

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -245,11 +245,6 @@ var BMC = (function() {
     }
 
     _setStatus('Searching for "' + q + '"…', 'working');
-    if (typeof CloudSync !== 'undefined' && !CloudSync.online) {
-      _setStatus('Offline — can only check titles already in the family library.', 'error');
-      return;
-    }
-
     _fetchJson(VPS + '/api/media/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -268,7 +263,10 @@ var BMC = (function() {
       })
       .catch(function(err) {
         console.warn('[BMC] Lookup failed:', err);
-        _setStatus('Could not search right now. Please try again.', 'error');
+        var msg = (err && err.name === 'AbortError')
+          ? 'The search timed out. Check your connection and try again.'
+          : 'Could not reach the book server. Please try again.';
+        _setStatus(msg, 'error');
       });
   }
 
@@ -638,7 +636,9 @@ var BMC = (function() {
       .then(function(library) {
         _familyLibrary = library || {};
       })
-      .catch(function() { /* offline or endpoint down — that's OK */ });
+      .catch(function(err) {
+        console.warn('[BMC] Library hydrate failed:', err);
+      });
   }
 
   // ── Init ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR improves error handling in the book movie check module by providing more specific error messages to users and removing an outdated offline check that prevented searches when CloudSync was offline.

## Key Changes
- **Removed offline check**: Deleted the CloudSync offline validation that was blocking searches. The API call will now proceed regardless of CloudSync status, allowing the actual network request to determine success or failure.
- **Enhanced error messages**: Replaced generic "Could not search right now" message with context-aware error handling:
  - Detects timeout errors (AbortError) and suggests checking connection
  - Provides a more specific message for server connectivity issues
- **Improved logging**: Added console warning to library hydration error handler for better debugging visibility

## Implementation Details
The error handling now distinguishes between timeout errors and other failures, giving users more actionable feedback. The removal of the CloudSync offline check simplifies the flow and lets the actual HTTP request determine availability, which is more reliable than checking a separate sync status indicator.

https://claude.ai/code/session_01Te42db27fuCE3bsuVh89rp