### PR TITLE
Add search type filter for books and movies

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -30,6 +30,14 @@
           <input type="text" id="bmc-query" placeholder="e.g. The Hobbit" autocomplete="off" />
           <button class="bmc-btn bmc-btn-primary" onclick="BMC.search()">Search</button>
         </div>
+        <div class="bmc-search-type" id="bmc-search-type" role="radiogroup" aria-label="Search type">
+          <button type="button" class="bmc-filter-chip active" data-search-type="all"
+                  onclick="BMC.setSearchType('all')">Anything</button>
+          <button type="button" class="bmc-filter-chip" data-search-type="book"
+                  onclick="BMC.setSearchType('book')">📕 Book</button>
+          <button type="button" class="bmc-filter-chip" data-search-type="movie"
+                  onclick="BMC.setSearchType('movie')">🎬 Movie</button>
+        </div>
         <div class="bmc-search-actions">
           <button class="bmc-btn bmc-btn-secondary" onclick="BMC.scanIsbn()">📷 Scan ISBN</button>
           <button class="bmc-btn bmc-btn-secondary" onclick="BMC.capturePhoto()">🖼 Photo of cover</button>

--- a/css/book-movie-check.css
+++ b/css/book-movie-check.css
@@ -118,6 +118,9 @@ body {
   border-color: var(--bmc-accent);
   box-shadow: 0 0 0 3px var(--bmc-glow);
 }
+.bmc-search-type {
+  display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px;
+}
 .bmc-search-actions {
   display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px;
 }
@@ -376,15 +379,23 @@ body {
   margin-bottom: 6px;
 }
 .bmc-result-type {
-  display: inline-block;
-  font-size: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.85rem;
   font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  background: rgba(96,165,250,0.15);
+  letter-spacing: 0.3px;
+  background: rgba(96,165,250,0.18);
   color: var(--bmc-accent);
-  padding: 3px 8px;
-  border-radius: 6px;
+  border: 1.5px solid rgba(96,165,250,0.35);
+  padding: 5px 12px;
+  border-radius: 99px;
+}
+.bmc-result-type-movie,
+.bmc-result-type-series {
+  background: rgba(244,114,182,0.18);
+  color: #f472b6;
+  border-color: rgba(244,114,182,0.35);
 }
 
 /* Verdict banner */

--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -19,6 +19,7 @@ var BMC = (function() {
   var _scanStream = null;
   var _parentMode = false;  // session-only, resets on page reload
   var _libraryTypeFilter = 'all';  // 'all' | 'book' | 'movie'
+  var _searchType = 'all';         // 'all' | 'book' | 'movie' — restricts /media/lookup
 
   // Environment detection for iPad-in-WKWebView-wrapper cases
   var _cameraAvailable = null;  // null = unknown; true/false after probe
@@ -350,17 +351,32 @@ var BMC = (function() {
     return '⚠️ Caution';
   }
 
+  function setSearchType(type) {
+    _searchType = (type === 'book' || type === 'movie') ? type : 'all';
+    var row = document.getElementById('bmc-search-type');
+    if (!row) return;
+    var chips = row.querySelectorAll('[data-search-type]');
+    for (var i = 0; i < chips.length; i++) {
+      var chip = chips[i];
+      if (chip.getAttribute('data-search-type') === _searchType) chip.classList.add('active');
+      else chip.classList.remove('active');
+    }
+  }
+
   // ── Search flow (title text) ───────────────────────────────────
   function search() {
     var input = document.getElementById('bmc-query');
     var q = (input ? input.value : '').trim();
     if (!q) return;
 
+    var body = { query: q };
+    if (_searchType !== 'all') body.type = _searchType;
+
     _setStatus('Searching for "' + q + '"…', 'working');
     _fetchJson(VPS + '/api/media/lookup', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ query: q })
+      body: JSON.stringify(body)
     })
       .then(function(res) {
         if (!res.candidates || !res.candidates.length) {
@@ -799,7 +815,10 @@ var BMC = (function() {
         '<div class="bmc-result-meta">' +
           '<h2>' + _escHtmlLocal(e.title) + '</h2>' +
           '<div class="bmc-result-author">' + _escHtmlLocal(e.author_or_director || '') + (e.year ? ' · ' + e.year : '') + '</div>' +
-          '<span class="bmc-result-type">' + _escHtmlLocal(e.type || 'book') + '</span>' +
+          '<span class="bmc-result-type bmc-result-type-' + escAttr(e.type || 'book') + '">' +
+            ((e.type === 'movie' || e.type === 'series') ? '🎬 ' : '📕 ') +
+            _escHtmlLocal(e.type === 'series' ? 'Series' : (e.type === 'movie' ? 'Movie' : 'Book')) +
+          '</span>' +
         '</div>' +
       '</div>' +
 
@@ -1205,6 +1224,7 @@ var BMC = (function() {
     resetFamilyLibrary: resetFamilyLibrary,
     removeItem: removeItem,
     setLibraryFilter: setLibraryFilter,
+    setSearchType: setSearchType,
     unlockTrailer: unlockTrailer
   };
 })();


### PR DESCRIPTION
## Summary
This PR adds the ability to filter search results by media type (books, movies, or all) before performing a lookup. Users can now select whether they want to search for books, movies, or both using filter chips in the UI.

## Key Changes
- **UI**: Added a new search type filter row with three toggle buttons ("Anything", "📕 Book", "🎬 Movie") below the search input
- **State Management**: Introduced `_searchType` variable to track the current filter selection ('all', 'book', or 'movie')
- **API Integration**: Modified the search function to include the selected type in the POST request body when it's not 'all'
- **Result Display**: Enhanced result type badges with:
  - Emoji icons (📕 for books, 🎬 for movies/series)
  - Improved styling with borders, better spacing, and rounded pill shape
  - Distinct color scheme for movie/series results (pink) vs books (blue)
- **Styling**: Updated `.bmc-result-type` styling for better visual hierarchy and added new `.bmc-search-type` container styles

## Implementation Details
- The `setSearchType()` function manages filter chip state and updates the active selection
- Search type is passed to the `/api/media/lookup` endpoint only when a specific type is selected
- Result type badges now display human-readable labels ("Book", "Movie", "Series") with appropriate emoji indicators
- Filter chips use semantic HTML with `role="radiogroup"` for accessibility

https://claude.ai/code/session_01YRdS5WERiZMiuzDRKe24uS