### PR TITLE
Add PWA install + offline support (#183)

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -7,6 +7,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/art-studio.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="app">
@@ -170,5 +177,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/art-studio.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/book-movie-check.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:420px;height:420px;background:rgba(96,165,250,0.08);top:-120px;left:-120px;"></div>
@@ -193,5 +200,7 @@
   <script src="js/sounds.js"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/book-movie-check.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/chess-quest.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
 <div class="atmo atmo-1"></div>
@@ -102,5 +109,7 @@
 <script src="js/activity-log.js"></script>
 <script src="js/learning-checks.js"></script>
 <script src="js/chess-quest.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/descubre-chile.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
 <div class="atmo atmo-1"></div><div class="atmo atmo-2"></div>
@@ -74,5 +81,7 @@
 <script src="js/activity-log.js"></script>
 <script src="js/learning-checks.js"></script>
 <script src="js/descubre-chile.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -89,6 +89,13 @@
 
     .confetti { position: fixed; pointer-events: none; z-index: 1000; width: 10px; height: 10px; }
   </style>
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="header">
@@ -324,5 +331,7 @@
 
     render();
   </script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/guess-quest.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(251,191,36,0.08);top:-100px;left:-100px;"></div>
@@ -97,5 +104,7 @@
   <script src="js/learning-checks.js"></script>
   <script src="js/guess-quest.js"></script>
   <script src="js/daily-word.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -7,6 +7,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/guitar-jam.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="app">
@@ -158,5 +165,7 @@
       }
     });
   </script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/icons/icon-maskable.svg
+++ b/icons/icon-maskable.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="gm" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="0.5" stop-color="#EC4899"/>
+      <stop offset="1" stop-color="#FBBF24"/>
+    </linearGradient>
+  </defs>
+  <!-- Full-bleed bg so any mask shape reveals colour, not transparency -->
+  <rect width="512" height="512" fill="url(#gm)"/>
+  <!-- Rocket glyph constrained to the 80% safe-zone (inner 410px circle) -->
+  <g transform="translate(256 256) scale(0.78)">
+    <g transform="translate(0 10)">
+      <path d="M-30 110 Q-10 160 0 190 Q10 160 30 110 Z" fill="#FBBF24"/>
+      <path d="M-18 115 Q-6 150 0 170 Q6 150 18 115 Z" fill="#FDE68A"/>
+    </g>
+    <path d="M0 -130
+             C 60 -100 70 -30 70 40
+             L 70 100
+             L -70 100
+             L -70 40
+             C -70 -30 -60 -100 0 -130 Z"
+          fill="#fff"/>
+    <path d="M-70 40 L-115 110 L-70 100 Z" fill="#0B0B1A"/>
+    <path d="M70 40 L115 110 L70 100 Z" fill="#0B0B1A"/>
+    <circle cx="0" cy="-30" r="32" fill="#60A5FA"/>
+    <circle cx="0" cy="-30" r="32" fill="none" stroke="#0B0B1A" stroke-width="6"/>
+    <rect x="-70" y="50" width="140" height="8" fill="#0B0B1A"/>
+  </g>
+</svg>

--- a/icons/icon.svg
+++ b/icons/icon.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="0.5" stop-color="#EC4899"/>
+      <stop offset="1" stop-color="#FBBF24"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.5" cy="0.4" r="0.6">
+      <stop offset="0" stop-color="#fff" stop-opacity="0.25"/>
+      <stop offset="1" stop-color="#fff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#g)"/>
+  <rect width="512" height="512" rx="96" fill="url(#glow)"/>
+  <!-- Rocket glyph in the centre -->
+  <g transform="translate(256 256)">
+    <g transform="translate(0 10)">
+      <!-- Flame -->
+      <path d="M-30 110 Q-10 160 0 190 Q10 160 30 110 Z" fill="#FBBF24"/>
+      <path d="M-18 115 Q-6 150 0 170 Q6 150 18 115 Z" fill="#FDE68A"/>
+    </g>
+    <!-- Rocket body -->
+    <path d="M0 -130
+             C 60 -100 70 -30 70 40
+             L 70 100
+             L -70 100
+             L -70 40
+             C -70 -30 -60 -100 0 -130 Z"
+          fill="#fff"/>
+    <!-- Fins -->
+    <path d="M-70 40 L-115 110 L-70 100 Z" fill="#0B0B1A"/>
+    <path d="M70 40 L115 110 L70 100 Z" fill="#0B0B1A"/>
+    <!-- Window -->
+    <circle cx="0" cy="-30" r="32" fill="#60A5FA"/>
+    <circle cx="0" cy="-30" r="32" fill="none" stroke="#0B0B1A" stroke-width="6"/>
+    <path d="M-18 -40 Q0 -56 20 -38" stroke="#fff" stroke-width="6" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <!-- Body stripe -->
+    <rect x="-70" y="50" width="140" height="8" fill="#0B0B1A"/>
+  </g>
+  <!-- Twinkles -->
+  <circle cx="90" cy="110" r="4" fill="#fff" opacity="0.7"/>
+  <circle cx="420" cy="130" r="5" fill="#fff" opacity="0.8"/>
+  <circle cx="400" cy="410" r="3" fill="#fff" opacity="0.7"/>
+  <circle cx="110" cy="400" r="4" fill="#fff" opacity="0.6"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Baloo+2:wght@500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/index.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta name="apple-mobile-web-app-title" content="ZS Apps">
 </head>
 <body>
   <script src="js/debug.js"></script>
@@ -381,6 +388,7 @@
   <script src="js/learning-checks.js?v=2"></script>
   <script src="js/recital.js?v=1"></script>
   <script src="js/chilean-calendar.js?v=1"></script>
+  <script src="js/pwa.js?v=1"></script>
   <script src="js/index.js?v=2"></script>
 </body>
 </html>

--- a/js/pwa.js
+++ b/js/pwa.js
@@ -1,0 +1,135 @@
+/* ================================================================
+   PWA — pwa.js
+   - Registers ./sw.js so the suite is offline-capable.
+   - Captures the beforeinstallprompt event and exposes a small
+     "📱 Install" button on the hub after the user has visited
+     at least twice (not first-load nagging).
+   - Shows a one-line "Nueva versión disponible" banner when a new
+     service worker is waiting.
+
+   The install button is created lazily only when the browser both
+   supports the prompt and hasn't already been installed.
+   ================================================================ */
+
+(function() {
+  'use strict';
+  if (typeof window === 'undefined') return;
+  if (!('serviceWorker' in navigator)) return;
+
+  // ── Visit counter so we don't spam the install UX on first load.
+  try {
+    var visits = parseInt(localStorage.getItem('zs_visits') || '0', 10) || 0;
+    visits++;
+    localStorage.setItem('zs_visits', String(visits));
+  } catch (e) {}
+
+  var deferredPrompt = null;
+
+  // Skip SW on file:// and other dev protocols.
+  var protoOk = location.protocol === 'http:' || location.protocol === 'https:';
+  if (!protoOk) return;
+
+  function _visits() {
+    try { return parseInt(localStorage.getItem('zs_visits') || '0', 10) || 0; }
+    catch (e) { return 0; }
+  }
+
+  function _alreadyInstalled() {
+    return window.matchMedia && window.matchMedia('(display-mode: standalone)').matches;
+  }
+
+  // ── Register the SW ────────────────────────────────────────────
+  window.addEventListener('load', function() {
+    navigator.serviceWorker.register('./sw.js')
+      .then(function(reg) {
+        if (typeof Debug !== 'undefined') Debug.log('[PWA] SW registered:', reg.scope);
+
+        // Listen for updates becoming available.
+        reg.addEventListener('updatefound', function() {
+          var newWorker = reg.installing;
+          if (!newWorker) return;
+          newWorker.addEventListener('statechange', function() {
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              _showUpdateBanner(reg);
+            }
+          });
+        });
+      })
+      .catch(function(err) {
+        if (typeof Debug !== 'undefined') Debug.warn('[PWA] SW registration failed:', err);
+      });
+
+    // If a new SW activates and takes control, reload once so the
+    // freshly-cached HTML is in effect.
+    var reloading = false;
+    navigator.serviceWorker.addEventListener('controllerchange', function() {
+      if (reloading) return;
+      reloading = true;
+      window.location.reload();
+    });
+  });
+
+  // ── Install prompt capture ─────────────────────────────────────
+  window.addEventListener('beforeinstallprompt', function(e) {
+    e.preventDefault();
+    deferredPrompt = e;
+    if (_visits() >= 2 && !_alreadyInstalled()) _mountInstallButton();
+  });
+
+  window.addEventListener('appinstalled', function() {
+    try { localStorage.setItem('zs_pwa_installed', '1'); } catch (e) {}
+    _removeInstallButton();
+  });
+
+  // ── UI: install button on the hub footer ───────────────────────
+  function _mountInstallButton() {
+    if (document.getElementById('zs-pwa-install')) return;
+    // Only on hub.
+    if (!document.getElementById('hub-screen')) return;
+
+    var btn = document.createElement('button');
+    btn.id = 'zs-pwa-install';
+    btn.className = 'parent-btn';
+    btn.style.cssText = 'margin-top:0;background:linear-gradient(135deg,#7C3AED,#EC4899);color:#fff;border:none;font-weight:800;';
+    btn.textContent = '📱 Instalar en pantalla de inicio';
+    btn.addEventListener('click', function() {
+      if (!deferredPrompt) return;
+      deferredPrompt.prompt();
+      deferredPrompt.userChoice.then(function(choice) {
+        if (choice && choice.outcome === 'accepted') _removeInstallButton();
+        deferredPrompt = null;
+      });
+    });
+
+    // Slot into the bottom action row if we can find it.
+    var row = document.querySelector('#hub-screen .parent-btn');
+    if (row && row.parentElement) row.parentElement.appendChild(btn);
+    else document.body.appendChild(btn);
+  }
+
+  function _removeInstallButton() {
+    var el = document.getElementById('zs-pwa-install');
+    if (el && el.parentElement) el.parentElement.removeChild(el);
+  }
+
+  // ── UI: update-available banner ────────────────────────────────
+  function _showUpdateBanner(reg) {
+    if (document.getElementById('zs-pwa-update')) return;
+    var bar = document.createElement('div');
+    bar.id = 'zs-pwa-update';
+    bar.style.cssText =
+      'position:fixed;left:0;right:0;bottom:0;z-index:9999;' +
+      'padding:10px 16px;background:linear-gradient(135deg,#7C3AED,#EC4899);color:#fff;' +
+      'font-family:var(--font-body,sans-serif);font-weight:700;font-size:0.9rem;' +
+      'display:flex;align-items:center;justify-content:center;gap:14px;' +
+      'box-shadow:0 -8px 24px -12px rgba(0,0,0,0.5);';
+    bar.innerHTML =
+      '<span>✨ Nueva versión lista. Toca para actualizar.</span>' +
+      '<button id="zs-pwa-update-btn" style="padding:6px 14px;border-radius:99px;border:none;background:#fff;color:#7C3AED;font-weight:800;cursor:pointer;">Actualizar</button>';
+    document.body.appendChild(bar);
+    document.getElementById('zs-pwa-update-btn').addEventListener('click', function() {
+      if (reg && reg.waiting) reg.waiting.postMessage({ type: 'SKIP_WAITING' });
+      // controllerchange listener above will reload.
+    });
+  }
+})();

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/lab-explorer.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(16,185,129,0.08);top:-100px;left:-100px;"></div>
@@ -66,5 +73,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/lab-explorer.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -13905,6 +13905,8 @@ document.addEventListener('DOMContentLoaded', () => {
       Exported ${new Date().toLocaleDateString()}
     </div>
   </div>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>`;
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,27 @@
+{
+  "name": "Zavala Serra Apps",
+  "short_name": "ZS Apps",
+  "description": "Educational app suite for the Zavala Serra kids",
+  "start_url": "index.html",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "any",
+  "background_color": "#0B0B1A",
+  "theme_color": "#7C3AED",
+  "lang": "es",
+  "icons": [
+    {
+      "src": "icons/icon.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-maskable.svg",
+      "type": "image/svg+xml",
+      "sizes": "any",
+      "purpose": "maskable"
+    }
+  ],
+  "categories": ["education", "kids"]
+}

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/math-galaxy.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="nebula nebula-1"></div>
@@ -105,5 +112,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/math-galaxy.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/quest-adventure.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(245,158,11,0.08);top:-100px;left:-100px;"></div>
@@ -42,5 +49,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/quest-adventure.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/shopping-list.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(52,211,153,0.08);top:-100px;left:-100px;"></div>
@@ -69,5 +76,7 @@
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/sports-arena.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
 
@@ -756,5 +763,7 @@
   // ── Helpers ──
   function escAttr(s) { return String(s).replace(/'/g, "\\'").replace(/"/g, '\\"'); }
 </script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/story-explorer.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(139,92,246,0.08);top:-100px;left:-100px;"></div>
@@ -85,5 +92,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/story-explorer.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,160 @@
+/* ================================================================
+   ZAVALA SERRA APPS — Service Worker
+   Caching strategy:
+     - HTML documents         → network-first (fall back to cache)
+     - CSS / JS / images      → stale-while-revalidate
+     - Fonts (Google CDN)     → cache-first (they're versioned)
+     - /api/* (VPS sync)      → never cache (user data)
+     - External URLs we don't know → pass through
+
+   Bump CACHE_VERSION when you change SW logic or want to invalidate
+   the precache. Existing caches are cleaned up on activate.
+   ================================================================ */
+
+'use strict';
+
+const CACHE_VERSION = 'zs-suite-v1';
+const CORE_CACHE = CACHE_VERSION + '-core';
+const ASSETS_CACHE = CACHE_VERSION + '-assets';
+const FONTS_CACHE = CACHE_VERSION + '-fonts';
+
+// Bare-minimum shell: the hub + the shared JS/CSS so the suite can
+// boot offline. Per-app HTML is cached lazily as the user visits them.
+const CORE_ASSETS = [
+  './',
+  './index.html',
+  './css/common.css',
+  './css/index.css',
+  './js/auth.js',
+  './js/sync.js',
+  './js/index.js',
+  './js/nav.js',
+  './js/debug.js',
+  './manifest.json',
+  './icons/icon.svg',
+  './icons/icon-maskable.svg'
+];
+
+self.addEventListener('install', function(event) {
+  event.waitUntil(
+    caches.open(CORE_CACHE).then(function(cache) {
+      // Use individual puts so one bad asset doesn't abort the whole install.
+      return Promise.all(CORE_ASSETS.map(function(url) {
+        return fetch(url, { cache: 'no-store' })
+          .then(function(res) {
+            if (res.ok) return cache.put(url, res.clone());
+          })
+          .catch(function() { /* ok, try again on next install */ });
+      }));
+    }).then(function() { return self.skipWaiting(); })
+  );
+});
+
+self.addEventListener('activate', function(event) {
+  event.waitUntil(
+    caches.keys().then(function(keys) {
+      return Promise.all(keys.map(function(k) {
+        if (k.indexOf(CACHE_VERSION) !== 0) return caches.delete(k);
+      }));
+    }).then(function() { return self.clients.claim(); })
+  );
+});
+
+function _isHTML(req) {
+  if (req.mode === 'navigate') return true;
+  var accept = req.headers.get('accept') || '';
+  return accept.indexOf('text/html') !== -1;
+}
+
+function _isFont(url) {
+  return url.hostname === 'fonts.googleapis.com' || url.hostname === 'fonts.gstatic.com';
+}
+
+function _isAPI(url) {
+  return url.pathname.indexOf('/api/') !== -1;
+}
+
+function _sameOrigin(url) {
+  return url.origin === self.location.origin;
+}
+
+self.addEventListener('fetch', function(event) {
+  var req = event.request;
+  // Only GET requests are cacheable.
+  if (req.method !== 'GET') return;
+
+  var url;
+  try { url = new URL(req.url); }
+  catch (e) { return; }
+
+  // Never cache the sync/diag APIs.
+  if (_isAPI(url)) return;
+
+  // Chrome extensions and other schemes: pass through.
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return;
+
+  if (_isFont(url)) {
+    event.respondWith(_cacheFirst(req, FONTS_CACHE));
+    return;
+  }
+
+  if (!_sameOrigin(url)) {
+    // Third-party non-font: don't touch it — let the network handle.
+    return;
+  }
+
+  if (_isHTML(req)) {
+    event.respondWith(_networkFirst(req, CORE_CACHE));
+    return;
+  }
+
+  // Same-origin static asset (css/js/images/svg)
+  event.respondWith(_staleWhileRevalidate(req, ASSETS_CACHE));
+});
+
+function _networkFirst(req, cacheName) {
+  return fetch(req).then(function(res) {
+    if (res && res.ok) {
+      var clone = res.clone();
+      caches.open(cacheName).then(function(c) { c.put(req, clone); });
+    }
+    return res;
+  }).catch(function() {
+    return caches.match(req).then(function(cached) {
+      return cached || caches.match('./index.html');
+    });
+  });
+}
+
+function _cacheFirst(req, cacheName) {
+  return caches.match(req).then(function(cached) {
+    if (cached) return cached;
+    return fetch(req).then(function(res) {
+      if (res && res.ok) {
+        var clone = res.clone();
+        caches.open(cacheName).then(function(c) { c.put(req, clone); });
+      }
+      return res;
+    });
+  });
+}
+
+function _staleWhileRevalidate(req, cacheName) {
+  return caches.match(req).then(function(cached) {
+    var fetchPromise = fetch(req).then(function(res) {
+      if (res && res.ok) {
+        var clone = res.clone();
+        caches.open(cacheName).then(function(c) { c.put(req, clone); });
+      }
+      return res;
+    }).catch(function() { return cached; });
+    return cached || fetchPromise;
+  });
+}
+
+// Allow the page to ask the SW to activate a pending update immediately.
+self.addEventListener('message', function(event) {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
+});

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/trophy-room.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(251,191,36,0.1);top:-100px;left:-100px;"></div>
@@ -42,5 +49,7 @@
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -9,6 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/world-explorer.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
 </head>
 <body>
   <div class="atmo" style="width:400px;height:400px;background:rgba(59,130,246,0.08);top:-100px;left:-100px;"></div>
@@ -74,5 +81,7 @@
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/world-explorer.js"></script>
+  <script src="js/pwa.js"></script>
+
 </body>
 </html>


### PR DESCRIPTION
Ships the four pieces needed to make the suite installable and
usable offline:

manifest.json
  - name, short_name, description, theme_color #7C3AED
  - start_url index.html, display standalone, scope "./"
  - SVG icon (icons/icon.svg) and maskable variant
    (icons/icon-maskable.svg), both hand-authored rocket glyphs

sw.js (at root so scope covers every app)
  - CACHE_VERSION-prefixed caches; old versions cleaned on activate
  - HTML documents        → network-first (cache fallback)
  - Same-origin CSS/JS/img→ stale-while-revalidate
  - Google Fonts CDN      → cache-first
  - /api/* requests       → pass-through (never cached)
  - Non-GET requests      → pass-through
  - SKIP_WAITING message  → activates a pending update immediately

js/pwa.js (loaded on every page)
  - Registers ./sw.js
  - Captures beforeinstallprompt; shows a subtle "📱 Instalar en
    pantalla de inicio" button on the hub only after 2+ visits
  - Reloads once when a new SW takes control
  - Shows a bottom "Nueva versión disponible" banner when a waiting
    worker is ready; tap to activate + reload

Integration
  - index.html gets the manifest link + Apple PWA meta tags + icon
    links in <head>, and js/pwa.js before the main index script
  - All 16 other app pages get the same manifest/theme/icon/pwa.js
    additions so the whole suite installs as one PWA

Notes for iOS
  - Apple still prefers PNG apple-touch-icons. The SVG is accepted
    and works, but a 180x180 PNG at icons/apple-touch-icon.png would
    look sharper. Drop in when you want to polish — nothing here
    blocks on it.