### PR TITLE
Add daily routine check-in for morning + evening (#152)

### DIFF
--- a/css/routines.css
+++ b/css/routines.css
@@ -1,0 +1,144 @@
+/* ============================================================
+   DAILY ROUTINES — hub widget + modal styling
+   ============================================================ */
+
+#routines-widget { animation: fadeUp 0.6s ease-out both; }
+
+.rn-card {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 14px 18px;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, rgba(96,165,250,0.08), rgba(167,139,250,0.05));
+  border: 1.5px solid rgba(96,165,250,0.2);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.25s;
+}
+.rn-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(96,165,250,0.45);
+  box-shadow: 0 8px 24px -8px rgba(96,165,250,0.4);
+}
+.rn-card.rn-done {
+  background: linear-gradient(135deg, rgba(52,211,153,0.1), rgba(251,191,36,0.06));
+  border-color: rgba(52,211,153,0.3);
+}
+.rn-emoji { font-size: 2rem; flex-shrink: 0; }
+.rn-body { flex: 1; min-width: 0; }
+.rn-title {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text-primary);
+}
+.rn-sub {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-top: 2px;
+}
+.rn-bar {
+  margin-top: 8px;
+  height: 6px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.rn-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #60A5FA, #A78BFA);
+  border-radius: 99px;
+  transition: width 0.5s cubic-bezier(0.34,1.56,0.64,1);
+}
+.rn-arrow {
+  color: var(--text-muted);
+  font-size: 1.4rem;
+  font-weight: 700;
+  opacity: 0.6;
+  flex-shrink: 0;
+}
+
+/* Modal */
+.rn-streak {
+  text-align: center;
+  font-weight: 800;
+  color: #FBBF24;
+  padding: 10px 16px;
+  background: rgba(251,191,36,0.08);
+  border-radius: 12px;
+  margin-bottom: 16px;
+  font-size: 0.95rem;
+}
+.rn-streak.rn-streak-empty {
+  color: var(--text-muted);
+  background: rgba(255,255,255,0.03);
+}
+
+.rn-progress {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.rn-progress-text {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--text-primary);
+  min-width: 60px;
+  text-align: right;
+}
+.rn-progress-bar {
+  flex: 1;
+  height: 10px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.rn-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #34D399, #60A5FA);
+  border-radius: 99px;
+  transition: width 0.5s cubic-bezier(0.34,1.56,0.64,1);
+}
+
+.rn-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+.rn-item {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  background: rgba(255,255,255,0.03);
+  border: 1.5px solid rgba(255,255,255,0.06);
+  border-radius: 14px;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-size: 1rem;
+  font-weight: 700;
+}
+.rn-item:hover {
+  border-color: rgba(96,165,250,0.4);
+  background: rgba(96,165,250,0.05);
+}
+.rn-item input[type="checkbox"] {
+  width: 22px;
+  height: 22px;
+  accent-color: #34D399;
+  cursor: pointer;
+}
+.rn-item.rn-done-item {
+  opacity: 0.55;
+}
+.rn-item.rn-done-item .rn-item-label {
+  text-decoration: line-through;
+}
+
+.rn-switch { text-align: center; margin-top: 12px; }
+.rn-switch button { padding: 10px 18px !important; font-size: 0.85rem; }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Baloo+2:wght@500;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/index.css">
+  <link rel="stylesheet" href="css/routines.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -90,6 +91,7 @@
       </div>
 
       <div id="calendar-widget"></div>
+      <div id="routines-widget"></div>
       <div id="next-challenge-wrap"></div>
 
       <!-- App Grid -->
@@ -389,6 +391,7 @@
   <script src="js/recital.js?v=1"></script>
   <script src="js/chilean-calendar.js?v=1"></script>
   <script src="js/tts.js?v=1"></script>
+  <script src="js/routines.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
   <script src="js/index.js?v=2"></script>
 </body>

--- a/js/index.js
+++ b/js/index.js
@@ -361,6 +361,11 @@
       catch(e) { if (typeof Debug !== 'undefined') Debug.error('renderHubWidget failed', e.message); }
     }
 
+    if (typeof Routines !== 'undefined') {
+      try { Routines.renderHubWidget('routines-widget'); }
+      catch(e) { if (typeof Debug !== 'undefined') Debug.error('Routines.renderHubWidget failed', e.message); }
+    }
+
     if (typeof Debug !== 'undefined') Debug.log('Rendering app cards...');
     try {
       renderAppCards(user);

--- a/js/routines.js
+++ b/js/routines.js
@@ -1,0 +1,288 @@
+/* ================================================================
+   DAILY ROUTINES — routines.js
+   Morning + evening self-report checklists that live on the hub.
+   Separate from the existing Chores/Token system by design: this is
+   about building habit (streak) not earning screen-time.
+
+   Storage key: zs_routines_<userkey>
+   Shape:
+     {
+       days: { "YYYY-MM-DD": { morning: ["bed","teeth"], evening: [...] } },
+       streak: 3,
+       bestStreak: 9,
+       lastFullDay: "YYYY-MM-DD"
+     }
+
+   Default routines are intentional minimums. Parents can edit later
+   (v2 adds a Parents Corner editor; for now DEFAULTS ship in-code).
+   ================================================================ */
+
+var Routines = (function() {
+  'use strict';
+
+  var STORAGE_PREFIX = 'zs_routines_';
+
+  // Default morning/evening templates. Kid-authored text only.
+  var DEFAULTS = {
+    morning: [
+      { id: 'bed',       label: 'Hacer la cama 🛏️' },
+      { id: 'teeth',     label: 'Cepillarse los dientes 🦷' },
+      { id: 'dressed',   label: 'Vestirse 👕' },
+      { id: 'breakfast', label: 'Desayunar 🥣' },
+      { id: 'backpack',  label: 'Preparar la mochila 🎒' }
+    ],
+    evening: [
+      { id: 'homework',  label: 'Tarea del cole ✏️' },
+      { id: 'tidy',      label: 'Ordenar el cuarto 🧸' },
+      { id: 'laundry',   label: 'Guardar la ropa 🧦' },
+      { id: 'teeth_pm',  label: 'Cepillarse los dientes 🦷' },
+      { id: 'read',      label: 'Leer un rato 📖' }
+    ]
+  };
+
+  function _userKey() {
+    if (typeof getActiveUser !== 'function') return null;
+    var u = getActiveUser();
+    if (!u) return null;
+    return u.name.toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function _storageKey() {
+    var k = _userKey();
+    return k ? (STORAGE_PREFIX + k) : null;
+  }
+
+  function _today() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _yesterday() {
+    var d = new Date();
+    d.setDate(d.getDate() - 1);
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _load() {
+    var k = _storageKey();
+    if (!k) return null;
+    try {
+      var raw = localStorage.getItem(k);
+      var data = raw ? JSON.parse(raw) : {};
+      if (!data.days) data.days = {};
+      if (typeof data.streak !== 'number') data.streak = 0;
+      if (typeof data.bestStreak !== 'number') data.bestStreak = 0;
+      return data;
+    } catch (e) { return { days: {}, streak: 0, bestStreak: 0 }; }
+  }
+
+  function _save(data) {
+    var k = _storageKey();
+    if (!k) return;
+    try { localStorage.setItem(k, JSON.stringify(data)); } catch (e) {}
+  }
+
+  function _getDay(data, dayKey) {
+    if (!data.days[dayKey]) data.days[dayKey] = { morning: [], evening: [] };
+    var day = data.days[dayKey];
+    if (!Array.isArray(day.morning)) day.morning = [];
+    if (!Array.isArray(day.evening)) day.evening = [];
+    return day;
+  }
+
+  function getStatus() {
+    var data = _load();
+    if (!data) return null;
+    var today = _today();
+    var day = _getDay(data, today);
+    return {
+      date: today,
+      streak: data.streak,
+      bestStreak: data.bestStreak,
+      morning: {
+        items: DEFAULTS.morning.map(function(c) {
+          return { id: c.id, label: c.label, done: day.morning.indexOf(c.id) !== -1 };
+        }),
+        doneCount: day.morning.length,
+        total: DEFAULTS.morning.length,
+        complete: day.morning.length >= DEFAULTS.morning.length
+      },
+      evening: {
+        items: DEFAULTS.evening.map(function(c) {
+          return { id: c.id, label: c.label, done: day.evening.indexOf(c.id) !== -1 };
+        }),
+        doneCount: day.evening.length,
+        total: DEFAULTS.evening.length,
+        complete: day.evening.length >= DEFAULTS.evening.length
+      }
+    };
+  }
+
+  function toggle(routine, itemId) {
+    if (routine !== 'morning' && routine !== 'evening') return getStatus();
+    var data = _load();
+    if (!data) return null;
+    var today = _today();
+    var day = _getDay(data, today);
+    var list = day[routine];
+    var idx = list.indexOf(itemId);
+    if (idx === -1) {
+      // Don't add ids that aren't in the template (defence).
+      var isKnown = DEFAULTS[routine].some(function(c) { return c.id === itemId; });
+      if (!isKnown) return getStatus();
+      list.push(itemId);
+    } else {
+      list.splice(idx, 1);
+    }
+
+    // Update streak when BOTH routines hit 100% for the day.
+    var bothDone = day.morning.length >= DEFAULTS.morning.length &&
+                   day.evening.length >= DEFAULTS.evening.length;
+    if (bothDone && data.lastFullDay !== today) {
+      if (data.lastFullDay === _yesterday()) {
+        data.streak = (data.streak || 0) + 1;
+      } else {
+        data.streak = 1;
+      }
+      data.lastFullDay = today;
+      if (data.streak > data.bestStreak) data.bestStreak = data.streak;
+      if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
+        ActivityLog.log('Routines', '✅', 'Day complete (streak ' + data.streak + ')');
+      }
+    }
+    _save(data);
+    return getStatus();
+  }
+
+  // Which routine is currently "relevant" based on local time.
+  // Before 14:00 → morning, after → evening.
+  function getActiveRoutine() {
+    var hour = new Date().getHours();
+    return hour < 14 ? 'morning' : 'evening';
+  }
+
+  // ── Hub widget ──
+  function renderHubWidget(containerId) {
+    var el = typeof containerId === 'string' ? document.getElementById(containerId) : containerId;
+    if (!el) return;
+    var status = getStatus();
+    if (!status) { el.innerHTML = ''; return; }
+
+    var which = getActiveRoutine();
+    var block = which === 'morning' ? status.morning : status.evening;
+    var heading = which === 'morning' ? '🌅 Buenos días' : '🌙 Buenas noches';
+
+    if (block.complete) {
+      el.innerHTML =
+        '<div class="rn-card rn-done" onclick="Routines._open(\'' + which + '\')">' +
+          '<div class="rn-emoji">🎉</div>' +
+          '<div class="rn-body">' +
+            '<div class="rn-title">' + heading + ' — ¡listo!</div>' +
+            '<div class="rn-sub">Racha: 🔥 ' + status.streak + ' día' + (status.streak === 1 ? '' : 's') + '</div>' +
+          '</div>' +
+          '<div class="rn-arrow">→</div>' +
+        '</div>';
+      return;
+    }
+
+    var remaining = block.total - block.doneCount;
+    el.innerHTML =
+      '<div class="rn-card" onclick="Routines._open(\'' + which + '\')">' +
+        '<div class="rn-emoji">' + (which === 'morning' ? '🌅' : '🌙') + '</div>' +
+        '<div class="rn-body">' +
+          '<div class="rn-title">' + heading + '</div>' +
+          '<div class="rn-sub">' + remaining + ' cosa' + (remaining === 1 ? '' : 's') + ' por hacer' +
+          (status.streak > 0 ? ' · 🔥 ' + status.streak : '') + '</div>' +
+          '<div class="rn-bar"><div class="rn-bar-fill" style="width:' + Math.round((block.doneCount / block.total) * 100) + '%"></div></div>' +
+        '</div>' +
+        '<div class="rn-arrow">→</div>' +
+      '</div>';
+  }
+
+  // ── Modal ──
+  function _ensureOverlay() {
+    if (document.getElementById('routines-overlay')) return;
+    var ov = document.createElement('div');
+    ov.className = 'dash-overlay';
+    ov.id = 'routines-overlay';
+    ov.onclick = function(e) { if (e.target === ov) _close(); };
+    ov.innerHTML =
+      '<div class="dash-panel" style="max-width:480px;">' +
+        '<h2 style="display:flex;align-items:center;justify-content:space-between;">' +
+          '<span id="routines-title">Routine</span>' +
+          '<button class="dash-close" onclick="Routines._close()" aria-label="Cerrar">✕</button>' +
+        '</h2>' +
+        '<div id="routines-body"></div>' +
+      '</div>';
+    document.body.appendChild(ov);
+  }
+
+  function _open(which) {
+    _ensureOverlay();
+    _renderModal(which);
+    var ov = document.getElementById('routines-overlay');
+    if (ov) ov.classList.add('active');
+  }
+
+  function _close() {
+    var ov = document.getElementById('routines-overlay');
+    if (ov) ov.classList.remove('active');
+  }
+
+  function _renderModal(which) {
+    var status = getStatus();
+    var block = which === 'morning' ? status.morning : status.evening;
+    var title = which === 'morning' ? '🌅 Rutina de la mañana' : '🌙 Rutina de la noche';
+    var other = which === 'morning' ? 'evening' : 'morning';
+    var otherLabel = which === 'morning' ? '🌙 Noche' : '🌅 Mañana';
+
+    var titleEl = document.getElementById('routines-title');
+    if (titleEl) titleEl.textContent = title;
+
+    var body = document.getElementById('routines-body');
+    if (!body) return;
+
+    var progressPct = Math.round((block.doneCount / block.total) * 100);
+    var streakLine = status.streak > 0
+      ? '<div class="rn-streak">🔥 Racha de ' + status.streak + ' día' + (status.streak === 1 ? '' : 's') +
+        (status.bestStreak > status.streak ? ' · Mejor: ' + status.bestStreak : '') + '</div>'
+      : '<div class="rn-streak rn-streak-empty">Completa ambas rutinas para empezar una racha</div>';
+
+    var itemsHtml = block.items.map(function(it) {
+      return '<label class="rn-item ' + (it.done ? 'rn-done-item' : '') + '">' +
+        '<input type="checkbox" ' + (it.done ? 'checked' : '') + ' ' +
+               'onchange="Routines._toggle(\'' + which + '\', \'' + it.id + '\')">' +
+        '<span class="rn-item-label">' + it.label + '</span>' +
+      '</label>';
+    }).join('');
+
+    body.innerHTML =
+      streakLine +
+      '<div class="rn-progress">' +
+        '<div class="rn-progress-text">' + block.doneCount + ' / ' + block.total + '</div>' +
+        '<div class="rn-progress-bar"><div class="rn-progress-fill" style="width:' + progressPct + '%"></div></div>' +
+      '</div>' +
+      '<div class="rn-list">' + itemsHtml + '</div>' +
+      '<div class="rn-switch">' +
+        '<button class="hub-action-btn secondary" onclick="Routines._open(\'' + other + '\')">' +
+          'Ver ' + otherLabel +
+        '</button>' +
+      '</div>';
+  }
+
+  function _toggle(which, id) {
+    toggle(which, id);
+    _renderModal(which);
+    renderHubWidget('routines-widget');
+  }
+
+  return {
+    getStatus: getStatus,
+    getActiveRoutine: getActiveRoutine,
+    toggle: toggle,
+    renderHubWidget: renderHubWidget,
+    _open: _open,
+    _close: _close,
+    _toggle: _toggle
+  };
+})();


### PR DESCRIPTION
New `js/routines.js` renders a small card on the hub showing the day's active routine (morning before 14:00, evening after) with a progress bar and a streak counter. Tapping opens a modal to check items off.

### Scope choices
- **Separate from the existing Chores/Token system**: this builds habit, not screen-time currency. No token reward in v1.
- Morning and evening templates hardcoded; a Parents Corner editor is a v2 follow-up.
- **Streak** increments when *both* routines hit 100% for the same day consecutively. Breaks if a day ends without a full set.
- **Self-report** — no PIN to check items off. Parents can spot-audit.
- Storage: `zs_routines_<userkey>` (per-kid, local only). Activity log records every "Day complete" event.

### Hub integration
- New mount point `#routines-widget` rendered during `showHub`, below the calendar widget and above Next Challenge.

### Flag for review
Streak window is calendar-day local time — a kid traveling across timezones will see a reset/continuation matching device local time, not the trip.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_