### PR TITLE
Remove AI fallback from ISBN lookup due to hallucination risks

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -444,7 +444,11 @@ var BMC = (function() {
     })
       .then(function(res) {
         if (!res.candidates || !res.candidates.length) {
-          _setStatus('Could not find that ISBN.', 'error');
+          _setStatus(
+            'Couldn\'t find that ISBN. Try searching by title, ' +
+            'or tap "Photo of cover" to identify the book from its cover.',
+            'error'
+          );
           return;
         }
         _requestEvaluation(res.candidates[0]);

--- a/vps/media.js
+++ b/vps/media.js
@@ -360,11 +360,23 @@ async function _lookupIsbn(isbn) {
     const cand = await _openLibrarySearchByIsbn(v);
     if (cand) return [cand];
   }
-  // 5. AI fallback — knows Chilean, Spanish-language, and regional titles
-  //    that the public book databases don't index.
-  const aiCand = await _lookupFromAI({ isbn: clean });
-  if (aiCand) return [aiCand];
-
+  // No AI fallback for ISBN lookup.
+  //
+  // LLMs do not have a reliable ISBN→book index and will confidently
+  // pattern-match ISBN prefixes to famous titles. Example: ISBN
+  // 9789563495799 (Papelucho by Marcela Paz) was mis-identified as
+  // "El Principito" with high confidence because the model saw the
+  // Chilean ISBN prefix and guessed the most-famous Spanish-language
+  // children's book.
+  //
+  // In a kids' content safety app this is unsafe: the downstream
+  // evaluation would be run against the wrong book. When all public
+  // databases miss, we return no candidates and let the client
+  // suggest title search / cover photo / manual add instead.
+  //
+  // AI fallback is retained in _searchBooks (title queries) because
+  // there the user's input is semantically meaningful and a wrong
+  // result is visible to them.
   return [];
 }
 


### PR DESCRIPTION
## Summary
Removed the AI fallback mechanism from ISBN-based book lookups to prevent LLM hallucinations that could cause incorrect book identification in content safety evaluations.

## Key Changes
- **Removed AI fallback from `_lookupIsbn()`**: Deleted the `_lookupFromAI()` call that served as a fallback when public book databases couldn't find an ISBN match
- **Added detailed explanation**: Included comprehensive comments explaining why AI fallback is unsafe for ISBN lookups, with a concrete example of misidentification (Chilean ISBN 9789563495799 being confused with "El Principito")
- **Updated user-facing error message**: Enhanced the "Could not find that ISBN" error message in `book-movie-check.js` to guide users toward alternative search methods (title search, cover photo identification, or manual entry)
- **Retained AI fallback for title searches**: Clarified that AI fallback remains in `_searchBooks()` for title-based queries, where user input is semantically meaningful and incorrect results are visible to the user

## Implementation Details
The change prioritizes safety in a children's content evaluation context: when ISBN lookup fails across all public databases, the system now returns no candidates rather than risk running content evaluation against the wrong book. Users are guided to more reliable identification methods instead.

https://claude.ai/code/session_01CYH9svuf2k1G8LtGpGqPLT