### PR TITLE
fix(bmcheck): propagate Gemini status codes and smart retry in audit script

### DIFF
--- a/vps/audit-media-prompt.js
+++ b/vps/audit-media-prompt.js
@@ -204,17 +204,31 @@ const CORPUS = [
 
 // ── Runner ─────────────────────────────────────────────────────
 
-async function testEvaluate(metadata) {
+const MAX_RETRIES_503 = 4;   // Gemini overload — usually clears fast
+const MAX_RETRIES_429 = 2;   // quota — retry a couple times, then give up
+const PACING_MS = 2000;      // delay between tests
+
+async function testEvaluate(metadata, attempt) {
+  attempt = attempt || 1;
   const r = await fetch(VPS + '/api/media/test-evaluate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ metadata })
   });
-  if (r.status === 429) {
-    console.log('\n   ⏸️  Rate limited; sleeping 60s…');
-    await new Promise(res => setTimeout(res, 60000));
-    return testEvaluate(metadata);
+
+  if (r.status === 503 && attempt <= MAX_RETRIES_503) {
+    const wait = 5000 * attempt;  // 5s, 10s, 15s, 20s
+    console.log('\n   ⏸️  upstream 503 (overloaded); retry ' + attempt + '/' + MAX_RETRIES_503 + ' in ' + (wait / 1000) + 's…');
+    await new Promise(res => setTimeout(res, wait));
+    return testEvaluate(metadata, attempt + 1);
   }
+  if (r.status === 429 && attempt <= MAX_RETRIES_429) {
+    const wait = 60000 * attempt;  // 60s, 120s
+    console.log('\n   ⏸️  upstream 429 (quota); retry ' + attempt + '/' + MAX_RETRIES_429 + ' in ' + (wait / 1000) + 's…');
+    await new Promise(res => setTimeout(res, wait));
+    return testEvaluate(metadata, attempt + 1);
+  }
+
   if (!r.ok) {
     const body = await r.text();
     throw new Error('HTTP ' + r.status + ': ' + body.slice(0, 200));
@@ -303,9 +317,15 @@ async function main() {
       }
     } catch (err) {
       console.log('❌ ERROR: ' + err.message);
-      results.push({ test, result: null, grade: { status: 'error', notes: [err.message] } });
+      // Informational titles that error are not scored failures.
+      const isInfo = !test.expect || test.expect.verdict === null;
+      results.push({
+        test,
+        result: null,
+        grade: { status: isInfo ? 'info-error' : 'error', notes: [err.message] }
+      });
     }
-    await new Promise(r => setTimeout(r, 500));  // polite pacing
+    await new Promise(r => setTimeout(r, PACING_MS));  // polite pacing
   }
 
   // ── Summary ──
@@ -316,7 +336,7 @@ async function main() {
   const cats = {};
   for (const r of results) {
     const c = r.test.category || 'other';
-    if (!cats[c]) cats[c] = { pass: 0, fail: 0, error: 0, info: 0 };
+    if (!cats[c]) cats[c] = { pass: 0, fail: 0, error: 0, info: 0, 'info-error': 0 };
     cats[c][r.grade.status]++;
   }
   const W = 28;
@@ -326,9 +346,11 @@ async function main() {
   for (const c of Object.keys(cats)) {
     const x = cats[c];
     const scored = x.pass + x.fail + x.error;
-    if (scored === 0 && x.info === 0) continue;
+    const infoTotal = x.info + x['info-error'];
+    if (scored === 0 && infoTotal === 0) continue;
     if (scored === 0) {
-      console.log('   ' + pad(c, W) + ' |    - |    - |  ' + pad(String(x.info), 3) + ' (info)');
+      const suffix = x['info-error'] ? ' (info, ' + x['info-error'] + ' errored)' : ' (info)';
+      console.log('   ' + pad(c, W) + ' |    - |    - |  ' + pad(String(infoTotal), 3) + suffix);
       continue;
     }
     totalPass += x.pass;

--- a/vps/media.js
+++ b/vps/media.js
@@ -50,6 +50,12 @@ function _httpsCover(url) {
   return String(url).replace(/^http:\/\//i, 'https://');
 }
 
+function _upstreamStatus(errMsg) {
+  // Parses "Gemini 429: ..." or "Grok 503: ..." from _evaluate*() error messages.
+  const m = String(errMsg || '').match(/^(?:Gemini|Grok)\s+(\d+):/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
 function _canonicalIsbn(isbn) { return 'isbn13:' + String(isbn).replace(/[^0-9Xx]/g, ''); }
 function _canonicalTmdb(id)   { return 'tmdb:' + id; }
 function _canonicalTitle(title, year, author) {
@@ -352,6 +358,10 @@ function init(app, dataDir) {
       res.json(evaluation);
     } catch (err) {
       console.error('[media/evaluate]', err.message);
+      const upstream = _upstreamStatus(err.message);
+      if (upstream === 429 || upstream === 503) {
+        return res.status(upstream).json({ error: err.message, upstream: upstream });
+      }
       res.status(500).json({ error: err.message });
     }
   });
@@ -405,6 +415,10 @@ function init(app, dataDir) {
       res.json(fresh);
     } catch (err) {
       console.error('[media/reevaluate]', err.message);
+      const upstream = _upstreamStatus(err.message);
+      if (upstream === 429 || upstream === 503) {
+        return res.status(upstream).json({ error: err.message, upstream: upstream });
+      }
       res.status(500).json({ error: err.message });
     }
   });
@@ -473,6 +487,10 @@ function init(app, dataDir) {
       res.json(evaluation);
     } catch (err) {
       console.error('[media/test-evaluate]', err.message);
+      const upstream = _upstreamStatus(err.message);
+      if (upstream === 429 || upstream === 503) {
+        return res.status(upstream).json({ error: err.message, upstream: upstream });
+      }
       res.status(500).json({ error: err.message });
     }
   });


### PR DESCRIPTION
## Summary

Fix the audit script's failure-cascade behavior after Rodrigo hit Gemini 503s then 429s in a fresh run.

Root cause: the VPS wrapped every upstream Gemini error as HTTP 500, so the audit script's built-in 60s retry (which only fired on outer `429`) never triggered. One slow Gemini call plus 500 ms pacing raced through all 18 calls in ~10 s, which itself tripped free-tier quota.

## Changes

- **`vps/media.js`** — parse upstream status from `"Gemini NNN:"` error messages and forward `429`/`503` verbatim (adds `upstream: NNN` to the error body) instead of collapsing everything to `500`. Applied to `/evaluate`, `/reevaluate/:id`, and `/test-evaluate`.
- **`vps/audit-media-prompt.js`** — exponential backoff:
  - `503` (Gemini overload): retry up to 4× with 5 s / 10 s / 15 s / 20 s waits.
  - `429` (quota): retry up to 2× with 60 s / 120 s waits, then give up gracefully.
  - Pacing bumped from 500 ms → 2 s so we stop out-running the upstream.
- **Summary accounting** — informational titles that error no longer count as scored failures; they show under the info row with a `(N errored)` suffix.

## Test plan

- [x] `node -c` passes on both files
- [ ] Run `node vps/audit-media-prompt.js` end-to-end — expect all retries to resolve cleanly and the final MECE table to reflect pass/fail without the informational errors double-counting
- [ ] Confirm the "Prompt version seen: 2" line still appears

https://claude.ai/code/session_012ToGeqAK5yPVZyEbiiE5jk