### PR TITLE
Add Home Routines Timer — morning & bedtime guided flow (#156)

### DIFF
--- a/css/home-timer.css
+++ b/css/home-timer.css
@@ -1,0 +1,253 @@
+/* ============================================================
+   HOME ROUTINES TIMER — visual step-by-step helper
+   ============================================================ */
+
+.ht-header {
+  text-align: center;
+  margin: 16px 0 24px;
+  animation: fadeUp 0.5s ease-out both;
+}
+.ht-icon { font-size: 56px; display: block; margin-bottom: 8px; }
+.ht-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, #FBBF24, #EC4899, #60A5FA);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradShift 6s ease-in-out infinite;
+}
+.ht-header p {
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-top: 4px;
+}
+
+/* Profile picker */
+.ht-profiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.ht-profile {
+  padding: 12px 10px;
+  background: rgba(255,255,255,0.04);
+  border: 1.5px solid rgba(255,255,255,0.08);
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: center;
+  transition: all 0.2s;
+  color: var(--text);
+  font-family: var(--font-body);
+}
+.ht-profile:hover { transform: translateY(-2px); border-color: #60A5FA; }
+.ht-profile.active {
+  border-color: #FBBF24;
+  background: rgba(251,191,36,0.08);
+}
+.ht-profile-avatar {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 4px;
+}
+.ht-profile-name {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.9rem;
+}
+
+/* Mode picker */
+.ht-modes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.ht-mode {
+  padding: 16px 12px;
+  background: rgba(255,255,255,0.04);
+  border: 1.5px solid rgba(255,255,255,0.08);
+  border-radius: 16px;
+  cursor: pointer;
+  text-align: center;
+  font-family: var(--font-body);
+  color: var(--text);
+  transition: all 0.2s;
+}
+.ht-mode:hover { transform: translateY(-2px); }
+.ht-mode .ht-m-icon { font-size: 2rem; display: block; margin-bottom: 4px; }
+.ht-mode.morning:hover { border-color: #FBBF24; }
+.ht-mode.evening:hover { border-color: #A78BFA; }
+.ht-mode .ht-m-title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+}
+.ht-mode .ht-m-sub {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-top: 2px;
+}
+
+/* Session */
+.ht-session {
+  padding: 24px 18px;
+  background: rgba(255,255,255,0.03);
+  border: 1.5px solid rgba(255,255,255,0.08);
+  border-radius: 20px;
+  text-align: center;
+}
+.ht-step-label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.ht-step-label .ht-step-n {
+  color: var(--text);
+  font-family: var(--font-display);
+  font-weight: 800;
+}
+.ht-step-title {
+  font-family: var(--font-display);
+  font-size: 2rem;
+  font-weight: 800;
+  color: var(--text);
+  margin: 8px 0 16px;
+  line-height: 1.15;
+}
+
+/* Circular timer */
+.ht-timer {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto 18px;
+}
+.ht-timer svg { width: 100%; height: 100%; transform: rotate(-90deg); }
+.ht-timer-track {
+  fill: none;
+  stroke: rgba(255,255,255,0.08);
+  stroke-width: 10;
+}
+.ht-timer-fill {
+  fill: none;
+  stroke: url(#ht-gradient);
+  stroke-width: 10;
+  stroke-linecap: round;
+  transition: stroke-dashoffset 1s linear;
+}
+.ht-timer-num {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+.ht-timer-secs {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 3rem;
+  color: var(--text);
+  line-height: 1;
+}
+.ht-timer-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-top: 4px;
+}
+
+.ht-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.ht-actions button {
+  padding: 10px 18px;
+  border-radius: 99px;
+  border: none;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: transform 0.15s;
+}
+.ht-actions button:hover { transform: translateY(-2px); }
+.ht-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
+.ht-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); border: 1.5px solid rgba(255,255,255,0.12) !important; }
+.ht-btn-danger { background: rgba(248,113,113,0.12); color: #F87171; border: 1.5px solid rgba(248,113,113,0.25) !important; }
+
+.ht-progress {
+  display: flex;
+  gap: 4px;
+  margin-top: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.ht-prog-dot {
+  width: 10px; height: 10px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.12);
+}
+.ht-prog-dot.done { background: #34D399; }
+.ht-prog-dot.active {
+  background: #FBBF24;
+  box-shadow: 0 0 0 3px rgba(251,191,36,0.25);
+}
+
+/* Done screen */
+.ht-done {
+  text-align: center;
+  padding: 30px 16px;
+}
+.ht-done-emoji { font-size: 64px; display: block; margin-bottom: 10px; }
+.ht-done h2 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.6rem;
+  margin-bottom: 6px;
+}
+.ht-done p { color: var(--text-muted); font-weight: 700; margin-bottom: 16px; }
+
+/* Skip log (parent-visible) */
+.ht-skip-log {
+  margin-top: 16px;
+  padding: 10px 14px;
+  background: rgba(248,113,113,0.06);
+  border: 1px solid rgba(248,113,113,0.18);
+  border-radius: 10px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: #F87171;
+}
+
+.ht-mute-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 10px;
+  padding: 6px 12px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 99px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+.ht-mute-toggle.muted { color: var(--text-muted); }
+
+@media (max-width: 480px) {
+  .ht-timer { width: 170px; height: 170px; }
+  .ht-step-title { font-size: 1.6rem; }
+  .ht-timer-secs { font-size: 2.5rem; }
+}

--- a/home-timer.html
+++ b/home-timer.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Home Timer ⏱</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/home-timer.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body>
+  <div class="atmo" style="width:400px;height:400px;background:rgba(251,191,36,0.08);top:-100px;left:-100px;"></div>
+  <div class="atmo" style="width:350px;height:350px;background:rgba(96,165,250,0.08);bottom:-80px;right:-80px;animation-delay:-8s;"></div>
+
+  <div class="app">
+    <div id="ht-wrap"></div>
+  </div>
+
+  <script src="js/debug.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/nav.js"></script>
+  <script src="js/activity-log.js"></script>
+  <script src="js/home-timer.js"></script>
+  <script src="js/pwa.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -241,6 +241,9 @@
         <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="shopping-list.html">
           🛒 Lista de Compras
         </a>
+        <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="home-timer.html">
+          ⏱ Home Timer
+        </a>
         <button class="parent-btn" style="margin-top:0;" onclick="requestPinThen(function() { openParentsCorner(); })">
           🔒 Parents Corner
         </button>

--- a/js/home-timer.js
+++ b/js/home-timer.js
@@ -1,0 +1,324 @@
+/* ================================================================
+   HOME ROUTINES TIMER — home-timer.js
+   Real-time step-by-step guide for morning and bedtime routines.
+
+   Different from js/routines.js (habit tracker, streak-focused):
+   this one runs a countdown per step with a soft chime between
+   transitions. Shares the same template source so edits in
+   Parents Corner apply here too.
+
+   Per-step duration defaults, kid can tap Next early (skipped step
+   is logged parent-visible).
+   ================================================================ */
+
+var HomeTimer = (function() {
+  'use strict';
+
+  // Default step durations in seconds if the template doesn't specify.
+  // Templates from js/routines.js are { id, label } only, so we
+  // augment them here. Labels containing "diente" get 120s (2 min),
+  // "leer"/"read" gets 600s (10 min), everything else 180s (3 min).
+  function _defaultDuration(label) {
+    var l = String(label || '').toLowerCase();
+    if (l.indexOf('diente') !== -1 || l.indexOf('teeth') !== -1) return 120;
+    if (l.indexOf('leer')   !== -1 || l.indexOf('read')  !== -1) return 600;
+    if (l.indexOf('desayun') !== -1) return 600;
+    if (l.indexOf('vest')   !== -1) return 300;
+    if (l.indexOf('cama')   !== -1 || l.indexOf('bed')   !== -1) return 180;
+    return 180;
+  }
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  // ── State ──
+  var state = {
+    kid: null,        // profile object
+    mode: null,       // 'morning' | 'evening'
+    steps: [],        // [{id, label, duration}]
+    idx: 0,
+    remaining: 0,
+    timerId: null,
+    paused: false,
+    muted: false,
+    skipped: []       // array of {label} the kid tapped through early
+  };
+
+  function _loadTemplate(which, kidName) {
+    // Use Routines.getTemplates if available; otherwise fall back to
+    // a small sensible default so this page still works standalone.
+    if (typeof Routines !== 'undefined' && Routines.getTemplates) {
+      try {
+        var tpls = Routines.getTemplates(kidName);
+        if (tpls && Array.isArray(tpls[which]) && tpls[which].length > 0) {
+          return tpls[which].map(function(it) {
+            return { id: it.id, label: it.label, duration: _defaultDuration(it.label) };
+          });
+        }
+      } catch (e) {}
+    }
+    var fallback = which === 'morning'
+      ? [
+          { id: 'bed',       label: 'Hacer la cama 🛏️' },
+          { id: 'teeth',     label: 'Cepillarse los dientes 🦷' },
+          { id: 'dressed',   label: 'Vestirse 👕' },
+          { id: 'breakfast', label: 'Desayunar 🥣' }
+        ]
+      : [
+          { id: 'tidy',     label: 'Ordenar el cuarto 🧸' },
+          { id: 'teeth_pm', label: 'Cepillarse los dientes 🦷' },
+          { id: 'read',     label: 'Leer un rato 📖' }
+        ];
+    return fallback.map(function(it) {
+      return { id: it.id, label: it.label, duration: _defaultDuration(it.label) };
+    });
+  }
+
+  // ── Gentle chime (Web Audio, no external asset) ──
+  var _audioCtx = null;
+  function _chime() {
+    if (state.muted) return;
+    try {
+      if (!_audioCtx) _audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      var now = _audioCtx.currentTime;
+      [660, 880].forEach(function(freq, i) {
+        var osc = _audioCtx.createOscillator();
+        var gain = _audioCtx.createGain();
+        osc.type = 'sine';
+        osc.frequency.value = freq;
+        gain.gain.value = 0;
+        osc.connect(gain).connect(_audioCtx.destination);
+        var start = now + i * 0.18;
+        osc.start(start);
+        gain.gain.setValueAtTime(0, start);
+        gain.gain.linearRampToValueAtTime(0.18, start + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + 0.5);
+        osc.stop(start + 0.55);
+      });
+    } catch (e) {}
+  }
+
+  // ── Screens ──
+  function _renderHome() {
+    var wrap = document.getElementById('ht-wrap');
+    if (!wrap) return;
+    var profiles = typeof getProfiles === 'function' ? getProfiles() : [];
+    var chosen = state.kid ? state.kid.name : null;
+
+    var profHtml = profiles.map(function(p) {
+      var active = chosen === p.name ? ' active' : '';
+      var color = typeof safeColor === 'function' ? safeColor(p.color) : (p.color || '#7C3AED');
+      return '<button class="ht-profile' + active + '" ' +
+        'onclick="HomeTimer._pickKid(\'' + _esc(p.name).replace(/'/g, "\\'") + '\')" ' +
+        'style="border-color:' + (chosen === p.name ? color : 'rgba(255,255,255,0.08)') + ';">' +
+        '<span class="ht-profile-avatar">' + _esc(p.avatar) + '</span>' +
+        '<span class="ht-profile-name">' + _esc(p.name) + '</span>' +
+      '</button>';
+    }).join('');
+
+    if (!profiles.length) {
+      wrap.innerHTML = '<div class="ht-header"><span class="ht-icon">⏱</span><h1>Home Timer</h1><p>Add a kid in the hub first.</p></div>';
+      return;
+    }
+
+    wrap.innerHTML =
+      '<div class="ht-header">' +
+        '<span class="ht-icon">⏱</span>' +
+        '<h1>Home Timer</h1>' +
+        '<p>Guided step-by-step for morning and bedtime.</p>' +
+      '</div>' +
+      '<div class="ht-profiles">' + profHtml + '</div>' +
+      '<div class="ht-modes">' +
+        '<button class="ht-mode morning" onclick="HomeTimer._start(\'morning\')"' + (chosen ? '' : ' disabled') + '>' +
+          '<span class="ht-m-icon">🌅</span>' +
+          '<div class="ht-m-title">Morning</div>' +
+          '<div class="ht-m-sub">Get ready for the day</div>' +
+        '</button>' +
+        '<button class="ht-mode evening" onclick="HomeTimer._start(\'evening\')"' + (chosen ? '' : ' disabled') + '>' +
+          '<span class="ht-m-icon">🌙</span>' +
+          '<div class="ht-m-title">Bedtime</div>' +
+          '<div class="ht-m-sub">Wind down and rest</div>' +
+        '</button>' +
+      '</div>' +
+      (chosen ? '' : '<p style="text-align:center;color:var(--text-muted);font-weight:700;margin-top:8px;">Pick who\'s playing first.</p>');
+  }
+
+  function _renderSession() {
+    var wrap = document.getElementById('ht-wrap');
+    if (!wrap) return;
+    var step = state.steps[state.idx];
+    if (!step) { _renderDone(); return; }
+
+    var totalSteps = state.steps.length;
+    var dots = state.steps.map(function(s, i) {
+      var cls = i < state.idx ? 'done' : (i === state.idx ? 'active' : '');
+      return '<span class="ht-prog-dot ' + cls + '"></span>';
+    }).join('');
+
+    var pct = step.duration > 0 ? (state.remaining / step.duration) : 0;
+    var circumference = 2 * Math.PI * 86;
+    var offset = circumference * (1 - pct);
+
+    wrap.innerHTML =
+      '<div class="ht-session">' +
+        '<div class="ht-step-label">Step <span class="ht-step-n">' + (state.idx + 1) + ' / ' + totalSteps + '</span></div>' +
+        '<div class="ht-step-title">' + _esc(step.label) + '</div>' +
+        '<div class="ht-timer">' +
+          '<svg viewBox="0 0 200 200">' +
+            '<defs>' +
+              '<linearGradient id="ht-gradient" x1="0" y1="0" x2="1" y2="1">' +
+                '<stop offset="0" stop-color="#7C3AED"/>' +
+                '<stop offset="0.5" stop-color="#EC4899"/>' +
+                '<stop offset="1" stop-color="#FBBF24"/>' +
+              '</linearGradient>' +
+            '</defs>' +
+            '<circle class="ht-timer-track" cx="100" cy="100" r="86"/>' +
+            '<circle class="ht-timer-fill" cx="100" cy="100" r="86" ' +
+                    'stroke-dasharray="' + circumference.toFixed(2) + '" ' +
+                    'stroke-dashoffset="' + offset.toFixed(2) + '"/>' +
+          '</svg>' +
+          '<div class="ht-timer-num">' +
+            '<div class="ht-timer-secs">' + _fmtSec(state.remaining) + '</div>' +
+            '<div class="ht-timer-label">' + (state.paused ? 'Paused' : 'Remaining') + '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="ht-actions">' +
+          (state.paused
+            ? '<button class="ht-btn-primary" onclick="HomeTimer._resume()">▶ Resume</button>'
+            : '<button class="ht-btn-secondary" onclick="HomeTimer._pause()">⏸ Pause</button>') +
+          '<button class="ht-btn-secondary" onclick="HomeTimer._next(true)">⏭ Skip</button>' +
+          '<button class="ht-btn-primary" onclick="HomeTimer._next(false)">✓ Done</button>' +
+          '<button class="ht-btn-danger" onclick="HomeTimer._quit()">✕ Quit</button>' +
+        '</div>' +
+        '<div class="ht-progress">' + dots + '</div>' +
+        '<button class="ht-mute-toggle ' + (state.muted ? 'muted' : '') + '" onclick="HomeTimer._toggleMute()">' +
+          (state.muted ? '🔕 Chime off' : '🔔 Chime on') +
+        '</button>' +
+      '</div>';
+  }
+
+  function _renderDone() {
+    var wrap = document.getElementById('ht-wrap');
+    if (!wrap) return;
+    var skipHtml = state.skipped.length === 0
+      ? ''
+      : '<div class="ht-skip-log">⏭ Skipped: ' +
+        state.skipped.map(function(s){ return _esc(s.label); }).join(', ') +
+        '</div>';
+    wrap.innerHTML =
+      '<div class="ht-done">' +
+        '<span class="ht-done-emoji">' + (state.mode === 'morning' ? '🌅' : '🌙') + '</span>' +
+        '<h2>¡' + (state.mode === 'morning' ? 'Listo para el día' : 'Buenas noches') + ', ' +
+          _esc(state.kid ? state.kid.name : '') + '!</h2>' +
+        '<p>Routine complete.</p>' +
+        '<div class="ht-actions">' +
+          '<button class="ht-btn-primary" onclick="HomeTimer._home()">🏠 Back</button>' +
+        '</div>' +
+        skipHtml +
+      '</div>';
+
+    if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
+      ActivityLog.log('Home Timer', state.mode === 'morning' ? '🌅' : '🌙',
+        'Completó rutina de ' + (state.mode === 'morning' ? 'mañana' : 'noche') +
+        (state.skipped.length ? ' · ' + state.skipped.length + ' saltadas' : ''));
+    }
+    // Reset running state
+    clearInterval(state.timerId);
+    state.timerId = null;
+  }
+
+  function _fmtSec(s) {
+    s = Math.max(0, Math.floor(s));
+    var m = Math.floor(s / 60);
+    s = s % 60;
+    return m + ':' + String(s).padStart(2, '0');
+  }
+
+  // ── Flow ──
+  function _pickKid(name) {
+    var profiles = typeof getProfiles === 'function' ? getProfiles() : [];
+    for (var i = 0; i < profiles.length; i++) {
+      if (profiles[i].name === name) { state.kid = profiles[i]; break; }
+    }
+    _renderHome();
+  }
+
+  function _start(mode) {
+    if (!state.kid) return;
+    state.mode = mode;
+    state.steps = _loadTemplate(mode, state.kid.name);
+    state.idx = 0;
+    state.skipped = [];
+    state.paused = false;
+    state.remaining = state.steps[0] ? state.steps[0].duration : 0;
+    _renderSession();
+    _tickLoop();
+  }
+
+  function _tickLoop() {
+    clearInterval(state.timerId);
+    state.timerId = setInterval(function() {
+      if (state.paused) return;
+      state.remaining -= 1;
+      if (state.remaining <= 0) {
+        state.remaining = 0;
+        _renderSession();
+        _chime();
+        setTimeout(function() { _next(false); }, 300);
+        return;
+      }
+      _renderSession();
+    }, 1000);
+  }
+
+  function _next(skipped) {
+    if (skipped) {
+      var step = state.steps[state.idx];
+      if (step) state.skipped.push({ label: step.label });
+    }
+    state.idx++;
+    if (state.idx >= state.steps.length) {
+      clearInterval(state.timerId);
+      _renderDone();
+      return;
+    }
+    state.remaining = state.steps[state.idx].duration;
+    state.paused = false;
+    _renderSession();
+  }
+
+  function _pause() { state.paused = true; _renderSession(); }
+  function _resume() { state.paused = false; _renderSession(); }
+  function _toggleMute() { state.muted = !state.muted; _renderSession(); }
+  function _quit() {
+    clearInterval(state.timerId);
+    state.timerId = null;
+    state.mode = null;
+    _renderHome();
+  }
+  function _home() { _quit(); }
+
+  // ── Init ──
+  function init() {
+    _renderHome();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  return {
+    _pickKid: _pickKid,
+    _start: _start,
+    _next: _next,
+    _pause: _pause,
+    _resume: _resume,
+    _toggleMute: _toggleMute,
+    _quit: _quit,
+    _home: _home
+  };
+})();


### PR DESCRIPTION
Real-time step-by-step companion for morning and bedtime. **Separate from `js/routines.js`** (which tracks habit streaks): this one runs a live countdown per step with a soft chime between transitions. Both share the same template source, so parent edits in Parents Corner flow into both places.

### Flow
1. Pick a kid (avatars grid)
2. Pick mode (🌅 morning / 🌙 bedtime)
3. Big circular progress ring + BIG step title + remaining time
4. Controls: Pause / Skip / ✓ Done / Quit; Chime on/off
5. Chime uses the Web Audio API (no external asset) — two soft tones
6. Skipped steps are recorded and shown on the done screen (parent-visible spot-audit) and logged to ActivityLog

### Step durations (auto from label keywords)
- `dientes` / `teeth` → 2 min
- `leer` / `read` → 10 min
- `desayunar` → 10 min
- `vestirse` → 5 min
- everything else → 3 min

### Files
- `home-timer.html`
- `css/home-timer.css`
- `js/home-timer.js`
- Hub button **⏱ Home Timer** next to Shopping List

### Fallback
If `js/routines.js` isn't loaded, the page uses a small built-in default template so it still works standalone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_