### PR TITLE
Add prompt versioning and bulk re-evaluation tools for criteria updates

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -75,6 +75,12 @@
       <div class="bmc-section-header">
         <h2>📚 Family library</h2>
         <p>Every book and movie we've looked up together.</p>
+        <div id="bmc-parent-tools" style="display:none; margin-top:12px;">
+          <button class="bmc-btn bmc-btn-secondary" onclick="BMC.reviewWithNewCriteria()">
+            🔄 Re-review library with new criteria (<span id="bmc-stale-count">?</span>)
+          </button>
+          <div id="bmc-reeval-status" style="margin-top:8px; font-size:0.85rem; color:var(--text-muted);"></div>
+        </div>
       </div>
       <div id="bmc-library-filter" class="bmc-filter-row"></div>
       <div id="bmc-library-list" class="bmc-list">

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -35,6 +35,7 @@ var BMC = (function() {
   function unlockParent() {
     if (_requestParentMode()) {
       if (_currentResult) showResult(_currentResult);
+      _refreshStaleCount();
     }
   }
 
@@ -115,6 +116,7 @@ var BMC = (function() {
     if (name === 'library') {
       document.getElementById('screen-library').classList.add('active');
       _renderLibrary();
+      _refreshStaleCount();
       _activateTabButtons('.bmc-tab-btn[onclick*="library"]');
     } else if (name === 'history') {
       document.getElementById('screen-history').classList.add('active');
@@ -714,6 +716,42 @@ var BMC = (function() {
       });
   }
 
+  // ── Re-review / stale-count (parent tools) ─────────────────────
+  function _refreshStaleCount() {
+    var tools = document.getElementById('bmc-parent-tools');
+    var countEl = document.getElementById('bmc-stale-count');
+    if (!tools) return;
+    if (!_parentMode) {
+      tools.style.display = 'none';
+      return;
+    }
+    tools.style.display = 'block';
+    _fetchJson(VPS + '/api/media/stale-count')
+      .then(function(r) {
+        if (countEl) countEl.textContent = r.stale + ' of ' + r.total;
+      })
+      .catch(function() {
+        if (countEl) countEl.textContent = '?';
+      });
+  }
+
+  function reviewWithNewCriteria() {
+    if (!_requestParentMode()) return;
+    if (!confirm('Re-review all stale entries? This can take several minutes.')) return;
+    var statusEl = document.getElementById('bmc-reeval-status');
+    if (statusEl) statusEl.textContent = 'Starting…';
+    _fetchJson(VPS + '/api/media/reevaluate-stale', { method: 'POST' })
+      .then(function(r) {
+        if (statusEl) {
+          statusEl.textContent = 'Re-reviewing ' + r.count + ' books in the background. '
+            + 'Refresh in a few minutes.';
+        }
+      })
+      .catch(function(err) {
+        if (statusEl) statusEl.textContent = 'Failed to start: ' + (err && err.message ? err.message : 'unknown');
+      });
+  }
+
   // ── Init ───────────────────────────────────────────────────────
   function init() {
     _hydrateFamilyLibrary().then(function() {
@@ -748,7 +786,8 @@ var BMC = (function() {
     pickCandidate: pickCandidate,
     recordConsumed: recordConsumed,
     addToWishlist: addToWishlist,
-    unlockParent: unlockParent
+    unlockParent: unlockParent,
+    reviewWithNewCriteria: reviewWithNewCriteria
   };
 })();
 

--- a/vps/media-prompt.txt
+++ b/vps/media-prompt.txt
@@ -6,12 +6,42 @@ You are NOT a neutral reviewer. You review through the lens of this family's exp
 
 Mark any of the following as "moderate" or "significant" when present. "Significant" means the content is central, sympathetic, or aspirational — not merely mentioned.
 
-1. **LGBTQ content** — any portrayal of same-sex romance, transgender identity, non-traditional gender expression, drag, pride themes, or LGBTQ activism framed positively or neutrally. Even incidental sympathetic portrayal counts as at least "mild".
-2. **Critical Race Theory / racial ideology** — narratives framing history or current events primarily through oppressor/oppressed racial dynamics, white guilt, systemic racism claims presented as settled fact, or DEI/social-justice ideology.
+1. **LGBTQ content and gender ideology** — this family treats normalization itself as the issue, not just central themes. Any ONE of the following is at least "mild", and two or more, or any central/sympathetic treatment, is "moderate" or "significant":
+   - Same-sex romance, dating, marriage, hand-holding, or attraction portrayed positively or neutrally
+   - Transgender characters, pronoun changes, "deadnaming" framed as harm, gender transition as a positive arc
+   - Non-binary characters or singular "they/them" used as settled fact for a character
+   - Drag performers, pride flags, rainbow symbolism, pride-month events woven into the setting
+   - Gender-non-conforming children whose non-conformity is framed as identity rather than play
+   - "Chosen family" framed as superior to or replacing the biological family
+   - Side characters casually given same-sex partners as a normalizing beat
+   - Author note, publisher blurb, or front-matter celebrating LGBTQ inclusion, "queer joy", or "Own Voices" framing
+   - Any publisher category or marketing tag containing "LGBTQ+", "queer", "gay", or "trans"
+
+   A one-line background mention is still "mild", not "none". If two or more signals appear, or if any signal is given narrative weight, it is "moderate" at minimum.
+2. **Critical Race Theory / racial and identity ideology** — any ONE of the following is at least "mild":
+   - History or current events framed primarily through oppressor/oppressed racial dynamics
+   - Systemic racism, "white privilege", "whiteness", or structural oppression presented as settled fact
+   - Land acknowledgments, "decolonize", or indigenous-as-perpetual-victim framings in children's settings
+   - "Anti-racism" activism presented as a heroic character arc
+   - Characters coded by race as representatives of structural forces rather than as individuals
+   - DEI/equity-over-equality language, or "centering marginalized voices" as an explicit authorial stance
+   - Author note, publisher blurb, or marketing copy that foregrounds these themes
+
+   If front-matter/author-bio/publisher categorization foregrounds these themes, rate at least "moderate" even if the story itself is subtle — the packaging is part of the work.
 3. **Pro-abortion messaging** — portraying abortion as a right, a neutral choice, or empowering.
 4. **Sexual content** — any sexual activity, sexualized imagery, nudity, sexualized dress, innuendo aimed at children, romance with sexual undertones outside of marriage.
 5. **Moral relativism** — blurring good and evil, sympathetic villains whose evil goes unchallenged, "everyone's truth is valid" framing.
-6. **Disrespect toward parents or legitimate authority** — as a celebrated personality trait. (Note: heroic resistance to tyranny is distinct and acceptable.)
+6. **Celebrated disrespect of legitimate authority** — applies ONLY when a character's contempt, rudeness, or defiance toward parents, teachers, clergy, or legitimate civil authority is portrayed as a celebrated personality trait that the narrative voice approves of and never meaningfully corrects. Signals: "sassy" children whose rudeness is played for laughs, teen protagonists who treat parents as fools to be outwitted, framings where obedience equals weakness and defiance equals virtue.
+
+   This criterion explicitly does NOT cover:
+   - Plot-driven independence. Orphan protagonists, boarding-school stories, summer adventures, fantasy quests, travel narratives, "children sent to stay with relatives" setups, or worlds where parents are absent for structural reasons. A child living or acting apart from parents is a genre convention of children's literature, not disrespect. Do NOT flag Narnia, the Boxcar Children, Anne of Green Gables, Harry Potter's school setting, Percy Jackson, A Wrinkle in Time, The Penderwicks, Swallows and Amazons, or similar.
+   - Heroic resistance to genuinely evil or illegitimate authority (Les Misérables, 1984, resistance narratives, hiding Jews from Nazis, etc.).
+   - Protagonists who make mistakes that the story corrects via natural consequences, remorse, or a redemptive arc.
+   - Authority figures portrayed as fallible, comic, strict, or even flawed — provided the story does not frame rebellion against them as a virtue in itself.
+   - Light-hearted mischief resolved within the family's love and structure.
+   - A protagonist sneaking off for an adventure against reasonable parental wishes, when this is a plot mechanic and not a celebrated trait.
+
+   Flag this only when contempt for legitimate authority is endorsed by the narrative voice, goes unchallenged, and is presented as admirable. When in doubt, set to "none", not "mild".
 7. **Anti-Catholic / anti-Christian content** — clergy portrayed as uniformly corrupt, faith portrayed as ignorance, Catholic practices mocked.
 8. **Occult as aspiration** — real-world occult practices (Wicca, channeling, tarot, summoning) portrayed as good or desirable. NOTE: classical literary magic (Narnia, Tolkien, fairy tales, mythological creatures) is EXPLICITLY ACCEPTABLE and should not be flagged as occult.
 9. **Gender confusion themes** — transgender characters, rejection of the male/female created order, pronoun ideology.
@@ -90,6 +120,7 @@ Return ONE JSON object. No markdown. No preamble. No code fences. Just the JSON.
 
 - Be honest and specific. Vague positivity helps no one.
 - Modern works (2015 or later) require extra scrutiny for implicit ideological content. Check for gender ideology, racial framing, subversive subtexts.
+- Do not conflate a protagonist's independence with disrespect. Orphans, boarding-school students, and adventurers living apart from parents is a genre convention, not criterion #6.
 - If you are uncertain about specific content, set confidence to "low" and lean toward "caution".
 - NEVER soften assessment to be more palatable. This family wants truth.
 - Classical literary magic (Narnia, LOTR, fairy tales) → do NOT flag as occult.

--- a/vps/media.js
+++ b/vps/media.js
@@ -14,6 +14,7 @@ const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 const GROK_KEY = process.env.GROK_API_KEY;
 const CACHE_TTL_DAYS = 90;
+const PROMPT_VERSION = 2;  // bump whenever media-prompt.txt is edited
 const RATE_LIMIT_PER_HOUR = 60;  // per source IP, total evaluate calls
 
 let DATA_DIR = null;
@@ -329,6 +330,7 @@ function init(app, dataDir) {
       const cache = _loadCache();
       const now = Date.now();
       if (cache[canonical_id] && cache[canonical_id].evaluated_at
+          && cache[canonical_id].prompt_version === PROMPT_VERSION
           && (now - cache[canonical_id].evaluated_at) < CACHE_TTL_DAYS * 86400000) {
         return res.json(cache[canonical_id]);
       }
@@ -338,6 +340,7 @@ function init(app, dataDir) {
       evaluation.canonical_id = canonical_id;
       evaluation.cover_url = _httpsCover(metadata.cover_url || null);
       evaluation.evaluated_at = now;
+      evaluation.prompt_version = PROMPT_VERSION;
       if (typeof evaluation.parent_reviewed !== 'boolean') evaluation.parent_reviewed = false;
       if (!evaluation.type) evaluation.type = metadata.type || 'book';
       if (!evaluation.title) evaluation.title = metadata.title;
@@ -374,6 +377,82 @@ function init(app, dataDir) {
     entry.parent_reviewed = true;
     _saveCache(cache);
     res.json(entry);
+  });
+
+  // ── POST /api/media/reevaluate/:id ── (force re-eval one entry)
+  app.post('/api/media/reevaluate/:id', async (req, res) => {
+    const ip = req.ip || 'unknown';
+    if (!_rateOk(ip)) return res.status(429).json({ error: 'Rate limit exceeded' });
+    const cache = _loadCache();
+    const entry = cache[req.params.id];
+    if (!entry) return res.status(404).json({ error: 'Not cached' });
+    try {
+      const metadata = {
+        title: entry.title,
+        author_or_director: entry.author_or_director,
+        year: entry.year,
+        type: entry.type,
+        synopsis: entry.summary || ''
+      };
+      const fresh = await _evaluate(metadata);
+      fresh.canonical_id = entry.canonical_id;
+      fresh.cover_url = entry.cover_url;
+      fresh.evaluated_at = Date.now();
+      fresh.prompt_version = PROMPT_VERSION;
+      fresh.parent_reviewed = entry.parent_reviewed || false;
+      cache[entry.canonical_id] = fresh;
+      _saveCache(cache);
+      res.json(fresh);
+    } catch (err) {
+      console.error('[media/reevaluate]', err.message);
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  // ── POST /api/media/reevaluate-stale ── (walks cache, re-evals stale entries)
+  app.post('/api/media/reevaluate-stale', async (req, res) => {
+    const cache = _loadCache();
+    const stale = Object.keys(cache).filter(id =>
+      cache[id].prompt_version !== PROMPT_VERSION);
+    res.json({ started: true, count: stale.length });
+    // Fire-and-forget; process serially with delay to respect rate limit
+    (async () => {
+      for (const id of stale) {
+        try {
+          const entry = cache[id];
+          const metadata = {
+            title: entry.title,
+            author_or_director: entry.author_or_director,
+            year: entry.year,
+            type: entry.type,
+            synopsis: entry.summary || ''
+          };
+          const fresh = await _evaluate(metadata);
+          fresh.canonical_id = id;
+          fresh.cover_url = entry.cover_url;
+          fresh.evaluated_at = Date.now();
+          fresh.prompt_version = PROMPT_VERSION;
+          fresh.parent_reviewed = entry.parent_reviewed || false;
+          const current = _loadCache();
+          current[id] = fresh;
+          _saveCache(current);
+          console.log('[media/reevaluate-stale] Updated ' + entry.title);
+          await new Promise(r => setTimeout(r, 1500));
+        } catch (err) {
+          console.warn('[media/reevaluate-stale] Failed ' + id + ':', err.message);
+        }
+      }
+      console.log('[media/reevaluate-stale] Done');
+    })();
+  });
+
+  // ── GET /api/media/stale-count ── (how many entries need re-eval)
+  app.get('/api/media/stale-count', (req, res) => {
+    const cache = _loadCache();
+    const total = Object.keys(cache).length;
+    const stale = Object.keys(cache).filter(id =>
+      cache[id].prompt_version !== PROMPT_VERSION).length;
+    res.json({ total: total, stale: stale, prompt_version: PROMPT_VERSION });
   });
 }
 


### PR DESCRIPTION
## Summary
This PR introduces a prompt versioning system to track when evaluation criteria change, and adds parent-facing tools to bulk re-evaluate the library when new assessment guidelines are deployed. It also significantly expands and clarifies the evaluation criteria in the media-prompt.txt file.

## Key Changes

**Backend (vps/media.js):**
- Added `PROMPT_VERSION` constant to track evaluation criteria versions
- Modified cache validation to check `prompt_version` matches current version, invalidating stale entries
- Added `POST /api/media/reevaluate/:id` endpoint to force re-evaluation of a single cached entry
- Added `POST /api/media/reevaluate-stale` endpoint to bulk re-evaluate all entries with outdated prompt versions (fire-and-forget, serial processing with rate-limit delays)
- Added `GET /api/media/stale-count` endpoint to report how many entries need re-evaluation

**Frontend (js/book-movie-check.js):**
- Added `_refreshStaleCount()` function to fetch and display the count of stale entries
- Added `reviewWithNewCriteria()` function to trigger bulk re-evaluation with user confirmation
- Integrated stale-count refresh on library view load and after parent mode unlock
- Exported `reviewWithNewCriteria` as public API

**UI (book-movie-check.html):**
- Added parent-tools section in the library header (hidden by default, shown only in parent mode)
- Added "Re-review library with new criteria" button with stale entry count display
- Added status message area for re-evaluation feedback

**Evaluation Criteria (vps/media-prompt.txt):**
- Significantly expanded criterion #1 (LGBTQ content) with detailed signal list and clarification that normalization itself is the concern
- Expanded criterion #2 (CRT/racial ideology) with specific examples and packaging-level assessment guidance
- Clarified criterion #6 (disrespect of authority) with extensive exclusions for plot-driven independence, heroic resistance, and genre conventions (explicitly names Harry Potter, Narnia, Percy Jackson, etc.)
- Added guidance note about not conflating protagonist independence with disrespect

## Implementation Details
- Stale entries are identified by mismatched `prompt_version` in cache
- Bulk re-evaluation processes serially with 1.5s delays to respect rate limits
- Re-evaluation is fire-and-forget; client receives immediate response with count
- Parent mode required for accessing re-evaluation tools
- All re-evaluated entries preserve original metadata (title, author, cover) and parent-review status while updating evaluation results

https://claude.ai/code/session_012ToGeqAK5yPVZyEbiiE5jk