### PR TITLE
Remove family library lookup from media search

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -356,18 +356,6 @@ var BMC = (function() {
     var q = (input ? input.value : '').trim();
     if (!q) return;
 
-    // Check family library first
-    var hit = Object.keys(_familyLibrary).find(function(id) {
-      var it = _familyLibrary[id];
-      return it && (
-        it.title.toLowerCase() === q.toLowerCase() ||
-        (it.title + ' ' + (it.author_or_director || '')).toLowerCase().includes(q.toLowerCase())
-      );
-    });
-    if (hit) {
-      return selectCandidate(hit);
-    }
-
     _setStatus('Searching for "' + q + '"…', 'working');
     _fetchJson(VPS + '/api/media/lookup', {
       method: 'POST',


### PR DESCRIPTION
## Summary
Removed the local family library search optimization from the media lookup flow. The search now proceeds directly to the API call without checking the family library first.

## Changes
- Removed the family library lookup logic that checked for exact title matches or partial matches against author/director names before making an API request
- The search now skips the local cache check and goes directly to the `/api/media/lookup` API endpoint

## Implementation Details
This change simplifies the search flow by removing the optimization that attempted to find matches in the local `_familyLibrary` object before making a network request. The API-based search will now be the sole method for resolving media queries.

https://claude.ai/code/session_01EBxjATudUG8FkcnCQuftyh