### PR TITLE
Add parent tools for re-reviewing titles individually and in batch

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -76,7 +76,7 @@
         <h2>📚 Family library</h2>
         <p>Every book and movie we've looked up together.</p>
         <div id="bmc-parent-bar" style="margin-top:12px;">
-          <button class="bmc-btn bmc-btn-secondary" id="bmc-parent-unlock"
+          <button class="bmc-btn bmc-btn-secondary bmc-parent-unlock-btn" id="bmc-parent-unlock"
                   onclick="BMC.unlockParent()">
             🔒 Parents
           </button>
@@ -91,6 +91,9 @@
           <div style="display:flex; flex-wrap:wrap; gap:8px;">
             <button class="bmc-btn bmc-btn-secondary" onclick="BMC.reviewWithNewCriteria()">
               🔄 Re-review with new criteria (<span id="bmc-stale-count">?</span>)
+            </button>
+            <button class="bmc-btn bmc-btn-secondary" onclick="BMC.rereviewFamilyLibrary()">
+              🔄 Re-review ENTIRE library
             </button>
             <button class="bmc-btn bmc-btn-secondary" onclick="BMC.clearMySearches()">
               🧹 Clear my recent checks
@@ -121,6 +124,27 @@
       <div class="bmc-section-header">
         <h2>📖 My shelf</h2>
         <p>What you've read, watched, or want to.</p>
+        <div id="bmc-shelf-parent-bar" style="margin-top:12px;">
+          <button class="bmc-btn bmc-btn-secondary bmc-parent-unlock-btn"
+                  onclick="BMC.unlockParent()">
+            🔒 Parents
+          </button>
+        </div>
+        <div id="bmc-shelf-parent-tools" style="display:none; margin-top:12px;
+             padding:14px; background:var(--bg-card);
+             border:1.5px solid var(--border-subtle); border-radius:12px;">
+          <h4 style="font-size:0.75rem; letter-spacing:0.6px; text-transform:uppercase;
+                     color:var(--text-muted); font-weight:800; margin-bottom:10px;">
+            Parent tools
+          </h4>
+          <div style="display:flex; flex-wrap:wrap; gap:8px;">
+            <button class="bmc-btn bmc-btn-secondary" onclick="BMC.rereviewMyShelf()">
+              🔄 Re-review my shelf
+            </button>
+          </div>
+          <div id="bmc-shelf-reeval-status" style="margin-top:10px; font-size:0.85rem;
+               color:var(--text-muted);"></div>
+        </div>
       </div>
       <div id="bmc-history-list" class="bmc-list">
         <!-- Populated by JS -->

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -135,6 +135,7 @@ var BMC = (function() {
     } else if (name === 'history') {
       document.getElementById('screen-history').classList.add('active');
       _renderHistory();
+      _refreshStaleCount();
       _activateTabButtons('.bmc-tab-btn[onclick*="history"]');
     } else if (name === 'result') {
       document.getElementById('screen-result').classList.add('active');
@@ -721,6 +722,11 @@ var BMC = (function() {
         : ''
       ) +
 
+      (isParent
+        ? '<div class="bmc-action-row"><button class="bmc-btn bmc-btn-ghost" onclick="BMC.rereviewCurrent()">🔄 Re-review this ' + ((e.type === 'movie' || e.type === 'series') ? 'title' : 'book') + '</button></div>'
+        : ''
+      ) +
+
       unlockStrip +
       confBanner;
 
@@ -785,23 +791,103 @@ var BMC = (function() {
 
   // ── Re-review / stale-count (parent tools) ─────────────────────
   function _refreshStaleCount() {
-    var tools = document.getElementById('bmc-parent-tools');
+    var libTools = document.getElementById('bmc-parent-tools');
+    var shelfTools = document.getElementById('bmc-shelf-parent-tools');
     var countEl = document.getElementById('bmc-stale-count');
-    var unlockBtn = document.getElementById('bmc-parent-unlock');
-    if (!tools) return;
-    if (!_parentMode) {
-      tools.style.display = 'none';
-      if (unlockBtn) unlockBtn.textContent = '🔒 Parents';
-      return;
-    }
-    tools.style.display = 'block';
-    if (unlockBtn) unlockBtn.textContent = '🔓 Parent mode on';
+    var unlockBtns = document.querySelectorAll('.bmc-parent-unlock-btn');
+    var display = _parentMode ? 'block' : 'none';
+    if (libTools) libTools.style.display = display;
+    if (shelfTools) shelfTools.style.display = display;
+    unlockBtns.forEach(function(b) {
+      b.textContent = _parentMode ? '🔓 Parent mode on' : '🔒 Parents';
+    });
+    if (!_parentMode) return;
     _fetchJson(VPS + '/api/media/stale-count')
       .then(function(r) {
         if (countEl) countEl.textContent = r.stale + ' of ' + r.total;
       })
       .catch(function() {
         if (countEl) countEl.textContent = '?';
+      });
+  }
+
+  // Re-review the book currently on the result screen (parent only)
+  function rereviewCurrent() {
+    if (!_currentResult) return;
+    if (!_requestParentMode()) return;
+    var id = _currentResult.canonical_id;
+    var title = _currentResult.title;
+    if (!confirm('Re-evaluate "' + title + '" from scratch? This takes a few seconds.')) return;
+    _setStatus('Re-evaluating "' + title + '"…', 'working');
+    _fetchJson(VPS + '/api/media/reevaluate/' + encodeURIComponent(id), { method: 'POST' })
+      .then(function(fresh) {
+        _familyLibrary[id] = fresh;
+        _setStatus('');
+        showResult(fresh);
+      })
+      .catch(function(err) {
+        console.warn('[BMC] Re-review failed:', err);
+        _setStatus('Re-review failed: ' + (err && err.message ? err.message : 'unknown'), 'error');
+      });
+  }
+
+  // Re-review every title on this child's shelf + wishlist + recent checks
+  function rereviewMyShelf() {
+    if (!_requestParentMode()) return;
+    var statusEl = document.getElementById('bmc-shelf-reeval-status');
+    var data = loadData();
+    var ids = {};
+    (data.consumed || []).forEach(function(c) { ids[c.canonical_id] = true; });
+    (data.wishlist || []).forEach(function(id) { ids[id] = true; });
+    Object.keys(data.lookups || {}).forEach(function(id) { ids[id] = true; });
+    var idList = Object.keys(ids).filter(function(id) { return _familyLibrary[id]; });
+    if (!idList.length) {
+      if (statusEl) statusEl.textContent = 'Nothing on this shelf to re-review.';
+      return;
+    }
+    if (!confirm('Re-review all ' + idList.length + ' titles on this child\'s shelf? This can take several minutes.')) return;
+    if (statusEl) statusEl.textContent = 'Starting…';
+    _fetchJson(VPS + '/api/media/reevaluate-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: idList })
+    })
+      .then(function(r) {
+        if (statusEl) {
+          statusEl.textContent = 'Re-reviewing ' + r.count + ' titles in the background. '
+            + 'Refresh in a few minutes.';
+        }
+      })
+      .catch(function(err) {
+        if (statusEl) statusEl.textContent = 'Failed to start: ' + (err && err.message ? err.message : 'unknown');
+      });
+  }
+
+  // Re-review every title in the family library, not just stale ones
+  function rereviewFamilyLibrary() {
+    if (!_requestParentMode()) return;
+    var statusEl = document.getElementById('bmc-reeval-status');
+    var idList = Object.keys(_familyLibrary);
+    if (!idList.length) {
+      if (statusEl) statusEl.textContent = 'Family library is empty.';
+      return;
+    }
+    if (!confirm('Re-review ALL ' + idList.length + ' titles in the family library? '
+                 + 'This can take a long time and uses API quota.')) return;
+    if (statusEl) statusEl.textContent = 'Starting…';
+    _fetchJson(VPS + '/api/media/reevaluate-batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: idList })
+    })
+      .then(function(r) {
+        if (statusEl) {
+          statusEl.textContent = 'Re-reviewing ' + r.count + ' titles in the background. '
+            + 'Refresh in a few minutes.';
+        }
+      })
+      .catch(function(err) {
+        if (statusEl) statusEl.textContent = 'Failed to start: ' + (err && err.message ? err.message : 'unknown');
       });
   }
 
@@ -904,6 +990,9 @@ var BMC = (function() {
     addToWishlist: addToWishlist,
     unlockParent: unlockParent,
     reviewWithNewCriteria: reviewWithNewCriteria,
+    rereviewCurrent: rereviewCurrent,
+    rereviewMyShelf: rereviewMyShelf,
+    rereviewFamilyLibrary: rereviewFamilyLibrary,
     clearMySearches: clearMySearches,
     resetFamilyLibrary: resetFamilyLibrary
   };

--- a/vps/media.js
+++ b/vps/media.js
@@ -423,6 +423,46 @@ function init(app, dataDir) {
     }
   });
 
+  // ── POST /api/media/reevaluate-batch ── (re-eval a specific list of ids)
+  app.post('/api/media/reevaluate-batch', (req, res) => {
+    const { ids } = req.body || {};
+    if (!Array.isArray(ids) || !ids.length) {
+      return res.status(400).json({ error: 'Missing ids array' });
+    }
+    const cache = _loadCache();
+    const valid = ids.filter(id => cache[id]);
+    res.json({ started: true, count: valid.length, skipped: ids.length - valid.length });
+    // Fire-and-forget; process serially with delay to respect rate limit
+    (async () => {
+      for (const id of valid) {
+        try {
+          const entry = cache[id];
+          const metadata = {
+            title: entry.title,
+            author_or_director: entry.author_or_director,
+            year: entry.year,
+            type: entry.type,
+            synopsis: entry.summary || ''
+          };
+          const fresh = await _evaluate(metadata);
+          fresh.canonical_id = id;
+          fresh.cover_url = entry.cover_url;
+          fresh.evaluated_at = Date.now();
+          fresh.prompt_version = PROMPT_VERSION;
+          fresh.parent_reviewed = entry.parent_reviewed || false;
+          const current = _loadCache();
+          current[id] = fresh;
+          _saveCache(current);
+          console.log('[media/reevaluate-batch] Updated ' + entry.title);
+          await new Promise(r => setTimeout(r, 1500));
+        } catch (err) {
+          console.warn('[media/reevaluate-batch] Failed ' + id + ':', err.message);
+        }
+      }
+      console.log('[media/reevaluate-batch] Done ' + valid.length);
+    })();
+  });
+
   // ── POST /api/media/reevaluate-stale ── (walks cache, re-evals stale entries)
   app.post('/api/media/reevaluate-stale', async (req, res) => {
     const cache = _loadCache();


### PR DESCRIPTION
## Summary
This PR adds comprehensive re-review functionality for parents, allowing them to re-evaluate titles on demand at three levels: individual titles, a child's shelf, and the entire family library.

## Key Changes

- **Individual title re-review**: Added "Re-review this [title]" button on result screens that allows parents to re-evaluate a single title from scratch
- **Shelf re-review**: New parent tool on the "My shelf" section to re-review all titles on a child's shelf (consumed, wishlist, and recent checks)
- **Family library re-review**: New button to re-review the entire family library, not just stale entries
- **Batch API endpoint**: Implemented `POST /api/media/reevaluate-batch` in the backend to handle re-evaluation of multiple titles with rate-limiting (1.5s delay between requests)
- **Improved parent mode UI**: Refactored `_refreshStaleCount()` to support multiple parent tool sections (library and shelf) with a single unlock state
- **Parent unlock buttons**: Unified parent unlock button styling with `.bmc-parent-unlock-btn` class for consistency across sections
- **Stale count refresh**: Added call to `_refreshStaleCount()` when navigating to history tab to keep parent tools in sync

## Implementation Details

- Re-review operations are fire-and-forget on the backend; the API responds immediately while processing continues asynchronously
- Batch re-evaluation preserves existing metadata (cover URL, parent review status) while updating evaluation results
- User confirmations prevent accidental bulk operations
- Status messages provide feedback on batch operation progress
- All three re-review functions require parent mode authentication via `_requestParentMode()`

https://claude.ai/code/session_01KWwQFuHkniwg8XRTM2zJ31