### PR TITLE
Silence Little Maestro SW warning in suite context

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -14172,11 +14172,21 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 
 <script>
+  // Little Maestro is published in two forms:
+  //   1. Standalone (ships its own ./_assets/sw.js)
+  //   2. As part of the Zavala Serra Apps suite (no service worker)
+  // We HEAD-check before registering so the suite context stays silent
+  // instead of emitting a "Registration failed" warning on every load.
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      navigator.serviceWorker.register('./_assets/sw.js', { scope: './' })
-        .then(reg => console.log('[SW] Registered:', reg.scope))
-        .catch(err => console.warn('[SW] Registration failed:', err));
+      fetch('./_assets/sw.js', { method: 'HEAD', cache: 'no-store' })
+        .then(res => {
+          if (!res.ok) return; // no SW shipped in this deploy — fine
+          return navigator.serviceWorker.register('./_assets/sw.js', { scope: './' })
+            .then(reg => console.log('[SW] Registered:', reg.scope))
+            .catch(err => console.warn('[SW] Registration failed:', err));
+        })
+        .catch(() => { /* offline or network-blocked probe — ignore */ });
     });
   }
 </script>


### PR DESCRIPTION
`little-maestro.html` registered a service worker at `./_assets/sw.js` on every load. That path only exists in the standalone Little Maestro build; in the suite context the file 404s and emits `[SW] Registration failed` on every visit — diag captured it 2× already.

**Fix**: HEAD-check the SW before registering. If present (standalone deploy) → register normally with success/failure logging. If 404 (suite deploy) → skip quietly.

First "real" diag-driven fix. Also rebased on latest main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_