### PR TITLE
Add Lab Explorer — Weather Station module (#174)

### DIFF
--- a/css/lab-explorer.css
+++ b/css/lab-explorer.css
@@ -154,3 +154,79 @@ body {
 }
 .feedback.active { opacity: 1; transform: translate(-50%, -50%) scale(1); }
 .feedback-emoji { font-size: 8rem; }
+
+/* ============================================================
+   WEATHER STATION LAB
+   ============================================================ */
+.wx-form { display: flex; flex-direction: column; gap: 14px; }
+.wx-date {
+  align-self: center;
+  padding: 4px 14px; border-radius: 99px;
+  background: rgba(96,165,250,0.15); color: #60A5FA;
+  font-family: var(--font-display); font-weight: 800; font-size: 0.9rem;
+}
+.wx-group { display: flex; flex-direction: column; gap: 6px; }
+.wx-grp-title { font-weight: 800; font-size: 0.85rem; color: var(--text); }
+.wx-chips { display: flex; gap: 6px; flex-wrap: wrap; }
+.wx-chips-col { flex-direction: column; }
+.wx-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 12px; border-radius: 99px;
+  background: rgba(255,255,255,0.05);
+  border: 1.5px solid rgba(255,255,255,0.1);
+  color: var(--text, #F0EDFF);
+  font-family: var(--font-body); font-size: 0.82rem; font-weight: 700;
+  cursor: pointer; transition: all 0.15s;
+}
+.wx-chip:hover { border-color: rgba(96,165,250,0.45); }
+.wx-chip.sel {
+  background: rgba(96,165,250,0.18); border-color: #60A5FA;
+  box-shadow: 0 0 0 2px rgba(96,165,250,0.25);
+}
+.wx-chip-ic { font-size: 1.1rem; }
+.wx-wind { justify-content: flex-start; }
+.wx-temp {
+  padding: 10px 12px; border-radius: 10px;
+  border: 1.5px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.2); color: var(--text, #F0EDFF);
+  font-family: var(--font-body); font-size: 1rem; font-weight: 700;
+  outline: none; max-width: 180px;
+}
+.wx-temp:focus { border-color: #60A5FA; }
+.wx-actions { display: flex; justify-content: center; margin-top: 4px; }
+.wx-actions button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+.wx-journal {
+  margin-top: 10px; padding: 12px 14px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 14px;
+}
+.wx-j-head {
+  font-weight: 800; font-family: var(--font-display);
+  font-size: 0.88rem; color: var(--text);
+  margin-bottom: 6px;
+}
+.wx-tallies { display: grid; grid-template-columns: repeat(5, 1fr); gap: 6px; margin-bottom: 4px; }
+.wx-tally {
+  display: flex; flex-direction: column; align-items: center; gap: 2px;
+  padding: 8px 4px; border-radius: 10px;
+  background: rgba(255,255,255,0.04);
+  font-size: 1rem;
+}
+.wx-tally-n { font-family: var(--font-display); font-weight: 800; color: var(--text); }
+.wx-tally-lbl { font-size: 0.68rem; color: var(--text-muted); font-weight: 700; }
+
+.wx-list { display: flex; flex-direction: column; gap: 4px; }
+.wx-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 2px;
+  border-top: 1px dashed rgba(255,255,255,0.06);
+  font-size: 0.82rem; font-weight: 600;
+}
+.wx-row:first-child { border-top: none; }
+.wx-date-sm { color: var(--text-muted); font-family: var(--font-body); font-weight: 700; min-width: 88px; }
+.wx-row-ic { font-size: 1.1rem; min-width: 48px; }
+.wx-row-txt { color: var(--text); }
+
+.wx-empty { color: var(--text-muted); font-weight: 600; font-size: 0.9rem; text-align: center; padding: 14px 8px; }

--- a/js/lab-explorer.js
+++ b/js/lab-explorer.js
@@ -66,6 +66,17 @@ const LabExplorer = (() => {
       ]
     },
     {
+      id: 'weather',
+      title: 'Weather Station',
+      icon: '☁️',
+      desc: 'Identify clouds, log the weather outside, and watch your month.',
+      category: 'earth_science',
+      ageMin: 5,
+      experiments: [
+        { id: 'log', title: 'Log Today\'s Weather', instruction: 'Observe the sky outside. Pick what you see, then tap Save.' },
+      ]
+    },
+    {
       id: 'astronomy',
       title: 'Night Sky',
       icon: '🌙',
@@ -207,9 +218,218 @@ const LabExplorer = (() => {
       _initSimpleMachinesLab();
     } else if (labId === 'magnets' && expId === 'magnetism') {
       _initMagnetsLab();
+    } else if (labId === 'weather' && expId === 'log') {
+      _initWeatherLab();
     } else {
       _renderPlaceholder(currentLab.icon + ' ' + currentLab.title);
     }
+  }
+
+  // ── Weather Station ──────────────────────────────────────────
+  // Not a canvas experiment — renders a DOM form into #exp-controls
+  // and a month-at-a-glance chart in #exp-journal. Observations live
+  // under zs_lab_<userkey>.weather.log[] as
+  //   { date:"YYYY-MM-DD", cloud:"cumulus", wind:1..5,
+  //     precip:"none|rain|snow|storm", tempC:number|null, note:"" }
+  // Cloud choices intentionally limited to the four common types so
+  // kids build recognition before nuance.
+  var _WEATHER_CLOUDS = [
+    { id: 'clear',     icon: '☀️', label: 'Clear' },
+    { id: 'cumulus',   icon: '⛅',  label: 'Cumulus (puffy)' },
+    { id: 'stratus',   icon: '🌫️', label: 'Stratus (flat grey)' },
+    { id: 'cirrus',    icon: '🌤️', label: 'Cirrus (wispy high)' },
+    { id: 'nimbus',    icon: '☁️',  label: 'Nimbus (rain)' }
+  ];
+  var _WEATHER_PRECIP = [
+    { id: 'none',  icon: '🌤️', label: 'None' },
+    { id: 'rain',  icon: '🌧️', label: 'Rain' },
+    { id: 'snow',  icon: '🌨️', label: 'Snow' },
+    { id: 'storm', icon: '⛈️', label: 'Storm' }
+  ];
+  // Simplified kid-observable Beaufort: 0=calm → 5=strong.
+  var _WEATHER_WIND = [
+    { v: 0, icon: '🍃', label: 'Calm — smoke rises straight' },
+    { v: 1, icon: '🌬️', label: 'Light — leaves rustle' },
+    { v: 2, icon: '🌬️', label: 'Breeze — flags flap' },
+    { v: 3, icon: '💨', label: 'Strong — small branches sway' },
+    { v: 4, icon: '💨', label: 'Gale — hard to walk' },
+    { v: 5, icon: '🌪️', label: 'Storm — branches break' }
+  ];
+
+  function _weatherToday() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _weatherLoad() {
+    var d = _load();
+    if (!d.weather) d.weather = { log: [] };
+    if (!Array.isArray(d.weather.log)) d.weather.log = [];
+    return d;
+  }
+
+  // In-memory pick state (reset each time the lab opens).
+  var _weatherPick = null;
+
+  function _initWeatherLab() {
+    // Blank the canvas — weather lab is DOM-only.
+    ctx.fillStyle = '#0e1f2e';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = '#60A5FA';
+    ctx.font = 'bold 24px Baloo 2';
+    ctx.textAlign = 'center';
+    ctx.fillText('☁️ ☀️ 🌧️ ⛈️', canvas.width / 2, canvas.height / 2 - 10);
+    ctx.font = 'bold 14px Nunito';
+    ctx.fillStyle = '#A8C5E8';
+    ctx.fillText('Observe the sky outside, then log it below.', canvas.width / 2, canvas.height / 2 + 20);
+
+    _weatherPick = { date: _weatherToday(), cloud: null, wind: null, precip: null, tempC: null };
+    _renderWeatherForm();
+    _renderWeatherJournal();
+    document.getElementById('next-btn').style.display = 'none';
+  }
+
+  function _renderWeatherForm() {
+    var controls = document.getElementById('exp-controls');
+    if (!controls) return;
+
+    function chips(items, field, getV, getLabel, getIcon) {
+      return items.map(function(it) {
+        var v = getV(it);
+        var sel = _weatherPick[field] === v ? ' sel' : '';
+        return '<button type="button" class="wx-chip' + sel + '" ' +
+          'onclick="LabExplorer._pickWeather(\'' + field + '\', ' + (typeof v === 'number' ? v : '\'' + v + '\'') + ')">' +
+          '<span class="wx-chip-ic">' + getIcon(it) + '</span>' +
+          '<span class="wx-chip-lbl">' + getLabel(it) + '</span>' +
+        '</button>';
+      }).join('');
+    }
+
+    var cloudChips = chips(_WEATHER_CLOUDS, 'cloud', function(c){return c.id;}, function(c){return c.label;}, function(c){return c.icon;});
+    var precipChips = chips(_WEATHER_PRECIP, 'precip', function(c){return c.id;}, function(c){return c.label;}, function(c){return c.icon;});
+    var windChips = _WEATHER_WIND.map(function(w) {
+      var sel = _weatherPick.wind === w.v ? ' sel' : '';
+      return '<button type="button" class="wx-chip wx-wind' + sel + '" onclick="LabExplorer._pickWeather(\'wind\', ' + w.v + ')">' +
+        '<span class="wx-chip-ic">' + w.icon + '</span>' +
+        '<span class="wx-chip-lbl">' + w.v + ' · ' + w.label + '</span>' +
+      '</button>';
+    }).join('');
+
+    var ready = _weatherPick.cloud && _weatherPick.precip !== null && _weatherPick.wind !== null;
+
+    controls.innerHTML =
+      '<div class="wx-form">' +
+        '<div class="wx-date">📅 ' + _weatherPick.date + '</div>' +
+        '<div class="wx-group"><div class="wx-grp-title">☁️ Clouds</div><div class="wx-chips">' + cloudChips + '</div></div>' +
+        '<div class="wx-group"><div class="wx-grp-title">💧 Precipitation</div><div class="wx-chips">' + precipChips + '</div></div>' +
+        '<div class="wx-group"><div class="wx-grp-title">🌬️ Wind (0–5)</div><div class="wx-chips wx-chips-col">' + windChips + '</div></div>' +
+        '<div class="wx-group">' +
+          '<div class="wx-grp-title">🌡️ Temperature (°C, optional)</div>' +
+          '<input type="number" id="wx-temp" class="wx-temp" min="-30" max="50" step="1" ' +
+                 'placeholder="e.g. 18" value="' + (_weatherPick.tempC != null ? _weatherPick.tempC : '') + '" ' +
+                 'oninput="LabExplorer._pickWeather(\'tempC\', this.value === \'\' ? null : parseInt(this.value,10))" />' +
+        '</div>' +
+        '<div class="wx-actions">' +
+          '<button class="action-btn btn-primary" ' + (ready ? '' : 'disabled') + ' ' +
+                  'onclick="LabExplorer._saveWeather()">💾 Save observation</button>' +
+        '</div>' +
+      '</div>';
+  }
+
+  function _renderWeatherJournal() {
+    var journal = document.getElementById('exp-journal');
+    if (!journal) return;
+    var data = _weatherLoad();
+    var log = data.weather.log.slice().sort(function(a, b) {
+      return (b.date || '').localeCompare(a.date || '');
+    });
+    if (log.length === 0) {
+      journal.innerHTML = '<p class="wx-empty">No observations yet. Pick today\'s weather above and tap Save — your log will show up here.</p>';
+      return;
+    }
+
+    // Last-30-days mini cloud-tally
+    var counts = { clear: 0, cumulus: 0, stratus: 0, cirrus: 0, nimbus: 0 };
+    var precipDays = 0;
+    var thirtyAgoMs = Date.now() - 30 * 24 * 3600 * 1000;
+    log.forEach(function(e) {
+      var t = Date.parse(e.date + 'T00:00:00');
+      if (!isFinite(t) || t < thirtyAgoMs) return;
+      if (counts[e.cloud] != null) counts[e.cloud]++;
+      if (e.precip && e.precip !== 'none') precipDays++;
+    });
+    var tallyHtml = _WEATHER_CLOUDS.map(function(c) {
+      var n = counts[c.id] || 0;
+      return '<div class="wx-tally"><span>' + c.icon + '</span><span class="wx-tally-n">' + n + '</span><span class="wx-tally-lbl">' + c.label.split(' ')[0] + '</span></div>';
+    }).join('');
+
+    var recentHtml = log.slice(0, 14).map(function(e) {
+      var cloud = _WEATHER_CLOUDS.filter(function(c){return c.id === e.cloud;})[0];
+      var precip = _WEATHER_PRECIP.filter(function(p){return p.id === e.precip;})[0];
+      var tempTxt = (e.tempC != null && !isNaN(e.tempC)) ? (' · ' + e.tempC + '°C') : '';
+      return '<div class="wx-row">' +
+        '<span class="wx-date-sm">' + e.date + '</span>' +
+        '<span class="wx-row-ic">' + (cloud ? cloud.icon : '') + (precip && precip.id !== 'none' ? ' ' + precip.icon : '') + '</span>' +
+        '<span class="wx-row-txt">wind ' + (e.wind != null ? e.wind : '–') + tempTxt + '</span>' +
+      '</div>';
+    }).join('');
+
+    journal.innerHTML =
+      '<div class="wx-journal">' +
+        '<div class="wx-j-head">📊 Last 30 days · ' + precipDays + ' rainy/snowy</div>' +
+        '<div class="wx-tallies">' + tallyHtml + '</div>' +
+        '<div class="wx-j-head" style="margin-top:10px;">📘 Recent observations</div>' +
+        '<div class="wx-list">' + recentHtml + '</div>' +
+      '</div>';
+  }
+
+  function _pickWeather(field, value) {
+    if (!_weatherPick) return;
+    _weatherPick[field] = value;
+    _renderWeatherForm();
+  }
+
+  function _saveWeather() {
+    if (!_weatherPick || !_weatherPick.cloud) return;
+    var data = _weatherLoad();
+    var today = _weatherPick.date;
+    // Replace today's entry if one exists (keeps the log tidy).
+    data.weather.log = data.weather.log.filter(function(e) { return e.date !== today; });
+    data.weather.log.push({
+      date: today,
+      cloud: _weatherPick.cloud,
+      wind: _weatherPick.wind,
+      precip: _weatherPick.precip,
+      tempC: _weatherPick.tempC,
+      ts: Date.now()
+    });
+    // Cap the log to last 120 entries to keep localStorage lean.
+    if (data.weather.log.length > 120) {
+      data.weather.log = data.weather.log
+        .sort(function(a, b) { return (a.date || '').localeCompare(b.date || ''); })
+        .slice(-120);
+    }
+
+    // Count this as one completed experiment for the existing star system.
+    var total = (data.totalStars || 0) + 1;
+    data.totalStars = total;
+    _save(data);
+
+    if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
+      var cloud = _WEATHER_CLOUDS.filter(function(c){return c.id === _weatherPick.cloud;})[0];
+      ActivityLog.log('Lab Explorer', '☁️',
+        'Logged weather: ' + (cloud ? cloud.label : _weatherPick.cloud) +
+        (_weatherPick.tempC != null ? ' · ' + _weatherPick.tempC + '°C' : ''));
+    }
+    if (typeof showConfetti === 'function') showConfetti();
+
+    // Re-render to reflect the new entry and enable Next.
+    _weatherPick = { date: _weatherToday(), cloud: null, wind: null, precip: null, tempC: null };
+    _renderWeatherForm();
+    _renderWeatherJournal();
+    document.getElementById('exp-stars').textContent = '⭐ ' + (stars + 1);
+    stars++;
+    document.getElementById('next-btn').style.display = '';
   }
 
   function _renderPlaceholder(text) {
@@ -1320,6 +1540,9 @@ const LabExplorer = (() => {
     startLab,
     nextExperiment,
     backToTopics,
-    getStats
+    getStats,
+    // Weather Station handlers — inline onclicks call these
+    _pickWeather: _pickWeather,
+    _saveWeather: _saveWeather
   };
 })();


### PR DESCRIPTION
New earth-science lab that teaches kids to observe the real sky outside instead of drawing on a canvas.

### Scope (v1)
- **Cloud-type picker (5)**: Clear / Cumulus / Stratus / Cirrus / Nimbus
- **Precipitation (4)**: None / Rain / Snow / Storm
- **Kid-observable Beaufort wind scale (0–5)** with memorable cues ("leaves rustle", "hard to walk")
- **Optional °C input** (no live API; kid reads a real thermometer)
- One observation per date; saving the same day overwrites
- Log capped at 120 entries to keep localStorage lean

### Journal panel
- Last-30-days cloud tally (5-cell bar) + "rainy/snowy" day count
- Last 14 observations in a compact list

### Integration
Strictly additive to `lab-explorer.js`:
- One new `LABS` entry (`id: 'weather'`)
- One extra branch in `_renderExperimentType` dispatch
- All UI rendered into `#exp-controls` / `#exp-journal` (DOM, no canvas drawing) so existing experiment logic is untouched
- Stars increment by 1 per saved observation; feeds the existing `totalStars` aggregation for Explorer Rank
- `ActivityLog` entry per save → surfaces in Parent Dashboard and Sunday Report

### Non-goals (intentional)
- Live weather API (keeps suite-wide "no external calls" promise)
- Forecasting / alerts
- Editing or deleting historical entries (v2)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_