### PR TITLE
Add Routines editor to Parents Corner

### DIFF
--- a/css/routines.css
+++ b/css/routines.css
@@ -142,3 +142,88 @@
 
 .rn-switch { text-align: center; margin-top: 12px; }
 .rn-switch button { padding: 10px 18px !important; font-size: 0.85rem; }
+
+/* ============================================================
+   PARENTS CORNER — Routines editor
+   ============================================================ */
+.rn-ed-block {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 12px;
+  padding: 10px 12px;
+  margin-top: 8px;
+}
+.rn-ed-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  font-weight: 800;
+  color: var(--text);
+  margin-bottom: 8px;
+}
+.rn-ed-reset {
+  padding: 4px 10px;
+  border-radius: 99px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.04);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.rn-ed-reset:hover { color: var(--text); border-color: rgba(255,255,255,0.25); }
+
+.rn-ed-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+.rn-ed-label, .rn-ed-add input {
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.2);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  outline: none;
+  transition: border-color 0.2s;
+}
+.rn-ed-label:focus, .rn-ed-add input:focus { border-color: #60A5FA; }
+
+.rn-ed-del {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid rgba(248,113,113,0.2);
+  background: rgba(248,113,113,0.08);
+  color: #F87171;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.rn-ed-del:hover { background: rgba(248,113,113,0.2); }
+
+.rn-ed-add { margin-top: 6px; }
+.rn-ed-add-btn {
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid rgba(52,211,153,0.25);
+  background: rgba(52,211,153,0.08);
+  color: #34D399;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+.rn-ed-add-btn:hover { background: rgba(52,211,153,0.18); }

--- a/js/index.js
+++ b/js/index.js
@@ -104,6 +104,10 @@
   window.redeemForTime = function() { redeemForTime(); };
   window.updateKidChess = function(idx, val) { updateKidChess(idx, val); };
   window.updateKidFaith = function(idx, val) { updateKidFaith(idx, val); };
+  window.addRoutineItem = function(idx, which) { addRoutineItem(idx, which); };
+  window.updateRoutineItem = function(idx, which, j, val) { updateRoutineItem(idx, which, j, val); };
+  window.removeRoutineItem = function(idx, which, j) { removeRoutineItem(idx, which, j); };
+  window.resetRoutine = function(idx, which) { resetRoutine(idx, which); };
   window.updateKidTts = function(idx, field, val) {
     if (typeof ZsTTS === 'undefined') return;
     var profiles = getProfiles();
@@ -1054,6 +1058,7 @@
                          'style="width:100%;">' +
                 '</div>'
               ) : '') +
+              (typeof Routines !== 'undefined' ? _renderRoutinesEditor(p, i) : '') +
             '</div>';
         }).join('') +
       '</div>' +
@@ -1131,6 +1136,89 @@
     profiles[idx].faithVisible = checked;
     saveProfiles(profiles);
     renderAppCards();
+  }
+
+  function _renderRoutinesEditor(profile, idx) {
+    var tpls = Routines.getTemplates(profile.name);
+    function block(which, icon, label) {
+      var items = tpls[which];
+      var rows = items.map(function(it, j) {
+        return '<div class="rn-ed-row" data-which="' + which + '" data-j="' + j + '">' +
+          '<input type="text" class="rn-ed-label" value="' + escHtml(it.label) + '" ' +
+                 'maxlength="80" data-which="' + which + '" data-idx="' + idx + '" data-j="' + j + '" ' +
+                 'oninput="updateRoutineItem(' + idx + ', \'' + which + '\', ' + j + ', this.value)" />' +
+          '<button type="button" class="rn-ed-del" onclick="removeRoutineItem(' + idx + ', \'' + which + '\', ' + j + ')" aria-label="Remove">✕</button>' +
+        '</div>';
+      }).join('');
+      return '<div class="rn-ed-block">' +
+        '<div class="rn-ed-head">' +
+          '<span>' + icon + ' ' + label + '</span>' +
+          '<button type="button" class="rn-ed-reset" onclick="resetRoutine(' + idx + ', \'' + which + '\')" title="Restaurar valores por defecto">↻ Default</button>' +
+        '</div>' +
+        rows +
+        '<div class="rn-ed-row rn-ed-add">' +
+          '<input type="text" id="rn-add-' + which + '-' + idx + '" placeholder="Nueva tarea…" maxlength="80" ' +
+                 'onkeydown="if(event.key===\'Enter\'){event.preventDefault();addRoutineItem(' + idx + ', \'' + which + '\');}" />' +
+          '<button type="button" class="rn-ed-add-btn" onclick="addRoutineItem(' + idx + ', \'' + which + '\')">＋ Añadir</button>' +
+        '</div>' +
+      '</div>';
+    }
+    return '<div class="pk-setting" style="margin-top:16px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.06);">' +
+      '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">📋 Rutinas</label>' +
+      block('morning', '🌅', 'Mañana') +
+      block('evening', '🌙', 'Noche') +
+    '</div>';
+  }
+
+  function addRoutineItem(idx, which) {
+    if (typeof Routines === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    var input = document.getElementById('rn-add-' + which + '-' + idx);
+    if (!input) return;
+    var val = input.value.trim();
+    if (!val) return;
+    var tpl = Routines.getTemplates(name)[which];
+    tpl.push({ id: 'c_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 5), label: val });
+    Routines.setTemplate(which, tpl, name);
+    input.value = '';
+    renderParentsCorner();
+  }
+
+  function updateRoutineItem(idx, which, j, val) {
+    if (typeof Routines === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    var tpl = Routines.getTemplates(name)[which];
+    if (!tpl[j]) return;
+    tpl[j].label = String(val).slice(0, 80);
+    Routines.setTemplate(which, tpl, name);
+    // Don't re-render on every keystroke — the input is already live.
+  }
+
+  function removeRoutineItem(idx, which, j) {
+    if (typeof Routines === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    var tpl = Routines.getTemplates(name)[which];
+    if (!tpl[j]) return;
+    if (tpl.length <= 1) { alert('Deja al menos una tarea en esta rutina.'); return; }
+    tpl.splice(j, 1);
+    Routines.setTemplate(which, tpl, name);
+    renderParentsCorner();
+  }
+
+  function resetRoutine(idx, which) {
+    if (typeof Routines === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    if (!confirm('¿Restaurar la rutina de la ' + (which === 'morning' ? 'mañana' : 'noche') + ' a los valores por defecto?')) return;
+    Routines.resetTemplate(which, name);
+    renderParentsCorner();
   }
 
   function updateParentPin() {

--- a/js/routines.js
+++ b/js/routines.js
@@ -90,30 +90,87 @@ var Routines = (function() {
     return day;
   }
 
+  // Returns the effective template for a routine. Priority:
+  //   1. Kid-specific override stored under data.templates.<which>
+  //   2. The hardcoded DEFAULTS.<which>
+  // Templates are arrays of { id, label } — same shape as DEFAULTS.
+  function _getTemplate(data, which) {
+    if (data && data.templates && Array.isArray(data.templates[which]) && data.templates[which].length > 0) {
+      return data.templates[which];
+    }
+    return DEFAULTS[which];
+  }
+
+  function getTemplates(userName) {
+    // Used by the Parents Corner editor.
+    var data;
+    if (userName) {
+      var k = STORAGE_PREFIX + userName.toLowerCase().replace(/\s+/g, '_');
+      try { data = JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { data = {}; }
+    } else {
+      data = _load() || {};
+    }
+    return {
+      morning: _getTemplate(data, 'morning').slice(),
+      evening: _getTemplate(data, 'evening').slice()
+    };
+  }
+
+  function setTemplate(which, items, userName) {
+    if (which !== 'morning' && which !== 'evening') return;
+    var k = userName
+      ? STORAGE_PREFIX + userName.toLowerCase().replace(/\s+/g, '_')
+      : _storageKey();
+    if (!k) return;
+    var data;
+    try { data = JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { data = {}; }
+    if (!data.templates) data.templates = {};
+    data.templates[which] = items.map(function(it, i) {
+      return {
+        id: it && it.id ? String(it.id) : 'custom_' + i + '_' + Date.now().toString(36),
+        label: String(it && it.label ? it.label : '').slice(0, 80)
+      };
+    }).filter(function(it) { return it.label.length > 0; });
+    try { localStorage.setItem(k, JSON.stringify(data)); } catch (e) {}
+  }
+
+  function resetTemplate(which, userName) {
+    var k = userName
+      ? STORAGE_PREFIX + userName.toLowerCase().replace(/\s+/g, '_')
+      : _storageKey();
+    if (!k) return;
+    var data;
+    try { data = JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { data = {}; }
+    if (data.templates) delete data.templates[which];
+    try { localStorage.setItem(k, JSON.stringify(data)); } catch (e) {}
+  }
+
   function getStatus() {
     var data = _load();
     if (!data) return null;
     var today = _today();
     var day = _getDay(data, today);
+    var morningTpl = _getTemplate(data, 'morning');
+    var eveningTpl = _getTemplate(data, 'evening');
     return {
       date: today,
       streak: data.streak,
       bestStreak: data.bestStreak,
       morning: {
-        items: DEFAULTS.morning.map(function(c) {
+        items: morningTpl.map(function(c) {
           return { id: c.id, label: c.label, done: day.morning.indexOf(c.id) !== -1 };
         }),
         doneCount: day.morning.length,
-        total: DEFAULTS.morning.length,
-        complete: day.morning.length >= DEFAULTS.morning.length
+        total: morningTpl.length,
+        complete: day.morning.length >= morningTpl.length
       },
       evening: {
-        items: DEFAULTS.evening.map(function(c) {
+        items: eveningTpl.map(function(c) {
           return { id: c.id, label: c.label, done: day.evening.indexOf(c.id) !== -1 };
         }),
         doneCount: day.evening.length,
-        total: DEFAULTS.evening.length,
-        complete: day.evening.length >= DEFAULTS.evening.length
+        total: eveningTpl.length,
+        complete: day.evening.length >= eveningTpl.length
       }
     };
   }
@@ -126,9 +183,10 @@ var Routines = (function() {
     var day = _getDay(data, today);
     var list = day[routine];
     var idx = list.indexOf(itemId);
+    var tpl = _getTemplate(data, routine);
     if (idx === -1) {
-      // Don't add ids that aren't in the template (defence).
-      var isKnown = DEFAULTS[routine].some(function(c) { return c.id === itemId; });
+      // Don't add ids that aren't in the active template (defence).
+      var isKnown = tpl.some(function(c) { return c.id === itemId; });
       if (!isKnown) return getStatus();
       list.push(itemId);
     } else {
@@ -136,8 +194,10 @@ var Routines = (function() {
     }
 
     // Update streak when BOTH routines hit 100% for the day.
-    var bothDone = day.morning.length >= DEFAULTS.morning.length &&
-                   day.evening.length >= DEFAULTS.evening.length;
+    var morningTpl = _getTemplate(data, 'morning');
+    var eveningTpl = _getTemplate(data, 'evening');
+    var bothDone = day.morning.length >= morningTpl.length &&
+                   day.evening.length >= eveningTpl.length;
     if (bothDone && data.lastFullDay !== today) {
       if (data.lastFullDay === _yesterday()) {
         data.streak = (data.streak || 0) + 1;
@@ -281,6 +341,10 @@ var Routines = (function() {
     getActiveRoutine: getActiveRoutine,
     toggle: toggle,
     renderHubWidget: renderHubWidget,
+    getTemplates: getTemplates,
+    setTemplate: setTemplate,
+    resetTemplate: resetTemplate,
+    DEFAULTS: DEFAULTS,
     _open: _open,
     _close: _close,
     _toggle: _toggle


### PR DESCRIPTION
Closes the v2 follow-up flagged when shipping #196 (daily routines). Parents can now customise each kid's morning and evening routine without touching code.

### New public API on `Routines`
- `getTemplates(userName)` → `{ morning: [...], evening: [...] }`
- `setTemplate(which, items, userName)`
- `resetTemplate(which, userName)`

Backwards compatible: internal `_getTemplate(data, which)` falls back to hardcoded DEFAULTS when no override is stored, so existing kids keep the same routines until a parent edits them.

### Parents Corner
Each kid card gains a **📋 Rutinas** block:
- Two stacked editors (🌅 Mañana + 🌙 Noche)
- Inline text edit + ✕ remove on every row
- "+ Añadir" row at the bottom, Enter-to-add keyboard shortcut
- "↻ Default" button per routine restores the canned list
- Enforces at least one item per routine (alert on last delete)

### Storage
Stays in the existing `zs_routines_<userkey>` blob under a new `.templates` key. No migration needed.

### Flag for review
No emoji picker — parents type the labels as free text (including any emoji). Keeps the editor fast; kid-visible labels still look good since the existing defaults are the reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_