### PR TITLE
Fix ReferenceError when creating a new profile

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1198,7 +1198,13 @@
     profiles.push(newUser);
     saveProfiles(profiles);
     closeModal();
-    loginAs(newUser);
+    // Auto-login the new profile: mirror the flow used by the existing
+    // profile-card click handler (setActiveUser → invalidate cache →
+    // showHub). Previous code called a non-existent loginAs() helper,
+    // which threw ReferenceError and left the user on the login screen.
+    setActiveUser(newUser);
+    if (typeof _activeUserCached !== 'undefined') window._activeUserCached = false;
+    showHub();
   }
 
   function requestPinThen(callback) {


### PR DESCRIPTION
Fixes a `ReferenceError: loginAs is not defined` thrown by `createProfile()` when a parent adds a new kid. The old helper was refactored out at some point and this call site was missed.

**Effect before fix**: profile was saved successfully but the auto-login threw, leaving the user on the login screen. They had to click the newly-added profile card to actually enter.

**Fix**: use the same flow the profile-card click handler uses — `setActiveUser(newUser)` + clear the auth cache + `showHub()`.

Caught by the zs-diag pipeline on 2026-04-23 (user `u-fdd496`, Chrome/macOS).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_