### PR TITLE
Add Family Sunday Report PDF (#178)

### DIFF
--- a/css/sunday-report.css
+++ b/css/sunday-report.css
@@ -1,0 +1,257 @@
+/* ============================================================
+   FAMILY SUNDAY REPORT
+   ============================================================ */
+
+.sr-body {
+  background: #2a2040;
+  min-height: 100vh;
+  padding: 24px;
+  font-family: var(--font-body, 'Nunito', sans-serif);
+  display: block;
+}
+.sr-body::before { display: none; }
+
+.sr-toolbar {
+  max-width: 880px;
+  margin: 0 auto 18px;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.sr-tb-btn {
+  padding: 10px 18px;
+  border-radius: 12px;
+  background: rgba(255,255,255,0.08);
+  border: 1.5px solid rgba(255,255,255,0.12);
+  color: #F0EDFF;
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-decoration: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.2s;
+}
+.sr-tb-btn:hover { background: rgba(255,255,255,0.14); }
+.sr-tb-btn.primary {
+  background: linear-gradient(135deg, #7C3AED, #A78BFA);
+  border-color: transparent;
+  color: #fff;
+}
+
+.sr-sheet {
+  max-width: 880px;
+  margin: 0 auto;
+  background: linear-gradient(180deg, #FFFAF0, #FFF8E7);
+  color: #1f1934;
+  padding: 36px 40px;
+  border-radius: 16px;
+  box-shadow: 0 30px 80px -30px rgba(0,0,0,0.5);
+}
+
+.sr-header {
+  text-align: center;
+  border-bottom: 2px solid rgba(201,164,73,0.35);
+  padding-bottom: 14px;
+  margin-bottom: 24px;
+}
+.sr-title {
+  font-family: 'Baloo 2', cursive;
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  font-weight: 800;
+  color: #1f1934;
+  line-height: 1.1;
+}
+.sr-subtitle {
+  font-size: 0.95rem;
+  color: #6b5a82;
+  font-style: italic;
+  font-weight: 700;
+  margin-top: 4px;
+}
+.sr-dates {
+  display: inline-block;
+  padding: 4px 14px;
+  margin-top: 8px;
+  border-radius: 99px;
+  background: rgba(201,164,73,0.15);
+  color: #7a2a2a;
+  font-family: 'Baloo 2', cursive;
+  font-weight: 700;
+  font-size: 0.95rem;
+}
+
+.sr-family {
+  background: rgba(201,164,73,0.08);
+  border: 1px solid rgba(201,164,73,0.25);
+  border-radius: 14px;
+  padding: 18px 20px;
+  margin-bottom: 24px;
+}
+.sr-family h2 {
+  font-family: 'Baloo 2', cursive;
+  font-size: 1.15rem;
+  font-weight: 800;
+  color: #1f1934;
+  margin-bottom: 10px;
+}
+.sr-family-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+.sr-family-stat {
+  text-align: center;
+}
+.sr-family-stat .num {
+  font-family: 'Baloo 2', cursive;
+  font-size: 1.9rem;
+  font-weight: 800;
+  color: #7a2a2a;
+  line-height: 1;
+}
+.sr-family-stat .lbl {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #6b5a82;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-top: 4px;
+}
+.sr-family-highlight {
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: rgba(122,42,42,0.06);
+  border-radius: 10px;
+  font-weight: 700;
+  color: #1f1934;
+  font-size: 0.92rem;
+  text-align: center;
+}
+
+/* Per-kid card */
+.sr-kid {
+  border: 1.5px solid rgba(201,164,73,0.28);
+  border-radius: 14px;
+  padding: 18px 20px;
+  margin-bottom: 18px;
+  page-break-inside: avoid;
+  break-inside: avoid;
+}
+.sr-kid-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 12px;
+}
+.sr-kid-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 26px;
+  border: 2.5px solid;
+  flex-shrink: 0;
+}
+.sr-kid-name {
+  font-family: 'Baloo 2', cursive;
+  font-size: 1.25rem;
+  font-weight: 800;
+  color: #1f1934;
+}
+.sr-kid-rank {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #6b5a82;
+}
+.sr-kid-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.sr-stat-pill {
+  background: rgba(201,164,73,0.08);
+  border: 1px solid rgba(201,164,73,0.18);
+  border-radius: 10px;
+  padding: 10px 8px;
+  text-align: center;
+}
+.sr-stat-pill .num {
+  font-family: 'Baloo 2', cursive;
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #7a2a2a;
+  line-height: 1;
+}
+.sr-stat-pill .lbl {
+  font-size: 0.7rem;
+  color: #6b5a82;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-top: 4px;
+}
+
+.sr-moments {
+  margin-top: 8px;
+}
+.sr-moments h3 {
+  font-family: 'Baloo 2', cursive;
+  font-size: 0.95rem;
+  font-weight: 800;
+  color: #1f1934;
+  margin-bottom: 6px;
+}
+.sr-moment {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: #3c3256;
+  padding: 4px 0;
+  border-top: 1px dashed rgba(201,164,73,0.25);
+}
+.sr-moment:first-child { border-top: none; }
+.sr-moment .ic { flex-shrink: 0; width: 20px; text-align: center; }
+.sr-moment .ds { flex: 1; min-width: 0; }
+.sr-moment .ts { color: #6b5a82; font-weight: 700; font-size: 0.78rem; flex-shrink: 0; }
+
+.sr-kid-empty {
+  font-size: 0.9rem;
+  color: #6b5a82;
+  font-style: italic;
+  text-align: center;
+  padding: 14px 0;
+}
+
+.sr-footer {
+  margin-top: 20px;
+  text-align: center;
+  font-size: 0.78rem;
+  color: #6b5a82;
+  font-weight: 700;
+  font-style: italic;
+}
+
+/* Print */
+@page { size: letter portrait; margin: 12mm; }
+@media print {
+  body.sr-body { background: #fff !important; padding: 0 !important; }
+  .no-print { display: none !important; }
+  .sr-sheet { box-shadow: none; max-width: none; margin: 0; padding: 0; border-radius: 0; background: #fff !important; }
+  .sr-kid, .sr-family { background: #fff; }
+  .sr-body { color: #000; }
+}
+
+@media (max-width: 640px) {
+  .sr-body { padding: 12px; }
+  .sr-sheet { padding: 20px 18px; border-radius: 12px; }
+  .sr-family-stats { grid-template-columns: repeat(2, 1fr); }
+  .sr-kid-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/index.html
+++ b/index.html
@@ -262,6 +262,9 @@
       <h2 style="display:flex; justify-content:space-between; align-items:center;">
         <span>👨‍👩‍👧‍👦 Parent Dashboard</span>
         <div style="display:flex; gap:12px; align-items:center;">
+          <a href="sunday-report.html" target="_blank" rel="noopener" class="hub-action-btn secondary" style="padding:8px 14px; font-size:0.8rem; margin:0; text-decoration:none; display:inline-flex; align-items:center; gap:6px;">
+            📄 Sunday Report
+          </a>
           <button class="hub-action-btn secondary" style="padding:8px 14px; font-size:0.8rem; margin:0;" onclick="exportProgress()">
             📥 Export
           </button>

--- a/js/sunday-report.js
+++ b/js/sunday-report.js
@@ -1,0 +1,245 @@
+/* ================================================================
+   FAMILY SUNDAY REPORT — sunday-report.js
+   Reads ActivityLog, getPlayerStats, Routines, and profile data to
+   produce a weekly family summary optimised for printing.
+
+   Pure read-only: no writes to localStorage, no network calls.
+   Query params:
+     ?week=YYYY-MM-DD  Monday anchor; default = this week (local time)
+   ================================================================ */
+
+var SundayReport = (function() {
+  'use strict';
+
+  var APP_LABELS = {
+    math: 'Math Galaxy', chile: 'Descubre Chile', chess: 'Chess Quest',
+    piano: 'Little Maestro', faith: 'Fe Explorador', guitar: 'Guitar Jam',
+    art: 'Art Studio', sports: 'Sports Arena', lab: 'Lab Explorer',
+    world: 'World Explorer', story: 'Story Explorer', guess: 'Guess Quest',
+    quest: 'Quest Adventure', bmcheck: 'Book & Movie Check',
+    Routines: 'Routines'
+  };
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function _getParam(k) {
+    var m = window.location.search.match(new RegExp('[?&]' + k + '=([^&]*)'));
+    return m ? decodeURIComponent(m[1]) : null;
+  }
+
+  function _mondayAnchor(d) {
+    // Return the Monday of the week containing d (local time).
+    var day = d.getDay(); // 0=Sun, 1=Mon, ... 6=Sat
+    var offset = (day === 0 ? -6 : 1 - day);
+    var m = new Date(d.getFullYear(), d.getMonth(), d.getDate() + offset);
+    m.setHours(0, 0, 0, 0);
+    return m;
+  }
+
+  function _weekBounds() {
+    var param = _getParam('week');
+    var base;
+    if (param && /^\d{4}-\d{2}-\d{2}$/.test(param)) {
+      var parts = param.split('-');
+      base = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
+    } else {
+      base = new Date();
+    }
+    var from = _mondayAnchor(base);
+    var to = new Date(from.getTime() + 7 * 24 * 3600 * 1000 - 1);
+    return { from: from, to: to };
+  }
+
+  function _fmtDate(d) {
+    var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+    return months[d.getMonth()] + ' ' + d.getDate();
+  }
+
+  function _fmtDateRange(from, to) {
+    return _fmtDate(from) + ' – ' + _fmtDate(to) + ', ' + to.getFullYear();
+  }
+
+  function _timeOfDayLabel(ts) {
+    var d = new Date(ts);
+    var m = d.getMonth() + 1;
+    return (d.getDate()) + '/' + m;
+  }
+
+  function _kidStats(name, weekFromMs, weekToMs) {
+    var nameKey = name.toLowerCase().replace(/\s+/g, '_');
+    var playerStats = typeof getPlayerStats === 'function' ? getPlayerStats(name) : { totalStars: 0, appStats: {} };
+    var activity = typeof ActivityLog !== 'undefined' && ActivityLog.getRecent
+      ? ActivityLog.getRecent(name, 14)
+      : [];
+    // Filter to the specific week
+    var weekActivity = activity.filter(function(e) {
+      return e && e.ts >= weekFromMs && e.ts <= weekToMs;
+    });
+
+    // Count events per app for the week
+    var appCounts = {};
+    weekActivity.forEach(function(e) {
+      var app = e.app || 'Other';
+      appCounts[app] = (appCounts[app] || 0) + 1;
+    });
+    var topApps = Object.keys(appCounts)
+      .sort(function(a, b) { return appCounts[b] - appCounts[a]; })
+      .slice(0, 3)
+      .map(function(app) { return { app: app, count: appCounts[app] }; });
+
+    // Routines streak
+    var routineStreak = 0;
+    try {
+      var rk = 'zs_routines_' + nameKey;
+      var raw = localStorage.getItem(rk);
+      if (raw) {
+        var rd = JSON.parse(raw);
+        if (rd && typeof rd.streak === 'number') routineStreak = rd.streak;
+      }
+    } catch (e) {}
+
+    // Top 3 activity highlights — spread across apps when possible
+    var seenApps = {};
+    var highlights = [];
+    weekActivity.forEach(function(e) {
+      if (highlights.length >= 4) return;
+      var tag = e.app + '|' + (e.desc || '').slice(0, 40);
+      if (seenApps[tag]) return;
+      seenApps[tag] = true;
+      highlights.push(e);
+    });
+
+    // Total events this week
+    var totalEvents = weekActivity.length;
+
+    // Rank
+    var rank = typeof getExplorerRank === 'function'
+      ? getExplorerRank(name, playerStats)
+      : { icon: '🛸', name: 'Cadet' };
+
+    return {
+      totalStars: playerStats.totalStars,
+      rank: rank,
+      totalEvents: totalEvents,
+      topApps: topApps,
+      routineStreak: routineStreak,
+      highlights: highlights
+    };
+  }
+
+  function _render() {
+    var bounds = _weekBounds();
+    var weekFromMs = bounds.from.getTime();
+    var weekToMs = bounds.to.getTime();
+    var profiles = typeof getProfiles === 'function' ? getProfiles() : [];
+    var content = document.getElementById('sr-content');
+    if (!content) return;
+
+    if (!profiles || profiles.length === 0) {
+      content.innerHTML = '<div class="sr-sheet"><div class="sr-kid-empty">No profiles found yet. Add a kid in the hub first.</div></div>';
+      return;
+    }
+
+    var kidBlocks = '';
+    var familyStars = 0;
+    var familyEvents = 0;
+    var bestStreak = { name: '', streak: 0 };
+
+    profiles.forEach(function(p) {
+      var stats = _kidStats(p.name, weekFromMs, weekToMs);
+      familyStars += stats.totalStars;
+      familyEvents += stats.totalEvents;
+      if (stats.routineStreak > bestStreak.streak) {
+        bestStreak = { name: p.name, streak: stats.routineStreak };
+      }
+
+      var color = typeof safeColor === 'function' ? safeColor(p.color) : (p.color || '#7C3AED');
+      var appLines = stats.topApps.map(function(a) {
+        var label = APP_LABELS[a.app] || a.app;
+        return '<div class="sr-moment"><span class="ic">•</span><span class="ds">' + _esc(label) + '</span><span class="ts">' + a.count + '×</span></div>';
+      }).join('');
+
+      var highlightLines = stats.highlights.map(function(h) {
+        return '<div class="sr-moment">' +
+          '<span class="ic">' + _esc(h.icon || '⭐') + '</span>' +
+          '<span class="ds">' + _esc((h.desc || '').slice(0, 80)) + '</span>' +
+          '<span class="ts">' + _timeOfDayLabel(h.ts) + '</span>' +
+        '</div>';
+      }).join('');
+
+      var body;
+      if (stats.totalEvents === 0 && stats.totalStars === 0) {
+        body = '<div class="sr-kid-empty">No recorded activity this week — a gentle nudge for next week!</div>';
+      } else {
+        body =
+          '<div class="sr-kid-grid">' +
+            '<div class="sr-stat-pill"><div class="num">⭐ ' + stats.totalStars + '</div><div class="lbl">Total stars</div></div>' +
+            '<div class="sr-stat-pill"><div class="num">' + stats.totalEvents + '</div><div class="lbl">This week</div></div>' +
+            '<div class="sr-stat-pill"><div class="num">🔥 ' + stats.routineStreak + '</div><div class="lbl">Routine streak</div></div>' +
+            '<div class="sr-stat-pill"><div class="num">' + stats.rank.icon + '</div><div class="lbl">' + _esc(stats.rank.name) + '</div></div>' +
+          '</div>' +
+          (appLines ? '<div class="sr-moments"><h3>Most active apps</h3>' + appLines + '</div>' : '') +
+          (highlightLines ? '<div class="sr-moments"><h3>Highlights</h3>' + highlightLines + '</div>' : '');
+      }
+
+      kidBlocks +=
+        '<div class="sr-kid">' +
+          '<div class="sr-kid-head">' +
+            '<div class="sr-kid-avatar" style="background:' + color + '22;border-color:' + color + ';">' + _esc(p.avatar || '🦊') + '</div>' +
+            '<div>' +
+              '<div class="sr-kid-name">' + _esc(p.name) + (p.age ? ' · ' + p.age + ' yrs' : '') + '</div>' +
+              '<div class="sr-kid-rank">' + stats.rank.icon + ' ' + _esc(stats.rank.name) + '</div>' +
+            '</div>' +
+          '</div>' +
+          body +
+        '</div>';
+    });
+
+    // Family highlight sentence
+    var highlight;
+    if (bestStreak.streak > 0) {
+      highlight = '🔥 Longest routine streak this week: <b>' + _esc(bestStreak.name) + '</b> with ' + bestStreak.streak + ' day' + (bestStreak.streak === 1 ? '' : 's') + '.';
+    } else if (familyEvents > 0) {
+      highlight = 'A busy week across the suite. Keep it going!';
+    } else {
+      highlight = 'A quieter week — consider trying a new app together.';
+    }
+
+    content.innerHTML =
+      '<div class="sr-sheet">' +
+        '<div class="sr-header">' +
+          '<div class="sr-title">👨‍👩‍👧‍👦 Family Sunday Report</div>' +
+          '<div class="sr-subtitle">Zavala · Serra</div>' +
+          '<div class="sr-dates">' + _fmtDateRange(bounds.from, bounds.to) + '</div>' +
+        '</div>' +
+        '<div class="sr-family">' +
+          '<h2>This week in one glance</h2>' +
+          '<div class="sr-family-stats">' +
+            '<div class="sr-family-stat"><div class="num">⭐ ' + familyStars + '</div><div class="lbl">Family stars</div></div>' +
+            '<div class="sr-family-stat"><div class="num">' + familyEvents + '</div><div class="lbl">Recorded events</div></div>' +
+            '<div class="sr-family-stat"><div class="num">👧👦 ' + profiles.length + '</div><div class="lbl">Explorers</div></div>' +
+          '</div>' +
+          '<div class="sr-family-highlight">' + highlight + '</div>' +
+        '</div>' +
+        kidBlocks +
+        '<div class="sr-footer">Generated ' + new Date().toLocaleString() + ' · Print to stick on the fridge.</div>' +
+      '</div>';
+
+    document.title = 'Family Sunday Report — ' + _fmtDateRange(bounds.from, bounds.to);
+  }
+
+  function print() { window.print(); }
+  function refresh() { _render(); }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _render);
+  } else {
+    _render();
+  }
+
+  return { print: print, refresh: refresh };
+})();

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Family Sunday Report 👨‍👩‍👧‍👦</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/sunday-report.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body class="sr-body">
+  <div class="sr-toolbar no-print">
+    <a href="index.html" class="sr-tb-btn">🏠 Home</a>
+    <button class="sr-tb-btn" onclick="SundayReport.refresh()">🔄 Refresh</button>
+    <button class="sr-tb-btn primary" onclick="SundayReport.print()">🖨 Print</button>
+  </div>
+  <div id="sr-content"></div>
+
+  <script src="js/debug.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/activity-log.js"></script>
+  <script src="js/routines.js"></script>
+  <script src="js/sunday-report.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Printable weekly family summary designed for the fridge.

### What it shows
**Family section** (top of the sheet):
- Combined stars across all kids
- Total recorded events for the week
- Explorer count
- One-line highlight sentence (longest routine streak, or a fallback)

**Per-kid section** (one block each, page-break-safe):
- Avatar, name, age, current Explorer Rank
- Four stat pills: total stars · this-week events · routine streak · rank icon
- Most active apps (top 3 by event count this week)
- Highlights (up to 4 recent ActivityLog entries this week)
- Graceful "no activity" state for quieter weeks

### Files
- `sunday-report.html` — standalone page
- `css/sunday-report.css` — warm, cream-and-burgundy print styling with @page letter portrait
- `js/sunday-report.js` — read-only aggregator

### Data sources
All read-only, no new storage:
`getProfiles()`, `getPlayerStats()`, `ActivityLog.getRecent()`, `zs_routines_<user>.streak`, `getExplorerRank()`.

### Integration
Parent Dashboard header gains a **📄 Sunday Report** link that opens the report in a new tab. The report accepts `?week=YYYY-MM-DD` to render a specific week's Monday anchor (useful for archives / past weeks).

### Flag for review
Week boundary is local-time Monday. Kids in different timezones still aggregate against the household's device clock.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_