### PR TITLE
Improve VPS deployment script reliability and safety

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -16,7 +16,11 @@ jobs:
           host: ${{ secrets.DROPLET_IP }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.DROPLET_SSH_KEY }}
+          script_stop: true
           script: |
-            cd /opt/zavala-sync && git pull
+            set -e
+            cd /opt/zavala-sync
+            git fetch origin main
+            git reset --hard origin/main
             cd vps && npm install --omit=dev
             sudo systemctl restart zavala-sync.service


### PR DESCRIPTION
## Summary
Enhanced the VPS deployment workflow to be more robust and safer by improving error handling and git synchronization strategy.

## Key Changes
- Added `script_stop: true` to halt execution on any command failure
- Implemented `set -e` to ensure the script exits immediately if any command fails
- Changed git synchronization from `git pull` to `git fetch` + `git reset --hard` for more predictable deployments
- This ensures the deployment always matches the remote main branch state, avoiding merge conflicts or local divergence issues

## Implementation Details
The new approach using `git fetch origin main` followed by `git reset --hard origin/main` is more reliable than `git pull` because it:
- Explicitly fetches the latest remote state without attempting a merge
- Forces the local repository to match the remote exactly, eliminating potential merge conflicts
- Provides clearer semantics about what the deployment is doing
- Combined with `set -e`, ensures any git operation failure will stop the deployment immediately rather than continuing with a potentially inconsistent state

https://claude.ai/code/session_01Pdw2TsgXR2mYhBP6WqJQHz