### PR TITLE
Add trailer embeds, library filtering, and per-item removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ test-results/
 playwright-report/
 blob-report/
 playwright/.cache/
+
+.env
+.env.local
+vps/.env

--- a/README.md
+++ b/README.md
@@ -100,6 +100,54 @@ Para la mejor experiencia en dispositivos móviles:
    - **iOS (Safari):** Toca el ícono de compartir (Share) y elige "Agregar a inicio" (Add to Home Screen).
    - **Android (Chrome):** Toca el menú de tres puntos y elige "Agregar a la pantalla principal" (Add to Home Screen).
 
+### Opción 3: Ejecutar el Servidor VPS (Run the Sync / Media Server)
+
+The static apps work standalone, but **Book & Movie Check** and cross-device sync require the small Express server in `vps/`. It handles:
+- CloudSync (per-kid app data + family profiles)
+- Book & Movie Check (title lookup, AI evaluation, trailer fetch)
+
+**1. Install deps**
+
+```bash
+cd vps
+npm install
+```
+
+**2. Create `vps/.env`**
+
+`vps/.env` is loaded automatically at startup (via `dotenv`) and is git-ignored. Copy the template below into `vps/.env` and fill in whichever keys you need:
+
+```bash
+# Which AI provider evaluates books/movies for family-values fit.
+# Either "gemini" (default, free tier works) or "grok" (paid).
+AI_PROVIDER=gemini
+
+# Required when AI_PROVIDER=gemini
+# Get one at https://aistudio.google.com/ → "Get API key"
+GEMINI_API_KEY=
+
+# Required when AI_PROVIDER=grok
+# Get one at https://console.x.ai/ → API Keys
+GROK_API_KEY=
+
+# Required for movie search + trailer embeds in Book & Movie Check.
+# Without it, movie lookups silently return no results.
+# Get one at https://www.themoviedb.org/ → Settings → API → request a
+# developer key (free, instant approval). Copy the "API Key (v3 auth)"
+# string — NOT the read-access token.
+TMDB_API_KEY=
+```
+
+**Minimum to run Book & Movie Check end-to-end:** `GEMINI_API_KEY` (for evaluations) + `TMDB_API_KEY` (for movie search and trailers). Books work without TMDB; movies don't.
+
+**3. Start the server**
+
+```bash
+npm start            # listens on :3333
+```
+
+The client talks to it via the `VPS` constant at the top of `js/book-movie-check.js` and `js/sync.js`. Swap that to `http://localhost:3333` (or your own tunnel/domain) to point the static apps at a non-default backend.
+
 ## 📂 Estructura del Proyecto (Project Structure)
 
 - `index.html`: The main app hub and profile selector.

--- a/css/book-movie-check.css
+++ b/css/book-movie-check.css
@@ -200,6 +200,24 @@ body {
 .bmc-filter-row {
   display: flex; gap: 8px; margin-bottom: 14px; flex-wrap: wrap;
 }
+.bmc-filter-chip {
+  background: var(--bg-card);
+  border: 1.5px solid var(--border-subtle);
+  color: var(--text-muted);
+  border-radius: 99px;
+  padding: 6px 14px;
+  font-weight: 800;
+  font-size: 0.8rem;
+  font-family: inherit;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.bmc-filter-chip:hover { background: rgba(255,255,255,0.06); color: var(--text-primary); }
+.bmc-filter-chip.active {
+  color: var(--text-primary);
+  border-color: var(--bmc-accent);
+  background: rgba(96,165,250,0.12);
+}
 
 /* Lists — shared */
 .bmc-list {
@@ -218,7 +236,15 @@ body {
   margin: 16px 0 4px;
 }
 
+/* A row wraps the clickable card + the parent-mode remove button
+   so the outer <button> stays a real button and stays keyboard-accessible. */
+.bmc-list-row {
+  position: relative;
+  display: block;
+}
+
 .bmc-list-item {
+  position: relative;
   display: flex;
   gap: 12px;
   align-items: flex-start;
@@ -230,8 +256,41 @@ body {
   cursor: pointer;
   transition: all 0.2s;
   text-align: left;
+  width: 100%;
+  color: inherit;
+  font-family: inherit;
 }
 .bmc-list-item:hover { transform: translateX(2px); border-color: var(--bmc-accent); }
+
+/* Parent-only per-item remove button (✕) overlaid on the top-right
+   corner of the card. */
+.bmc-list-remove {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 1.5px solid rgba(239,68,68,0.45);
+  background: rgba(11,11,26,0.85);
+  color: #F87171;
+  font-size: 0.85rem;
+  font-weight: 800;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-family: inherit;
+  transition: all 0.15s;
+  z-index: 2;
+}
+.bmc-list-remove:hover {
+  background: rgba(239,68,68,0.2);
+  color: #fff;
+  transform: scale(1.08);
+}
 .bmc-list-item.verdict-approved { border-left-color: var(--bmc-approved); }
 .bmc-list-item.verdict-caution { border-left-color: var(--bmc-caution); }
 .bmc-list-item.verdict-not_recommended { border-left-color: var(--bmc-notrec); }
@@ -535,6 +594,45 @@ body {
   color: var(--text-muted);
   font-weight: 600;
   font-size: 0.85rem;
+}
+
+/* Movie trailer block on the result screen */
+.bmc-trailer {
+  background: var(--bg-card);
+  border: 1.5px solid var(--border-subtle);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+}
+.bmc-trailer h4 {
+  font-size: 0.75rem;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 800;
+  margin-bottom: 10px;
+}
+.bmc-trailer-embed {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+}
+.bmc-trailer-embed iframe {
+  position: absolute;
+  top: 0; left: 0;
+  width: 100%; height: 100%;
+  border: 0;
+}
+.bmc-trailer-locked {
+  text-align: center;
+}
+.bmc-trailer-locked p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 12px;
 }
 
 /* Low-confidence notice (parent mode, below the verdict banner) */

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -18,6 +18,7 @@ var BMC = (function() {
   var _scanActive = false;
   var _scanStream = null;
   var _parentMode = false;  // session-only, resets on page reload
+  var _libraryTypeFilter = 'all';  // 'all' | 'book' | 'movie'
 
   // Environment detection for iPad-in-WKWebView-wrapper cases
   var _cameraAvailable = null;  // null = unknown; true/false after probe
@@ -50,6 +51,7 @@ var BMC = (function() {
     if (_requestParentMode()) {
       if (_currentResult) showResult(_currentResult);
       _refreshStaleCount();
+      _rerenderActiveScreen();
     }
   }
 
@@ -61,9 +63,10 @@ var BMC = (function() {
   function _defaultData() {
     return {
       totalStars: 0,
-      lookups: {},     // canonical_id -> { ts, query, verdict }
-      consumed: [],    // [{ canonical_id, ts, rating }]
-      wishlist: []     // [canonical_id]
+      lookups: {},           // canonical_id -> { ts, query, verdict }
+      consumed: [],          // [{ canonical_id, ts, rating }]
+      wishlist: [],          // [canonical_id]
+      hiddenSuggestions: {}  // canonical_id -> true (suppressed by parent)
     };
   }
 
@@ -78,6 +81,7 @@ var BMC = (function() {
       if (!d.lookups) d.lookups = {};
       if (!d.consumed) d.consumed = [];
       if (!d.wishlist) d.wishlist = [];
+      if (!d.hiddenSuggestions) d.hiddenSuggestions = {};
       if (typeof d.totalStars !== 'number') d.totalStars = 0;
       return d;
     } catch (e) { return _defaultData(); }
@@ -161,7 +165,7 @@ var BMC = (function() {
       html += recentIds.map(function(id) {
         var lib = _familyLibrary[id];
         if (!lib) return '';
-        return _listItemHtml(lib);
+        return _listItemHtml(lib, 'recent');
       }).join('');
       recentEl.innerHTML = html;
     } else if (recentEl) {
@@ -171,11 +175,13 @@ var BMC = (function() {
     // Suggested: approved items from the family library this kid hasn't looked up yet
     var kidLookupIds = {};
     Object.keys(data.lookups || {}).forEach(function(id) { kidLookupIds[id] = true; });
+    var hidden = data.hiddenSuggestions || {};
     var suggested = Object.keys(_familyLibrary)
       .map(function(id) { return _familyLibrary[id]; })
       .filter(function(item) {
         if (!item) return false;
         if (kidLookupIds[item.canonical_id]) return false;
+        if (hidden[item.canonical_id]) return false;
         if (item.verdict === 'not_recommended') return false;
         return true;
       })
@@ -183,7 +189,7 @@ var BMC = (function() {
 
     if (suggested.length && suggestedEl) {
       var html2 = '<div class="bmc-list-group-title">Suggested for you</div>';
-      html2 += suggested.map(_listItemHtml).join('');
+      html2 += suggested.map(function(it) { return _listItemHtml(it, 'suggested'); }).join('');
       suggestedEl.innerHTML = html2;
     } else if (suggestedEl) {
       suggestedEl.innerHTML = '';
@@ -191,7 +197,36 @@ var BMC = (function() {
   }
 
   // ── Library screen (family-wide) ───────────────────────────────
+  function _renderLibraryFilter() {
+    var filterEl = document.getElementById('bmc-library-filter');
+    if (!filterEl) return;
+    var opts = [
+      { key: 'all', label: 'All' },
+      { key: 'book', label: '📕 Books' },
+      { key: 'movie', label: '🎬 Movies' }
+    ];
+    filterEl.innerHTML = opts.map(function(o) {
+      var active = _libraryTypeFilter === o.key ? ' active' : '';
+      return '<button type="button" class="bmc-filter-chip' + active +
+             '" onclick="BMC.setLibraryFilter(\'' + o.key + '\')">' + o.label + '</button>';
+    }).join('');
+  }
+
+  function setLibraryFilter(kind) {
+    _libraryTypeFilter = kind;
+    _renderLibraryFilter();
+    _renderLibrary();
+  }
+
+  function _matchesTypeFilter(item) {
+    if (_libraryTypeFilter === 'all') return true;
+    var t = item.type || 'book';
+    if (_libraryTypeFilter === 'movie') return t === 'movie' || t === 'series';
+    return t === 'book';
+  }
+
   function _renderLibrary() {
+    _renderLibraryFilter();
     var container = document.getElementById('bmc-library-list');
     if (!container) return;
     var items = Object.keys(_familyLibrary)
@@ -199,6 +234,7 @@ var BMC = (function() {
       .filter(function(item) {
         if (!item) return false;
         if (!_parentMode && item.verdict === 'not_recommended') return false;
+        if (!_matchesTypeFilter(item)) return false;
         return true;
       })
       .sort(function(a, b) { return (b.evaluated_at || 0) - (a.evaluated_at || 0); });
@@ -206,7 +242,7 @@ var BMC = (function() {
       container.innerHTML = '<div class="bmc-empty">No titles checked yet. Search for a book or movie to get started!</div>';
       return;
     }
-    container.innerHTML = items.map(_listItemHtml).join('');
+    container.innerHTML = items.map(function(it) { return _listItemHtml(it, 'library'); }).join('');
   }
 
   // ── History screen (per kid) ───────────────────────────────────
@@ -221,7 +257,7 @@ var BMC = (function() {
       html += '<div class="bmc-list-group-title">Reading / watched</div>';
       html += consumed.map(function(c) {
         var lib = _familyLibrary[c.canonical_id];
-        return lib ? _listItemHtml(lib) : '';
+        return lib ? _listItemHtml(lib, 'consumed') : '';
       }).join('');
     }
     if ((data.wishlist || []).length) {
@@ -230,7 +266,7 @@ var BMC = (function() {
         var lib = _familyLibrary[id];
         if (!lib) return '';
         if (!_parentMode && lib.verdict === 'not_recommended') return '';
-        return _listItemHtml(lib);
+        return _listItemHtml(lib, 'wishlist');
       }).join('');
     }
     if (!html) {
@@ -244,7 +280,7 @@ var BMC = (function() {
     return url ? String(url).replace(/^http:\/\//i, 'https://') : '';
   }
 
-  function _listItemHtml(item) {
+  function _listItemHtml(item, context) {
     if (!item) return '';
     var coverUrl = _httpsCover(item.cover_url);
     var cover = coverUrl
@@ -277,14 +313,28 @@ var BMC = (function() {
       label = '🤔 Not sure';
     }
 
-    return '<button type="button" class="bmc-list-item verdict-' + escAttr(displayVerdict) + '" onclick="BMC.selectCandidate(\'' + escAttr(item.canonical_id) + '\')">' +
-      '<div class="bmc-list-cover" ' + cover + '>' + (coverUrl ? '' : emoji) + '</div>' +
-      '<div class="bmc-list-body">' +
-      '  <div class="bmc-list-title">' + escHtml(item.title) + '</div>' +
-      '  <div class="bmc-list-meta">' + escHtml(item.author_or_director || '') + (item.year ? ' · ' + item.year : '') + ' · ages ' + (item.minimum_age || '?') + '+</div>' +
-      '</div>' +
-      '<div class="bmc-list-verdict verdict-' + escAttr(displayVerdict) + '">' + label + '</div>' +
-    '</button>';
+    // Parent-only per-item remove. Rendered outside the clickable card
+    // (wrapped in .bmc-list-row) so the outer element stays a real <button>.
+    var removeBtn = '';
+    if (_parentMode && context) {
+      removeBtn = '<button type="button" class="bmc-list-remove" ' +
+        'aria-label="Remove" title="Remove" ' +
+        'onclick="BMC.removeItem(\'' + escAttr(context) +
+        '\', \'' + escAttr(item.canonical_id) + '\')">✕</button>';
+    }
+
+    return '<div class="bmc-list-row">' +
+      '<button type="button" class="bmc-list-item verdict-' + escAttr(displayVerdict) + '" ' +
+        'onclick="BMC.selectCandidate(\'' + escAttr(item.canonical_id) + '\')">' +
+        '<div class="bmc-list-cover" ' + cover + '>' + (coverUrl ? '' : emoji) + '</div>' +
+        '<div class="bmc-list-body">' +
+        '  <div class="bmc-list-title">' + escHtml(item.title) + '</div>' +
+        '  <div class="bmc-list-meta">' + escHtml(item.author_or_director || '') + (item.year ? ' · ' + item.year : '') + ' · ages ' + (item.minimum_age || '?') + '+</div>' +
+        '</div>' +
+        '<div class="bmc-list-verdict verdict-' + escAttr(displayVerdict) + '">' + label + '</div>' +
+      '</button>' +
+      removeBtn +
+    '</div>';
   }
 
   // ── Safe escape helpers ────────────────────────────────────────
@@ -569,6 +619,45 @@ var BMC = (function() {
     saveData(data);
   }
 
+  // Trailer block for the result screen. Only renders for movies/series
+  // with a YouTube embed URL. Visible inline when the title is approved
+  // or the session is in parent mode; otherwise a parent-only unlock
+  // button is shown in its place.
+  function _trailerBlockHtml(e, isParent, isSafe, isBlocked) {
+    var isVideo = (e.type === 'movie' || e.type === 'series');
+    if (!isVideo || !e.trailer_url) return '';
+    var showInline = isParent || isSafe;
+    if (showInline) {
+      return '<div class="bmc-trailer">' +
+        '<h4>🎬 Trailer</h4>' +
+        '<div class="bmc-trailer-embed">' +
+          '<iframe src="' + escAttr(e.trailer_url) + '" ' +
+            'title="Trailer" allowfullscreen ' +
+            'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" ' +
+            'referrerpolicy="strict-origin-when-cross-origin"></iframe>' +
+        '</div>' +
+      '</div>';
+    }
+    // Kid mode, not approved — hide the trailer behind a parent unlock.
+    var msg = isBlocked
+      ? 'This trailer is hidden because this title isn\'t a good fit for our family.'
+      : 'This trailer is for parents to preview first.';
+    return '<div class="bmc-trailer bmc-trailer-locked">' +
+      '<h4>🎬 Trailer</h4>' +
+      '<p>' + msg + '</p>' +
+      '<button class="bmc-btn bmc-btn-ghost" onclick="BMC.unlockTrailer()">🔒 Show trailer (parent PIN)</button>' +
+    '</div>';
+  }
+
+  // Triggered by the "Show trailer" button; re-renders the current result
+  // in parent mode, which inlines the iframe.
+  function unlockTrailer() {
+    if (_requestParentMode() && _currentResult) {
+      showResult(_currentResult);
+      _refreshStaleCount();
+    }
+  }
+
   // ── Result screen render ───────────────────────────────────────
   function showResult(e) {
     _currentResult = e;
@@ -750,6 +839,8 @@ var BMC = (function() {
         ? '<div class="bmc-summary"><h4>What it\'s about</h4>' + _escHtmlLocal(e.summary) + '</div>'
         : ''
       ) +
+
+      _trailerBlockHtml(e, isParent, isSafe, isBlocked) +
 
       ((chipHtml || posHtml)
         ? '<div class="bmc-chips">' + chipHtml + posHtml + '</div>'
@@ -945,6 +1036,81 @@ var BMC = (function() {
       });
   }
 
+  // ── Per-item remove (parent only) ─────────────────────────────
+  // Scope depends on the list the button was pressed from:
+  //   'recent'    → this kid's lookups[]
+  //   'suggested' → this kid's hiddenSuggestions[] (doesn't wipe family entry)
+  //   'consumed'  → this kid's consumed[]
+  //   'wishlist'  → this kid's wishlist[]
+  //   'library'   → family library (VPS DELETE + local cache)
+  function removeItem(context, canonicalId) {
+    if (!_requestParentMode()) return;
+    var item = _familyLibrary[canonicalId];
+    var title = (item && item.title) || 'this title';
+    var data = loadData();
+    var changed = false;
+
+    if (context === 'recent') {
+      if (data.lookups && data.lookups[canonicalId]) {
+        delete data.lookups[canonicalId];
+        changed = true;
+      }
+    } else if (context === 'suggested') {
+      data.hiddenSuggestions = data.hiddenSuggestions || {};
+      if (!data.hiddenSuggestions[canonicalId]) {
+        data.hiddenSuggestions[canonicalId] = true;
+        changed = true;
+      }
+    } else if (context === 'consumed') {
+      var beforeC = (data.consumed || []).length;
+      data.consumed = (data.consumed || []).filter(function(c) {
+        return c.canonical_id !== canonicalId;
+      });
+      changed = beforeC !== data.consumed.length;
+    } else if (context === 'wishlist') {
+      var beforeW = (data.wishlist || []).length;
+      data.wishlist = (data.wishlist || []).filter(function(id) {
+        return id !== canonicalId;
+      });
+      changed = beforeW !== data.wishlist.length;
+    } else if (context === 'library') {
+      if (!confirm('Remove "' + title + '" from the family library for everyone?')) return;
+      _fetchJson(VPS + '/api/media/library/' + encodeURIComponent(canonicalId),
+                 { method: 'DELETE' })
+        .then(function() {
+          delete _familyLibrary[canonicalId];
+          // Also scrub local references so kids don't see a dangling entry
+          var d = loadData();
+          if (d.lookups) delete d.lookups[canonicalId];
+          d.consumed = (d.consumed || []).filter(function(c) {
+            return c.canonical_id !== canonicalId;
+          });
+          d.wishlist = (d.wishlist || []).filter(function(id) { return id !== canonicalId; });
+          saveData(d);
+          _rerenderActiveScreen();
+        })
+        .catch(function(err) {
+          alert('Could not remove: ' + (err && err.message ? err.message : 'unknown error'));
+        });
+      return;
+    } else {
+      return;
+    }
+
+    if (changed) saveData(data);
+    _rerenderActiveScreen();
+  }
+
+  function _rerenderActiveScreen() {
+    if (document.getElementById('screen-home').classList.contains('active')) {
+      _renderHome();
+    } else if (document.getElementById('screen-library').classList.contains('active')) {
+      _renderLibrary();
+    } else if (document.getElementById('screen-history').classList.contains('active')) {
+      _renderHistory();
+    }
+  }
+
   // Clear this kid's lookups (recent checks list on home)
   function clearMySearches() {
     if (!_requestParentMode()) return;
@@ -1048,7 +1214,10 @@ var BMC = (function() {
     rereviewMyShelf: rereviewMyShelf,
     rereviewFamilyLibrary: rereviewFamilyLibrary,
     clearMySearches: clearMySearches,
-    resetFamilyLibrary: resetFamilyLibrary
+    resetFamilyLibrary: resetFamilyLibrary,
+    removeItem: removeItem,
+    setLibraryFilter: setLibraryFilter,
+    unlockTrailer: unlockTrailer
   };
 })();
 

--- a/vps/media.js
+++ b/vps/media.js
@@ -414,6 +414,7 @@ async function _searchMovies(query) {
     return (j.results || []).slice(0, 3).map(m => ({
       canonical_id: _canonicalTmdb(m.id),
       type: 'movie',
+      tmdb_id: m.id,
       title: m.title,
       author_or_director: '',  // TMDb requires a second call for director; synopsis is enough for eval
       year: m.release_date ? parseInt(m.release_date.slice(0, 4)) : null,
@@ -421,6 +422,26 @@ async function _searchMovies(query) {
       synopsis: m.overview || ''
     }));
   } catch (e) { return []; }
+}
+
+// Look up the first official YouTube trailer for a TMDB movie id.
+// Returns a YouTube embed URL (https://www.youtube.com/embed/<key>) or null.
+async function _trailerForTmdbId(tmdbId) {
+  if (!tmdbId || !process.env.TMDB_API_KEY) return null;
+  try {
+    const url = 'https://api.themoviedb.org/3/movie/' + tmdbId + '/videos?api_key=' + process.env.TMDB_API_KEY;
+    const r = await fetch(url);
+    if (!r.ok) return null;
+    const j = await r.json();
+    const videos = (j.results || []).filter(v =>
+      v.site === 'YouTube' && (v.type === 'Trailer' || v.type === 'Teaser'));
+    // Prefer official trailers, then anything
+    const pick = videos.find(v => v.official && v.type === 'Trailer')
+              || videos.find(v => v.type === 'Trailer')
+              || videos.find(v => v.official)
+              || videos[0];
+    return pick ? 'https://www.youtube.com/embed/' + pick.key : null;
+  } catch (e) { return null; }
 }
 
 // ── AI providers ─────────────────────────────────────────────────
@@ -625,6 +646,15 @@ function init(app, dataDir) {
       if (!evaluation.author_or_director) evaluation.author_or_director = metadata.author_or_director;
       if (!evaluation.year && metadata.year) evaluation.year = metadata.year;
 
+      // For movies/series, attach a YouTube trailer embed URL when available.
+      // Books never get trailers — the summary is the preview.
+      if ((evaluation.type === 'movie' || evaluation.type === 'series') &&
+          (metadata.tmdb_id || String(canonical_id).startsWith('tmdb:'))) {
+        const tmdbId = metadata.tmdb_id
+                    || parseInt(String(canonical_id).replace(/^tmdb:/, ''), 10);
+        evaluation.trailer_url = await _trailerForTmdbId(tmdbId);
+      }
+
       cache[canonical_id] = evaluation;
       _saveCache(cache);
       res.json(evaluation);
@@ -682,6 +712,7 @@ function init(app, dataDir) {
       fresh.evaluated_at = Date.now();
       fresh.prompt_version = PROMPT_VERSION;
       fresh.parent_reviewed = entry.parent_reviewed || false;
+      if (entry.trailer_url) fresh.trailer_url = entry.trailer_url;
       cache[entry.canonical_id] = fresh;
       _saveCache(cache);
       res.json(fresh);
@@ -779,6 +810,25 @@ function init(app, dataDir) {
     const stale = Object.keys(cache).filter(id =>
       cache[id].prompt_version !== PROMPT_VERSION).length;
     res.json({ total: total, stale: stale, prompt_version: PROMPT_VERSION });
+  });
+
+  // ── DELETE /api/media/library/:id ──
+  // Removes a single title from the family media cache. Parent-gated on
+  // the client via PIN; the server enforces only that the id exists.
+  app.delete('/api/media/library/:id', (req, res) => {
+    try {
+      const cache = _loadCache();
+      const id = req.params.id;
+      if (!cache[id]) return res.status(404).json({ error: 'Not cached' });
+      const title = cache[id].title;
+      delete cache[id];
+      _saveCache(cache);
+      console.log('[media/library DELETE one] Removed ' + id + ' (' + title + ')');
+      res.json({ ok: true, id: id });
+    } catch (err) {
+      console.error('[media/library DELETE one]', err.message);
+      res.status(500).json({ error: err.message });
+    }
   });
 
   // ── DELETE /api/media/library ──

--- a/vps/server.js
+++ b/vps/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config({ path: require('path').join(__dirname, '.env') });
+
 const express = require('express');
 const cors = require('cors');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
This PR adds three major features to Book & Movie Check: inline YouTube trailer embeds for movies/series, a type-based filter for the family library view, and per-item removal controls for parents. It also introduces a new `hiddenSuggestions` data field to track parent-suppressed suggestions and refactors list rendering to support context-aware actions.

## Key Changes

**Trailer Embeds**
- Added `_trailerBlockHtml()` to render YouTube trailers inline on the result screen for approved titles or in parent mode
- Implemented `unlockTrailer()` to allow kids to request parent PIN to preview trailers for unapproved titles
- Added `_trailerForTmdbId()` server-side function to fetch official YouTube trailer URLs from TMDb API
- Trailers are fetched during evaluation and cached in the `evaluation.trailer_url` field

**Library Filtering**
- Added `_libraryTypeFilter` state variable ('all' | 'book' | 'movie')
- Implemented `_renderLibraryFilter()` to render filter chip buttons and `setLibraryFilter()` to update the active filter
- Added `_matchesTypeFilter()` to classify items by type (movies/series vs. books)
- Library list now filters and re-renders based on selected type

**Per-Item Removal (Parent Mode)**
- Implemented `removeItem(context, canonicalId)` to remove items from different scopes:
  - `recent`: clears from kid's lookups
  - `suggested`: adds to `hiddenSuggestions` (suppresses without deleting family entry)
  - `consumed`: removes from kid's watched/read list
  - `wishlist`: removes from kid's wishlist
  - `library`: DELETE request to server + local cache cleanup
- Added `_rerenderActiveScreen()` helper to refresh the current view after changes
- Refactored `_listItemHtml()` to accept a `context` parameter and render a parent-only remove button (✕) overlaid on each card
- Wrapped list items in `.bmc-list-row` container to keep the outer button semantically valid

**Data Model**
- Added `hiddenSuggestions: {}` field to default data structure to track parent-suppressed suggestions per kid
- Added migration logic in `_loadData()` to initialize the field for existing users

**Server API**
- Added `DELETE /api/media/library/:id` endpoint to remove a single title from the family cache
- Integrated `.env` loading via `dotenv` for API keys (GEMINI_API_KEY, GROK_API_KEY, TMDB_API_KEY)
- Updated movie search to include `tmdb_id` in results for trailer lookup
- Trailer URL is preserved when re-evaluating cached entries

**UI/UX**
- Added `.bmc-filter-chip` styles for filter buttons with active state
- Added `.bmc-list-row` wrapper and `.bmc-list-remove` button styles (circular red ✕ with hover effects)
- Added `.bmc-trailer` and `.bmc-trailer-locked` styles for trailer blocks with iframe container
- Updated list rendering across home, library, and history screens to pass context to `_listItemHtml()`

**Documentation**
- Updated README with VPS server setup instructions, `.env` template, and API key requirements

## Notable Implementation Details
- The `context` parameter in `_listItemHtml()` enables the same function to render remove buttons appropriately for different list types
- `hiddenSuggestions` is a per-kid field that doesn't delete family library entries, allowing parents to suppress suggestions without affecting other kids
- Trailer unlock is gated by `_requestParentMode()`, so kids must authenticate with PIN to preview unapproved content
- The `.bmc-list-row` wrapper ensures the remove button doesn't break button semantics or keyboard accessibility

https://claude.ai/code/session_01CSWitB77QPJUeKZ26fQt86