### PR TITLE
Improve iPad camera support & add parent library management tools

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -75,11 +75,33 @@
       <div class="bmc-section-header">
         <h2>📚 Family library</h2>
         <p>Every book and movie we've looked up together.</p>
-        <div id="bmc-parent-tools" style="display:none; margin-top:12px;">
-          <button class="bmc-btn bmc-btn-secondary" onclick="BMC.reviewWithNewCriteria()">
-            🔄 Re-review library with new criteria (<span id="bmc-stale-count">?</span>)
+        <div id="bmc-parent-bar" style="margin-top:12px;">
+          <button class="bmc-btn bmc-btn-secondary" id="bmc-parent-unlock"
+                  onclick="BMC.unlockParent()">
+            🔒 Parents
           </button>
-          <div id="bmc-reeval-status" style="margin-top:8px; font-size:0.85rem; color:var(--text-muted);"></div>
+        </div>
+        <div id="bmc-parent-tools" style="display:none; margin-top:12px;
+             padding:14px; background:var(--bg-card);
+             border:1.5px solid var(--border-subtle); border-radius:12px;">
+          <h4 style="font-size:0.75rem; letter-spacing:0.6px; text-transform:uppercase;
+                     color:var(--text-muted); font-weight:800; margin-bottom:10px;">
+            Parent tools
+          </h4>
+          <div style="display:flex; flex-wrap:wrap; gap:8px;">
+            <button class="bmc-btn bmc-btn-secondary" onclick="BMC.reviewWithNewCriteria()">
+              🔄 Re-review with new criteria (<span id="bmc-stale-count">?</span>)
+            </button>
+            <button class="bmc-btn bmc-btn-secondary" onclick="BMC.clearMySearches()">
+              🧹 Clear my recent checks
+            </button>
+            <button class="bmc-btn bmc-btn-secondary" onclick="BMC.resetFamilyLibrary()"
+                    style="color:var(--bmc-notrec); border-color:var(--bmc-notrec);">
+              ⚠️ Reset family library
+            </button>
+          </div>
+          <div id="bmc-reeval-status" style="margin-top:10px; font-size:0.85rem;
+               color:var(--text-muted);"></div>
         </div>
       </div>
       <div id="bmc-library-filter" class="bmc-filter-row"></div>
@@ -115,6 +137,15 @@
     <div class="bmc-modal-panel">
       <button class="bmc-modal-close" onclick="BMC.closeScan()" aria-label="Close scanner">✕</button>
       <h3>Point camera at the ISBN barcode</h3>
+      <div id="bmc-scan-ipad-hint" style="display:none; padding:10px 12px; margin-bottom:10px;
+           background:rgba(96,165,250,0.1); border:1.5px solid rgba(96,165,250,0.4);
+           border-radius:10px; font-size:0.85rem; line-height:1.4;">
+        ℹ️ This app can't use the camera here. You have two options:
+        <ol style="margin:6px 0 0 20px; padding:0;">
+          <li>Open Book &amp; Movie Check in <b>Safari</b> to scan,</li>
+          <li>Or tap <b>"Type ISBN instead"</b> below to enter it manually.</li>
+        </ol>
+      </div>
       <video id="bmc-scan-video" playsinline muted></video>
       <div id="bmc-scan-hint" class="bmc-modal-hint">Looking for barcode…</div>
       <div class="bmc-modal-actions">

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -19,6 +19,20 @@ var BMC = (function() {
   var _scanStream = null;
   var _parentMode = false;  // session-only, resets on page reload
 
+  // Environment detection for iPad-in-WKWebView-wrapper cases
+  var _cameraAvailable = null;  // null = unknown; true/false after probe
+  function _isIpadWrapper() {
+    try {
+      var ua = navigator.userAgent || '';
+      var isIOS = /iPad|iPhone|iPod/.test(ua) ||
+                  (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1);
+      if (!isIOS) return false;
+      // Safari on iOS reports "Safari" in UA. WKWebView wrappers do not.
+      var isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
+      return !isSafari;
+    } catch (e) { return false; }
+  }
+
   function _requestParentMode() {
     if (_parentMode) return true;
     var entered = prompt('Parent PIN:');
@@ -305,16 +319,29 @@ var BMC = (function() {
   }
 
   // ── ISBN scan + manual entry ───────────────────────────────────
+  function _showScanModalWithHint() {
+    var modal = document.getElementById('bmc-scan-modal');
+    var hint = document.getElementById('bmc-scan-ipad-hint');
+    if (!modal) return false;
+    if (hint) hint.style.display = 'block';
+    modal.classList.add('active');
+    return true;
+  }
+
   function scanIsbn() {
+    // BarcodeDetector is Chromium-only; on all WebKit iPads it is undefined.
     if (typeof BarcodeDetector === 'undefined') {
+      if (_showScanModalWithHint()) return;
       return promptManualIsbn();
     }
     BarcodeDetector.getSupportedFormats().then(function(formats) {
       if (formats.indexOf('ean_13') === -1 && formats.indexOf('isbn_13') === -1) {
+        if (_showScanModalWithHint()) return;
         return promptManualIsbn();
       }
       _startScan(formats);
     }).catch(function() {
+      if (_showScanModalWithHint()) return;
       promptManualIsbn();
     });
   }
@@ -323,8 +350,18 @@ var BMC = (function() {
     var modal = document.getElementById('bmc-scan-modal');
     var video = document.getElementById('bmc-scan-video');
     var hint = document.getElementById('bmc-scan-hint');
+    var ipadHint = document.getElementById('bmc-scan-ipad-hint');
     if (!modal || !video) return promptManualIsbn();
     modal.classList.add('active');
+
+    // iPad WKWebView wrapper (e.g. Web MIDI Browser) — camera rarely works here
+    if (_isIpadWrapper() && ipadHint) {
+      ipadHint.style.display = 'block';
+    }
+    // BarcodeDetector is Chromium-only; on all WebKit iPads it is undefined
+    if (typeof BarcodeDetector === 'undefined' && ipadHint) {
+      ipadHint.style.display = 'block';
+    }
 
     navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
       .then(function(stream) {
@@ -349,8 +386,11 @@ var BMC = (function() {
         loop();
       })
       .catch(function() {
-        closeScan();
-        promptManualIsbn();
+        if (ipadHint) {
+          ipadHint.style.display = 'block';
+          ipadHint.innerHTML = '⚠️ Camera not available in this app. ' +
+            'Tap <b>"Type ISBN instead"</b> below, or open Book &amp; Movie Check in Safari.';
+        }
       });
   }
 
@@ -530,6 +570,33 @@ var BMC = (function() {
       ? 'This book or movie is not a good fit for our family. If you\'re curious, talk with Mom or Dad.'
       : (e.verdict_reasoning || '');
 
+    // Maturity gate vs. values rejection — soften messaging for pure adult content
+    if (isBlocked && !isParent) {
+      var f = e.content_flags || {};
+      var valuesFlags = ['lgbtq_content', 'crt_ideology', 'anti_religious', 'occult_aspirational'];
+      var hasSignificantValues = valuesFlags.some(function(k) {
+        return f[k] === 'significant';
+      });
+      var hasModerateValues = valuesFlags.some(function(k) {
+        return f[k] === 'moderate';
+      });
+      var hasSignificantRelativism = f.moral_relativism === 'significant';
+      var isPureMaturityGate =
+        !hasSignificantValues &&
+        !hasModerateValues &&
+        !hasSignificantRelativism &&
+        e.minimum_age && e.minimum_age >= 13;
+      if (isPureMaturityGate) {
+        verdictEmoji = '🧓';
+        verdictTitle = 'Grown-up book';
+        verdictMessage = 'This one is a grown-up book. Ask Mom or Dad if it is right for you yet.';
+      }
+    }
+
+    var bannerVerdictClass = (isBlocked && !isParent && verdictTitle === 'Grown-up book')
+      ? 'verdict-caution'  // reuse the amber caution styling for maturity
+      : e.verdict;
+
     var confBanner = (e.confidence === 'low' && (isParent || !isBlocked))
       ? '<div class="bmc-lowconf">ℹ️ This check is low-confidence — please verify with a parent.</div>'
       : '';
@@ -608,7 +675,7 @@ var BMC = (function() {
         '</div>' +
       '</div>' +
 
-      '<div class="bmc-verdict-banner verdict-' + escAttr(e.verdict) + '">' +
+      '<div class="bmc-verdict-banner verdict-' + escAttr(bannerVerdictClass) + '">' +
         '<div class="verdict-emoji">' + verdictEmoji + '</div>' +
         '<div><h3>' + verdictTitle + '</h3><p>' + _escHtmlLocal(verdictMessage) + '</p></div>' +
       '</div>' +
@@ -720,18 +787,67 @@ var BMC = (function() {
   function _refreshStaleCount() {
     var tools = document.getElementById('bmc-parent-tools');
     var countEl = document.getElementById('bmc-stale-count');
+    var unlockBtn = document.getElementById('bmc-parent-unlock');
     if (!tools) return;
     if (!_parentMode) {
       tools.style.display = 'none';
+      if (unlockBtn) unlockBtn.textContent = '🔒 Parents';
       return;
     }
     tools.style.display = 'block';
+    if (unlockBtn) unlockBtn.textContent = '🔓 Parent mode on';
     _fetchJson(VPS + '/api/media/stale-count')
       .then(function(r) {
         if (countEl) countEl.textContent = r.stale + ' of ' + r.total;
       })
       .catch(function() {
         if (countEl) countEl.textContent = '?';
+      });
+  }
+
+  // Clear this kid's lookups (recent checks list on home)
+  function clearMySearches() {
+    if (!_requestParentMode()) return;
+    if (!confirm('Clear this child\'s recent checks? Their shelf and wishlist stay.')) return;
+    var data = loadData();
+    data.lookups = {};
+    saveData(data);
+    var statusEl = document.getElementById('bmc-reeval-status');
+    if (statusEl) statusEl.textContent = 'Recent checks cleared.';
+    // If currently on home, re-render so the list disappears
+    if (document.getElementById('screen-home').classList.contains('active')) {
+      _renderHome();
+    }
+  }
+
+  // Wipe the family-wide media-cache.json on the VPS
+  function resetFamilyLibrary() {
+    if (!_requestParentMode()) return;
+    var statusEl = document.getElementById('bmc-reeval-status');
+    if (!confirm('⚠️ This will DELETE every evaluation in the family library for ALL kids.\n\n' +
+                 'Every previously-checked book will be re-evaluated from scratch the next time ' +
+                 'anyone searches for it.\n\nAre you sure?')) return;
+    var typed = prompt('Type WIPE to confirm:');
+    if (typed !== 'WIPE') {
+      if (statusEl) statusEl.textContent = 'Reset cancelled.';
+      return;
+    }
+    if (statusEl) statusEl.textContent = 'Wiping family library…';
+    _fetchJson(VPS + '/api/media/library', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ confirm: 'WIPE_FAMILY_LIBRARY' })
+    })
+      .then(function(r) {
+        _familyLibrary = {};
+        if (statusEl) statusEl.textContent = 'Wiped ' + r.cleared + ' entries. Library reset.';
+        _refreshStaleCount();
+        // Clear the displayed library list too
+        var listEl = document.getElementById('bmc-library-list');
+        if (listEl) listEl.innerHTML = '<div class="bmc-empty">Library is empty. Check a book to get started.</div>';
+      })
+      .catch(function(err) {
+        if (statusEl) statusEl.textContent = 'Reset failed: ' + err.message;
       });
   }
 
@@ -787,7 +903,9 @@ var BMC = (function() {
     recordConsumed: recordConsumed,
     addToWishlist: addToWishlist,
     unlockParent: unlockParent,
-    reviewWithNewCriteria: reviewWithNewCriteria
+    reviewWithNewCriteria: reviewWithNewCriteria,
+    clearMySearches: clearMySearches,
+    resetFamilyLibrary: resetFamilyLibrary
   };
 })();
 

--- a/vps/media.js
+++ b/vps/media.js
@@ -469,6 +469,25 @@ function init(app, dataDir) {
     res.json({ total: total, stale: stale, prompt_version: PROMPT_VERSION });
   });
 
+  // ── DELETE /api/media/library ──
+  // Wipes the entire family media cache. Requires a magic confirmation token
+  // to prevent accidental wipes via casual POSTs.
+  app.delete('/api/media/library', (req, res) => {
+    const { confirm } = req.body || {};
+    if (confirm !== 'WIPE_FAMILY_LIBRARY') {
+      return res.status(400).json({ error: 'Missing or invalid confirmation token' });
+    }
+    try {
+      const before = Object.keys(_loadCache()).length;
+      _saveCache({});
+      console.log('[media/library DELETE] Wiped ' + before + ' entries');
+      res.json({ ok: true, cleared: before });
+    } catch (err) {
+      console.error('[media/library DELETE]', err.message);
+      res.status(500).json({ error: err.message });
+    }
+  });
+
   // ── POST /api/media/test-evaluate ──
   // Hermetic evaluation for regression testing. Bypasses cache entirely.
   // Shares the same rate limit bucket as /evaluate.


### PR DESCRIPTION
## Summary
This PR enhances the Book & Movie Check app with better handling for iPad camera limitations and adds new parent-only library management features. It includes environment detection for iPad WKWebView wrappers, improved user guidance when camera access fails, and new tools for parents to manage their family's media library.

## Key Changes

**iPad Camera Support & UX Improvements:**
- Added `_isIpadWrapper()` function to detect iPad devices running in non-Safari WKWebView wrappers (e.g., Web MIDI Browser) where camera access is typically unavailable
- Created `_showScanModalWithHint()` helper to display camera unavailability hints at multiple fallback points
- Enhanced `_startScan()` to show contextual hints when BarcodeDetector is unavailable or camera access fails
- Added new `bmc-scan-ipad-hint` UI element with clear instructions for iPad users to either open Safari or use manual ISBN entry
- Improved error handling in camera permission rejection to display helpful messaging instead of silently closing the modal

**Parent Tools & Library Management:**
- Added `clearMySearches()` function to let parents clear a child's recent lookup history while preserving shelf and wishlist
- Added `resetFamilyLibrary()` function to wipe the entire family-wide media cache with multi-step confirmation (confirmation prompt + typed "WIPE" token)
- Reorganized parent tools UI: moved unlock button outside tools panel, added section header, and arranged buttons in a flex layout
- Updated `_refreshStaleCount()` to dynamically update the parent unlock button text based on mode state (🔒 vs 🔓)

**Verdict Display Refinement:**
- Added logic to soften messaging for "pure maturity gate" blocks (age-based restrictions without values-based concerns)
- When a book is blocked only due to minimum age ≥13 with no significant values flags, display as "Grown-up book" with amber styling instead of generic block message

**Backend API:**
- Added `DELETE /api/media/library` endpoint to wipe family media cache with required confirmation token (`WIPE_FAMILY_LIBRARY`) to prevent accidental deletions

## Implementation Details
- iPad detection uses both user agent parsing and `navigator.maxTouchPoints` to distinguish iPad from MacBook
- Camera hint visibility is controlled at three decision points: BarcodeDetector check, format support check, and getUserMedia failure
- Parent tools now use a card-style container with uppercase section header for better visual hierarchy
- All new parent functions require `_requestParentMode()` authentication before proceeding

https://claude.ai/code/session_01Rr96zHEtK7AhXbk2KhS4ZJ