### PR TITLE
Enforce HTTPS for cover image URLs

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -223,15 +223,20 @@ var BMC = (function() {
   }
 
   // ── List item HTML ─────────────────────────────────────────────
+  function _httpsCover(url) {
+    return url ? String(url).replace(/^http:\/\//i, 'https://') : '';
+  }
+
   function _listItemHtml(item) {
     if (!item) return '';
-    var cover = item.cover_url
-      ? 'style="background-image:url(\'' + escAttr(item.cover_url) + '\')"'
+    var coverUrl = _httpsCover(item.cover_url);
+    var cover = coverUrl
+      ? 'style="background-image:url(\'' + escAttr(coverUrl) + '\')"'
       : '';
     var emoji = (item.type === 'movie' || item.type === 'series') ? '🎬' : '📕';
     var verdict = item.verdict || 'caution';
     return '<button type="button" class="bmc-list-item verdict-' + escAttr(verdict) + '" onclick="BMC.selectCandidate(\'' + escAttr(item.canonical_id) + '\')">' +
-      '<div class="bmc-list-cover" ' + cover + '>' + (item.cover_url ? '' : emoji) + '</div>' +
+      '<div class="bmc-list-cover" ' + cover + '>' + (coverUrl ? '' : emoji) + '</div>' +
       '<div class="bmc-list-body">' +
       '  <div class="bmc-list-title">' + escHtml(item.title) + '</div>' +
       '  <div class="bmc-list-meta">' + escHtml(item.author_or_director || '') + (item.year ? ' · ' + item.year : '') + ' · ages ' + (item.minimum_age || '?') + '+</div>' +
@@ -431,12 +436,13 @@ var BMC = (function() {
     if (!wrap) return;
     var html = '<h3 style="font-family:var(--font-display);font-weight:800;margin-bottom:12px;color:var(--text-primary);">Which one?</h3>';
     html += candidates.map(function(c) {
-      var cover = c.cover_url
-        ? 'style="background-image:url(\'' + escAttr(c.cover_url) + '\');width:44px;height:60px;background-size:cover;background-position:center;border-radius:6px;flex-shrink:0;"'
+      var coverUrl = _httpsCover(c.cover_url);
+      var cover = coverUrl
+        ? 'style="background-image:url(\'' + escAttr(coverUrl) + '\');width:44px;height:60px;background-size:cover;background-position:center;border-radius:6px;flex-shrink:0;"'
         : 'style="width:44px;height:60px;border-radius:6px;background:rgba(255,255,255,0.05);display:flex;align-items:center;justify-content:center;font-size:1.6rem;flex-shrink:0;"';
       var emoji = (c.type === 'movie' || c.type === 'series') ? '🎬' : '📕';
       return '<button type="button" class="bmc-candidate" onclick="BMC.pickCandidate(\'' + escAttr(c.canonical_id) + '\')">' +
-        '<div ' + cover + '>' + (c.cover_url ? '' : emoji) + '</div>' +
+        '<div ' + cover + '>' + (coverUrl ? '' : emoji) + '</div>' +
         '<div style="flex:1;min-width:0;"><div>' + _escHtmlLocal(c.title) + '</div>' +
         '<div class="candidate-meta">' + _escHtmlLocal(c.author_or_director || '') + (c.year ? ' · ' + c.year : '') + '</div></div>' +
       '</button>';
@@ -497,7 +503,8 @@ var BMC = (function() {
     var wrap = document.getElementById('bmc-result');
     if (!wrap) return;
 
-    var coverStyle = e.cover_url ? 'style="background-image:url(\'' + escAttr(e.cover_url) + '\')"' : '';
+    var coverUrl = _httpsCover(e.cover_url);
+    var coverStyle = coverUrl ? 'style="background-image:url(\'' + escAttr(coverUrl) + '\')"' : '';
     var coverEmoji = (e.type === 'movie' || e.type === 'series') ? '🎬' : '📕';
 
     var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
@@ -591,7 +598,7 @@ var BMC = (function() {
 
     var html =
       '<div class="bmc-result-head">' +
-        '<div class="bmc-result-cover" ' + coverStyle + '>' + (e.cover_url ? '' : coverEmoji) + '</div>' +
+        '<div class="bmc-result-cover" ' + coverStyle + '>' + (coverUrl ? '' : coverEmoji) + '</div>' +
         '<div class="bmc-result-meta">' +
           '<h2>' + _escHtmlLocal(e.title) + '</h2>' +
           '<div class="bmc-result-author">' + _escHtmlLocal(e.author_or_director || '') + (e.year ? ' · ' + e.year : '') + '</div>' +

--- a/vps/media.js
+++ b/vps/media.js
@@ -44,6 +44,11 @@ function _rateOk(ip) {
   return true;
 }
 
+function _httpsCover(url) {
+  if (!url) return null;
+  return String(url).replace(/^http:\/\//i, 'https://');
+}
+
 function _canonicalIsbn(isbn) { return 'isbn13:' + String(isbn).replace(/[^0-9Xx]/g, ''); }
 function _canonicalTmdb(id)   { return 'tmdb:' + id; }
 function _canonicalTitle(title, year, author) {
@@ -66,7 +71,7 @@ async function _lookupIsbn(isbn) {
         title: v.title || 'Unknown',
         author_or_director: (v.authors || []).join(', ') || '',
         year: v.publishedDate ? parseInt(String(v.publishedDate).slice(0, 4)) : null,
-        cover_url: (v.imageLinks && (v.imageLinks.thumbnail || v.imageLinks.smallThumbnail)) || null,
+        cover_url: _httpsCover((v.imageLinks && (v.imageLinks.thumbnail || v.imageLinks.smallThumbnail)) || null),
         synopsis: v.description || ''
       }];
     }
@@ -112,7 +117,7 @@ async function _searchBooks(query) {
         title: v.title || 'Unknown',
         author_or_director: (v.authors || []).join(', ') || '',
         year: v.publishedDate ? parseInt(String(v.publishedDate).slice(0, 4)) : null,
-        cover_url: (v.imageLinks && (v.imageLinks.thumbnail || v.imageLinks.smallThumbnail)) || null,
+        cover_url: _httpsCover((v.imageLinks && (v.imageLinks.thumbnail || v.imageLinks.smallThumbnail)) || null),
         synopsis: v.description || ''
       };
     });
@@ -331,7 +336,7 @@ function init(app, dataDir) {
       const evaluation = await _evaluate(metadata);
       // Ensure required fields
       evaluation.canonical_id = canonical_id;
-      evaluation.cover_url = metadata.cover_url || null;
+      evaluation.cover_url = _httpsCover(metadata.cover_url || null);
       evaluation.evaluated_at = now;
       if (typeof evaluation.parent_reviewed !== 'boolean') evaluation.parent_reviewed = false;
       if (!evaluation.type) evaluation.type = metadata.type || 'book';


### PR DESCRIPTION
## Summary
This PR upgrades all cover image URLs from HTTP to HTTPS to ensure secure delivery of media assets and comply with modern security standards.

## Key Changes
- Added `_httpsCover()` utility function in both `js/book-movie-check.js` and `vps/media.js` to convert HTTP URLs to HTTPS
- Updated all cover URL references in the client-side code (`_listItemHtml()`, candidate selection, and result display) to use the new utility
- Updated server-side data processing in `vps/media.js` to convert cover URLs from Google Books API and metadata storage to HTTPS
- Ensured consistent URL handling across ISBN lookups, book searches, and evaluation results

## Implementation Details
- The `_httpsCover()` function safely handles null/undefined URLs and uses case-insensitive regex replacement (`/^http:\/\//i`) to convert HTTP to HTTPS
- All existing cover URL checks remain functional (e.g., conditional emoji display when no cover is available)
- The change is backward compatible and doesn't affect the overall data structure or API contracts

https://claude.ai/code/session_01THttjo8TfTNkW4WQUdRnbr