### PR TITLE
Add system-wide TTS toggle (#181)

### DIFF
--- a/index.html
+++ b/index.html
@@ -388,6 +388,7 @@
   <script src="js/learning-checks.js?v=2"></script>
   <script src="js/recital.js?v=1"></script>
   <script src="js/chilean-calendar.js?v=1"></script>
+  <script src="js/tts.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
   <script src="js/index.js?v=2"></script>
 </body>

--- a/js/index.js
+++ b/js/index.js
@@ -104,6 +104,19 @@
   window.redeemForTime = function() { redeemForTime(); };
   window.updateKidChess = function(idx, val) { updateKidChess(idx, val); };
   window.updateKidFaith = function(idx, val) { updateKidFaith(idx, val); };
+  window.updateKidTts = function(idx, field, val) {
+    if (typeof ZsTTS === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    var patch = {};
+    patch[field] = val;
+    ZsTTS.setSettings(patch, name);
+    if (field === 'rate') {
+      var label = document.getElementById('tts-rate-val-' + idx);
+      if (label) label.textContent = Number(val).toFixed(2) + 'x';
+    }
+  };
   window.updateParentPin = function() { updateParentPin(); };
   window.renderChoresList = function() { renderChoresList(); };
   window.completeChore = function(id) { if (typeof ChoresManager !== 'undefined') ChoresManager.completeChore(id); };
@@ -1022,6 +1035,20 @@
                 '<button class="hub-action-btn secondary" style="padding:6px 12px; font-size:0.75rem; flex:1;" onclick="addKidBonus(getProfiles()[' + i + '].name, 30)">+30 min</button>' +
                 '<button class="hub-action-btn secondary" style="padding:6px 12px; font-size:0.75rem; flex:1; border-color:rgba(239,68,68,0.3); color:#F87171;" onclick="resetKidTimer(getProfiles()[' + i + '].name)">Reset Today</button>' +
               '</div>' +
+              (typeof ZsTTS !== 'undefined' ? (
+                '<div class="pk-setting" style="margin-top:16px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.06);">' +
+                  '<label class="pk-toggle" style="font-size:0.9rem;">' +
+                    '<input type="checkbox" ' + (ZsTTS.getSettings(p.name).enabled ? 'checked' : '') + ' onchange="updateKidTts(' + i + ', \'enabled\', this.checked)">' +
+                    ' 🗣 Read-aloud enabled' +
+                  '</label>' +
+                  '<label style="display:block;margin-top:8px;font-size:0.8rem;color:var(--text-muted);font-weight:700;">' +
+                    'Rate: <span id="tts-rate-val-' + i + '">' + ZsTTS.getSettings(p.name).rate.toFixed(2) + '×</span>' +
+                  '</label>' +
+                  '<input type="range" min="0.5" max="1.2" step="0.05" value="' + ZsTTS.getSettings(p.name).rate + '" ' +
+                         'oninput="updateKidTts(' + i + ', \'rate\', parseFloat(this.value))" ' +
+                         'style="width:100%;">' +
+                '</div>'
+              ) : '') +
             '</div>';
         }).join('') +
       '</div>' +

--- a/js/story-explorer.js
+++ b/js/story-explorer.js
@@ -575,43 +575,69 @@ const StoryExplorer = (() => {
   }
 
   function readAloud() {
-    if (!('speechSynthesis' in window)) {
+    // Gate on the shared suite-wide TTS module if it's loaded.
+    var useShared = typeof ZsTTS !== 'undefined';
+
+    if (useShared) {
+      if (!ZsTTS.supported()) {
+        alert(lang === 'es'
+          ? 'Este navegador no soporta lectura en voz alta.'
+          : 'This browser does not support read-aloud.');
+        return;
+      }
+      if (!ZsTTS.getSettings().enabled) {
+        alert(lang === 'es'
+          ? 'Lectura en voz alta está desactivada. Un adulto puede activarla en el Dashboard.'
+          : 'Read-aloud is turned off. A grown-up can turn it on in the Dashboard.');
+        return;
+      }
+    } else if (!('speechSynthesis' in window)) {
       alert(lang === 'es'
         ? 'Este navegador no soporta lectura en voz alta.'
         : 'This browser does not support read-aloud.');
       return;
     }
+
     if (_readActive) { stopRead(); return; }
 
     const el = document.getElementById('page-text');
     const text = (el && el.dataset.raw) || (currentStory.pages[currentPage][lang === 'es' ? 'es' : 'en']);
 
-    try { speechSynthesis.cancel(); } catch (e) {}
-
-    _readUtterance = new SpeechSynthesisUtterance(text);
-    _readUtterance.lang = lang === 'es' ? 'es-CL' : 'en-US';
-    _readUtterance.rate = 0.9;
-    _readUtterance.pitch = 1.0;
-
-    _readUtterance.onboundary = function(ev) {
-      if (!_readActive) return;
-      if (ev.name && ev.name !== 'word') return;
-      _highlightAtChar(ev.charIndex);
-    };
-    _readUtterance.onend = function() {
-      _readActive = false;
-      _clearHighlight();
-      _updateReadButton();
-    };
-    _readUtterance.onerror = function() {
-      _readActive = false;
-      _clearHighlight();
-      _updateReadButton();
-    };
-
     _readActive = true;
     _updateReadButton();
-    speechSynthesis.speak(_readUtterance);
+
+    var ttsLang = lang === 'es' ? 'es-CL' : 'en-US';
+    var onBoundary = function(charIndex) {
+      if (!_readActive) return;
+      _highlightAtChar(charIndex);
+    };
+    var onEnd = function() {
+      _readActive = false;
+      _clearHighlight();
+      _updateReadButton();
+    };
+    var onError = onEnd;
+
+    if (useShared) {
+      _readUtterance = ZsTTS.speak(text, {
+        lang: ttsLang,
+        onBoundary: onBoundary,
+        onEnd: onEnd,
+        onError: onError
+      });
+    } else {
+      try { speechSynthesis.cancel(); } catch (e) {}
+      _readUtterance = new SpeechSynthesisUtterance(text);
+      _readUtterance.lang = ttsLang;
+      _readUtterance.rate = 0.9;
+      _readUtterance.onboundary = function(ev) {
+        if (ev.name && ev.name !== 'word') return;
+        onBoundary(ev.charIndex);
+      };
+      _readUtterance.onend = onEnd;
+      _readUtterance.onerror = onError;
+      speechSynthesis.speak(_readUtterance);
+    }
   }
 
   function toggleLanguage() {

--- a/js/tts.js
+++ b/js/tts.js
@@ -1,0 +1,123 @@
+/* ================================================================
+   ZS TTS — tts.js
+   Shared text-to-speech helper on top of the Web Speech API.
+   No external calls; uses the OS-provided voices.
+
+   Stores per-kid preferences under localStorage key `zs_tts` so any
+   app in the suite can check `ZsTTS.getSettings().enabled` before
+   rendering a read-aloud button.
+
+   Public API:
+     ZsTTS.supported()              → bool
+     ZsTTS.getSettings(userName?)   → { enabled, rate }
+     ZsTTS.setSettings(patch, user?)→ persist partial update
+     ZsTTS.speak(text, opts)        → SpeechSynthesisUtterance | null
+        opts = { lang, rate, onBoundary(charIndex), onEnd, onError }
+     ZsTTS.stop()
+     ZsTTS.isSpeaking()             → bool
+   ================================================================ */
+
+var ZsTTS = (function() {
+  'use strict';
+
+  var STORAGE_KEY = 'zs_tts';
+  // Sensible defaults — enabled by default for young readers; rate a
+  // touch below normal so newly-reading kids can track the words.
+  var DEFAULT_SETTINGS = { enabled: true, rate: 0.85 };
+
+  function supported() {
+    return typeof window !== 'undefined'
+      && 'speechSynthesis' in window
+      && 'SpeechSynthesisUtterance' in window;
+  }
+
+  function _userKey(userName) {
+    var name = userName;
+    if (!name && typeof getActiveUser === 'function') {
+      var u = getActiveUser();
+      if (u) name = u.name;
+    }
+    if (!name) return '_default';
+    return name.toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function _loadAll() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? JSON.parse(raw) || {} : {};
+    } catch (e) { return {}; }
+  }
+
+  function _saveAll(all) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(all)); }
+    catch (e) {}
+  }
+
+  function getSettings(userName) {
+    var all = _loadAll();
+    var key = _userKey(userName);
+    var s = all[key] || {};
+    return {
+      enabled: typeof s.enabled === 'boolean' ? s.enabled : DEFAULT_SETTINGS.enabled,
+      rate: typeof s.rate === 'number' ? s.rate : DEFAULT_SETTINGS.rate
+    };
+  }
+
+  function setSettings(patch, userName) {
+    if (!patch) return;
+    var all = _loadAll();
+    var key = _userKey(userName);
+    var current = Object.assign({}, DEFAULT_SETTINGS, all[key] || {});
+    if (typeof patch.enabled === 'boolean') current.enabled = patch.enabled;
+    if (typeof patch.rate === 'number') current.rate = patch.rate;
+    all[key] = current;
+    _saveAll(all);
+    return current;
+  }
+
+  function isSpeaking() {
+    return supported() && window.speechSynthesis.speaking;
+  }
+
+  function stop() {
+    if (!supported()) return;
+    try { window.speechSynthesis.cancel(); } catch (e) {}
+  }
+
+  function speak(text, opts) {
+    if (!supported() || !text) return null;
+    var s = getSettings();
+    if (!s.enabled) return null;
+
+    stop();
+    opts = opts || {};
+
+    var utterance = new window.SpeechSynthesisUtterance(text);
+    utterance.lang = opts.lang || 'en-US';
+    utterance.rate = typeof opts.rate === 'number' ? opts.rate : s.rate;
+    utterance.pitch = typeof opts.pitch === 'number' ? opts.pitch : 1.0;
+
+    if (typeof opts.onBoundary === 'function') {
+      utterance.onboundary = function(ev) {
+        if (ev.name && ev.name !== 'word') return;
+        opts.onBoundary(ev.charIndex);
+      };
+    }
+    if (typeof opts.onEnd === 'function')   utterance.onend   = opts.onEnd;
+    if (typeof opts.onError === 'function') utterance.onerror = opts.onError;
+
+    try { window.speechSynthesis.speak(utterance); }
+    catch (e) { if (opts.onError) opts.onError(e); return null; }
+
+    return utterance;
+  }
+
+  return {
+    supported: supported,
+    getSettings: getSettings,
+    setSettings: setSettings,
+    speak: speak,
+    stop: stop,
+    isSpeaking: isSpeaking
+  };
+})();

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -91,6 +91,7 @@
   <script src="js/timer.js"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
+  <script src="js/tts.js"></script>
   <script src="js/story-explorer.js"></script>
   <script src="js/pwa.js"></script>
 


### PR DESCRIPTION
New `js/tts.js` shared module wraps the Web Speech API and persists per-kid settings in `localStorage` (`zs_tts`):
- `enabled` (bool, default true)
- `rate` (number, default 0.85 — eases new readers)
- Per-profile keyed via `getActiveUser()`, `_default` fallback

### Public API
```js
ZsTTS.supported(), getSettings(), setSettings(),
speak(text, {lang, rate, onBoundary, onEnd, onError}),
stop(), isSpeaking()
```

### Story Explorer refactored
- Honors `ZsTTS.getSettings().enabled` (falls back to legacy path when module absent so standalone deploys still work)
- Delegates actual speech to `ZsTTS.speak` while keeping its word-boundary highlight logic unchanged

### Parents Corner
Gains a per-kid **🗣 Read-aloud** block with an enabled toggle and a 0.5× – 1.2× rate slider. Takes effect on next Read Aloud press — no reload required.

No external calls, no cloud TTS. Uses OS voices only.

### Flag for review
Defaults enabled for all ages. Flip `DEFAULT_SETTINGS.enabled` in `js/tts.js` if you'd rather have it opt-in.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_