### PR TITLE
Handle low-confidence verdicts differently in kid vs parent mode

### DIFF
--- a/css/book-movie-check.css
+++ b/css/book-movie-check.css
@@ -235,6 +235,7 @@ body {
 .bmc-list-item.verdict-approved { border-left-color: var(--bmc-approved); }
 .bmc-list-item.verdict-caution { border-left-color: var(--bmc-caution); }
 .bmc-list-item.verdict-not_recommended { border-left-color: var(--bmc-notrec); }
+.bmc-list-item.verdict-lowconf { border-left-color: var(--bmc-accent); }
 
 .bmc-list-cover {
   width: 46px; height: 64px;
@@ -272,6 +273,7 @@ body {
 .bmc-list-verdict.verdict-approved { background: rgba(16,185,129,0.15); color: var(--bmc-approved); }
 .bmc-list-verdict.verdict-caution { background: rgba(245,158,11,0.15); color: var(--bmc-caution); }
 .bmc-list-verdict.verdict-not_recommended { background: rgba(239,68,68,0.15); color: var(--bmc-notrec); }
+.bmc-list-verdict.verdict-lowconf { background: rgba(96,165,250,0.15); color: var(--bmc-accent); }
 
 .bmc-empty {
   text-align: center;

--- a/css/book-movie-check.css
+++ b/css/book-movie-check.css
@@ -366,6 +366,11 @@ body {
   border-color: var(--bmc-notrec);
 }
 .bmc-verdict-banner.verdict-not_recommended h3 { color: var(--bmc-notrec); }
+.bmc-verdict-banner.verdict-lowconf {
+  background: rgba(96,165,250,0.10);
+  border-color: rgba(96,165,250,0.55);
+}
+.bmc-verdict-banner.verdict-lowconf h3 { color: var(--bmc-accent); }
 
 /* Age pill + gate banner */
 .bmc-age-row {
@@ -530,13 +535,16 @@ body {
   font-size: 0.85rem;
 }
 
-/* Low-confidence banner */
+/* Low-confidence notice (parent mode, below the verdict banner) */
 .bmc-lowconf {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  font-weight: 600;
+  background: rgba(96,165,250,0.10);
+  border: 1.5px solid rgba(96,165,250,0.45);
+  color: var(--bmc-accent);
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.88rem;
   text-align: center;
-  margin-top: 4px;
 }
 
 /* Scan modal */

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -270,6 +270,13 @@ var BMC = (function() {
       }
     }
 
+    // Low-confidence: neutralize the colored border/label in kid mode so
+    // an unreliable verdict doesn't broadcast as a real concern.
+    if (!_parentMode && item.confidence === 'low') {
+      displayVerdict = 'lowconf';
+      label = '🤔 Not sure';
+    }
+
     return '<button type="button" class="bmc-list-item verdict-' + escAttr(displayVerdict) + '" onclick="BMC.selectCandidate(\'' + escAttr(item.canonical_id) + '\')">' +
       '<div class="bmc-list-cover" ' + cover + '>' + (coverUrl ? '' : emoji) + '</div>' +
       '<div class="bmc-list-body">' +

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -580,10 +580,15 @@ var BMC = (function() {
     var isSafe = e.verdict === 'approved';
     var isCaution = e.verdict === 'caution';
     var isBlocked = e.verdict === 'not_recommended';
+    var isLowConf = e.confidence === 'low';
 
+    // On low confidence in kid mode, the verdict itself is unreliable:
+    // hide content details so we don't present guesses as findings.
+    var kidHideDetails = isLowConf && !isParent;
     var showSummary = isParent || isSafe || isCaution;
-    var showFlags = isParent || isSafe;
-    var showConcerns = isParent || isSafe;
+    var showFlags = (isParent || isSafe) && !kidHideDetails;
+    var showConcerns = (isParent || isSafe) && !kidHideDetails;
+    var showAgeInfo = !kidHideDetails;
     var showParentNotes = isParent;
     var showActions = isParent || !isBlocked;
 
@@ -625,8 +630,19 @@ var BMC = (function() {
       ? 'verdict-caution'  // reuse the amber caution styling for maturity
       : e.verdict;
 
-    var confBanner = (e.confidence === 'low' && (isParent || !isBlocked))
-      ? '<div class="bmc-lowconf">ℹ️ This check is low-confidence — please verify with a parent.</div>'
+    // Kid mode + low confidence: replace verdict entirely with a neutral
+    // "not sure" banner so a hedged guess doesn't read as a real concern.
+    if (!isParent && isLowConf) {
+      verdictEmoji = '🤔';
+      verdictTitle = 'Not sure yet';
+      verdictMessage = 'I couldn\'t check this one well. Please ask Mom or Dad before reading or watching it.';
+      bannerVerdictClass = 'lowconf';
+    }
+
+    // Parent mode still gets the verdict banner plus a prominent low-conf
+    // notice; kid mode doesn't need it — the banner above is the notice.
+    var confBanner = (isLowConf && isParent)
+      ? '<div class="bmc-lowconf">ℹ️ This check is low-confidence — double-check before sharing with the kids.</div>'
       : '';
 
     var data = loadData();
@@ -708,12 +724,17 @@ var BMC = (function() {
         '<div><h3>' + verdictTitle + '</h3><p>' + _escHtmlLocal(verdictMessage) + '</p></div>' +
       '</div>' +
 
-      '<div class="bmc-age-row">' +
-        '<span class="bmc-age-pill">Ages ' + (e.minimum_age || '?') + '+' + (e.ideal_age_range ? ' · ideal ' + _escHtmlLocal(e.ideal_age_range) : '') + '</span>' +
-        (isParent && e.parent_reviewed ? '<span class="bmc-reviewed-pill">✓ Parent reviewed</span>' : '') +
-      '</div>' +
+      confBanner +
 
-      (tooYoung && !isParent
+      (showAgeInfo
+        ? ('<div class="bmc-age-row">' +
+            '<span class="bmc-age-pill">Ages ' + (e.minimum_age || '?') + '+' + (e.ideal_age_range ? ' · ideal ' + _escHtmlLocal(e.ideal_age_range) : '') + '</span>' +
+            (isParent && e.parent_reviewed ? '<span class="bmc-reviewed-pill">✓ Parent reviewed</span>' : '') +
+          '</div>')
+        : ''
+      ) +
+
+      (tooYoung && !isParent && showAgeInfo
         ? '<div class="bmc-age-gate">This is recommended for age ' + e.minimum_age + '+. Ask Mom or Dad first.</div>'
         : ''
       ) +
@@ -754,8 +775,7 @@ var BMC = (function() {
         : ''
       ) +
 
-      unlockStrip +
-      confBanner;
+      unlockStrip;
 
     wrap.innerHTML = html;
   }


### PR DESCRIPTION
## Summary
This PR improves the handling of low-confidence content verdicts by presenting them differently to children versus parents. In kid mode, low-confidence verdicts are neutralized to avoid presenting uncertain guesses as definitive concerns. In parent mode, they're clearly flagged as unreliable.

## Key Changes

- **Kid mode low-confidence handling**: When confidence is low and the user is not a parent, the verdict is replaced with a neutral "🤔 Not sure" message that asks the child to check with a parent, rather than displaying the potentially unreliable verdict details
- **Content detail visibility**: Added `kidHideDetails` flag to conditionally hide flags, concerns, and age information when in kid mode with low-confidence verdicts
- **Verdict banner styling**: Low-confidence verdicts now use a distinct neutral blue styling (`verdict-lowconf`) instead of inheriting the underlying verdict's color scheme
- **Parent mode notices**: Parent mode still displays the original verdict with a prominent low-confidence banner below it, changed from the previous inline notice
- **List item styling**: Added CSS styling for low-confidence list items with neutral blue accent color
- **Banner repositioning**: Moved the low-confidence notice to appear after the verdict banner in parent mode, making it more prominent

## Implementation Details

- The `kidHideDetails` variable gates visibility of potentially misleading content details (flags, concerns, age info) when confidence is low in kid mode
- Low-confidence verdicts in kid mode completely replace the verdict message with "I couldn't check this one well. Please ask Mom or Dad before reading or watching it."
- Parent mode preserves the original verdict information but adds a clear notice that the check is low-confidence
- CSS styling uses a consistent blue accent color (`var(--bmc-accent)`) for all low-confidence UI elements

https://claude.ai/code/session_01Uettkrvpwqi3KJPmafEe25