### PR TITLE
Add Weekly Menu Planner (#153)

### DIFF
--- a/css/menu.css
+++ b/css/menu.css
@@ -1,0 +1,225 @@
+/* ============================================================
+   WEEKLY MENU PLANNER
+   ============================================================ */
+
+.mn-header {
+  text-align: center;
+  margin: 16px 0 24px;
+}
+.mn-icon { font-size: 56px; display: block; margin-bottom: 8px; }
+.mn-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, #F87171, #FBBF24, #34D399);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradShift 6s ease-in-out infinite;
+}
+.mn-header p {
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-top: 4px;
+}
+
+.mn-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+.mn-toolbar button {
+  padding: 8px 14px;
+  border-radius: 99px;
+  border: 1.5px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.mn-toolbar button:hover { border-color: #FBBF24; color: #FBBF24; }
+.mn-toolbar .mn-tb-lock {
+  background: linear-gradient(135deg, rgba(167,139,250,0.15), rgba(96,165,250,0.12));
+  border-color: rgba(167,139,250,0.3);
+  color: #A78BFA;
+}
+
+.mn-today {
+  padding: 16px;
+  margin-bottom: 20px;
+  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(239,68,68,0.08));
+  border: 1.5px solid rgba(251,191,36,0.3);
+  border-radius: 16px;
+  text-align: center;
+  animation: fadeUp 0.5s ease-out both;
+}
+.mn-today-label {
+  font-size: 0.75rem;
+  font-weight: 800;
+  color: #FBBF24;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 4px;
+}
+.mn-today-meal {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.1rem;
+  color: var(--text);
+  margin: 2px 0;
+}
+.mn-today-meal.empty { color: var(--text-muted); font-style: italic; }
+.mn-today-sub {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-top: 4px;
+}
+
+/* Week grid */
+.mn-week {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.mn-day {
+  padding: 12px 14px;
+  background: var(--bg-surface);
+  border: 1.5px solid rgba(255,255,255,0.06);
+  border-radius: 14px;
+}
+.mn-day.today {
+  border-color: rgba(251,191,36,0.35);
+  background: linear-gradient(180deg, rgba(251,191,36,0.06), rgba(255,255,255,0.02));
+}
+.mn-day-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.mn-day-name {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+}
+.mn-day-date {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.mn-day.today .mn-day-name { color: #FBBF24; }
+
+.mn-meals {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.mn-meal {
+  padding: 8px 10px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.05);
+  border-radius: 10px;
+}
+.mn-meal-label {
+  display: block;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.mn-meal input {
+  width: 100%;
+  padding: 4px 6px;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-weight: 700;
+  outline: none;
+  line-height: 1.25;
+}
+.mn-meal input::placeholder { color: var(--text-muted); font-weight: 500; opacity: 0.6; }
+.mn-meal input:focus {
+  background: rgba(251,191,36,0.05);
+  border-radius: 6px;
+}
+.mn-meal.read-only input {
+  pointer-events: none;
+  user-select: text;
+}
+.mn-meal input:disabled { color: var(--text); }
+
+/* Shopping-list export modal */
+.mn-modal {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+.mn-modal.active { display: flex; }
+.mn-modal-panel {
+  max-width: 420px; width: 100%;
+  background: var(--bg-surface);
+  border: 1.5px solid rgba(255,255,255,0.1);
+  border-radius: 18px;
+  padding: 20px 22px;
+}
+.mn-modal-panel h3 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.15rem;
+  margin-bottom: 10px;
+}
+.mn-modal-panel textarea {
+  width: 100%;
+  min-height: 160px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.2);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.9rem;
+  font-weight: 600;
+  outline: none;
+  resize: vertical;
+}
+.mn-modal-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 12px;
+}
+.mn-modal-actions button {
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: none;
+  font-weight: 800;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+.mn-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
+.mn-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); }
+
+@media (max-width: 640px) {
+  .mn-meals { grid-template-columns: 1fr; }
+}
+
+@media print {
+  body.mn-body { background: #fff !important; color: #000; }
+  .no-print { display: none !important; }
+  .mn-day { break-inside: avoid; background: #fff; border-color: #ccc; }
+  .mn-meal { background: #fafafa; }
+  .atmo { display: none; }
+}

--- a/index.html
+++ b/index.html
@@ -244,6 +244,9 @@
         <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="home-timer.html">
           ⏱ Home Timer
         </a>
+        <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="menu.html">
+          🍽️ Menú Semanal
+        </a>
         <button class="parent-btn" style="margin-top:0;" onclick="requestPinThen(function() { openParentsCorner(); })">
           🔒 Parents Corner
         </button>

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,0 +1,343 @@
+/* ================================================================
+   WEEKLY MENU PLANNER — menu.js
+   Parent-editable 7-day × 3-meal grid (breakfast / lunch / dinner).
+   Kid view (read-only) appears until parent unlocks with PIN.
+   Data is per-week, keyed by the Monday anchor (YYYY-MM-DD).
+
+   Storage: zs_menu
+     {
+       weeks: {
+         "2026-04-20": { mon: { breakfast, lunch, dinner }, tue: {...}, ... },
+         ...
+       }
+     }
+
+   Tonight's dinner also shows as a small card on the hub (separate PR
+   would wire this; for now standalone page is enough).
+   ================================================================ */
+
+var WeeklyMenu = (function() {
+  'use strict';
+
+  var STORAGE_KEY = 'zs_menu';
+  var DAYS = [
+    { id: 'mon', name: 'Lunes' },
+    { id: 'tue', name: 'Martes' },
+    { id: 'wed', name: 'Miércoles' },
+    { id: 'thu', name: 'Jueves' },
+    { id: 'fri', name: 'Viernes' },
+    { id: 'sat', name: 'Sábado' },
+    { id: 'sun', name: 'Domingo' }
+  ];
+  var MEALS = [
+    { id: 'breakfast', label: '🥣 Desayuno' },
+    { id: 'lunch',     label: '🍽 Almuerzo' },
+    { id: 'dinner',    label: '🌙 Cena' }
+  ];
+
+  var _parentUnlocked = false;
+  var _weekAnchor = null; // 'YYYY-MM-DD' (Monday)
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function _iso(d) {
+    return d.getFullYear() + '-' +
+      String(d.getMonth() + 1).padStart(2, '0') + '-' +
+      String(d.getDate()).padStart(2, '0');
+  }
+
+  function _mondayOf(d) {
+    var day = d.getDay(); // 0=Sun, 1=Mon
+    var off = day === 0 ? -6 : 1 - day;
+    var m = new Date(d.getFullYear(), d.getMonth(), d.getDate() + off);
+    m.setHours(0, 0, 0, 0);
+    return m;
+  }
+
+  function _addDays(d, n) {
+    var r = new Date(d.getFullYear(), d.getMonth(), d.getDate() + n);
+    r.setHours(0, 0, 0, 0);
+    return r;
+  }
+
+  function _todayIso() { return _iso(new Date()); }
+  function _todayDayId() {
+    var d = new Date();
+    var map = ['sun','mon','tue','wed','thu','fri','sat'];
+    return map[d.getDay()];
+  }
+
+  function _load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      var d = raw ? JSON.parse(raw) : {};
+      if (!d.weeks) d.weeks = {};
+      return d;
+    } catch (e) { return { weeks: {} }; }
+  }
+
+  function _save(data) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); } catch (e) {}
+  }
+
+  function _getWeek(data, anchorIso) {
+    if (!data.weeks[anchorIso]) {
+      data.weeks[anchorIso] = {};
+    }
+    var w = data.weeks[anchorIso];
+    DAYS.forEach(function(day) {
+      if (!w[day.id]) w[day.id] = { breakfast: '', lunch: '', dinner: '' };
+      MEALS.forEach(function(m) {
+        if (typeof w[day.id][m.id] !== 'string') w[day.id][m.id] = '';
+      });
+    });
+    return w;
+  }
+
+  // ── Public actions ──
+  function unlockParent() {
+    if (typeof requestPinThen === 'function') {
+      requestPinThen(function() { _parentUnlocked = true; _render(); });
+    } else {
+      _parentUnlocked = true; _render();
+    }
+  }
+
+  function shiftWeek(delta) {
+    var base = new Date(_weekAnchor + 'T00:00:00');
+    var newAnchor = _addDays(base, delta * 7);
+    _weekAnchor = _iso(newAnchor);
+    _render();
+  }
+
+  function thisWeek() {
+    _weekAnchor = _iso(_mondayOf(new Date()));
+    _render();
+  }
+
+  function copyLastWeek() {
+    if (!_parentUnlocked) return;
+    var data = _load();
+    var base = new Date(_weekAnchor + 'T00:00:00');
+    var prevAnchor = _iso(_addDays(base, -7));
+    var prev = data.weeks[prevAnchor];
+    if (!prev) { alert('No hay menú de la semana anterior.'); return; }
+    if (!confirm('¿Copiar el menú de la semana anterior a esta semana? Reemplaza lo que haya ahora.')) return;
+    data.weeks[_weekAnchor] = JSON.parse(JSON.stringify(prev));
+    _save(data);
+    _render();
+  }
+
+  function setMeal(dayId, mealId, value) {
+    if (!_parentUnlocked) return;
+    var data = _load();
+    var week = _getWeek(data, _weekAnchor);
+    if (!week[dayId]) week[dayId] = { breakfast: '', lunch: '', dinner: '' };
+    week[dayId][mealId] = String(value).slice(0, 80);
+    _save(data);
+    // No full re-render on every keystroke; only re-render the today
+    // card when the edit is for today's date to keep it in sync.
+    if (dayId === _todayDayId()) _renderTodayCard();
+  }
+
+  function clearWeek() {
+    if (!_parentUnlocked) return;
+    if (!confirm('¿Borrar todo el menú de esta semana?')) return;
+    var data = _load();
+    delete data.weeks[_weekAnchor];
+    _save(data);
+    _render();
+  }
+
+  function shareOrPrint() {
+    var data = _load();
+    var week = _getWeek(data, _weekAnchor);
+    var lines = ['📅 Menú · Semana del ' + _fmtRange(_weekAnchor), ''];
+    DAYS.forEach(function(day, i) {
+      var d = _addDays(new Date(_weekAnchor + 'T00:00:00'), i);
+      lines.push('— ' + day.name + ' ' + d.getDate() + '/' + (d.getMonth() + 1) + ' —');
+      MEALS.forEach(function(m) {
+        var v = week[day.id][m.id] || '—';
+        lines.push('  ' + m.label + ': ' + v);
+      });
+      lines.push('');
+    });
+    var text = lines.join('\n');
+
+    if (navigator.share) {
+      navigator.share({ title: 'Menú semanal', text: text }).catch(function() {});
+      return;
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function() {
+        alert('Menú copiado al portapapeles.');
+      });
+      return;
+    }
+    // Open a modal with the text selected for copy
+    _showShareModal(text);
+  }
+
+  function printWeek() { window.print(); }
+
+  function _showShareModal(text) {
+    var mod = document.getElementById('mn-modal');
+    if (!mod) {
+      mod = document.createElement('div');
+      mod.id = 'mn-modal';
+      mod.className = 'mn-modal';
+      mod.innerHTML =
+        '<div class="mn-modal-panel">' +
+          '<h3>📤 Compartir menú</h3>' +
+          '<textarea id="mn-modal-text" readonly></textarea>' +
+          '<div class="mn-modal-actions">' +
+            '<button class="mn-btn-secondary" onclick="WeeklyMenu._closeModal()">Cerrar</button>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(mod);
+    }
+    var ta = document.getElementById('mn-modal-text');
+    if (ta) { ta.value = text; setTimeout(function() { ta.select(); }, 50); }
+    mod.classList.add('active');
+  }
+
+  function _closeModal() {
+    var mod = document.getElementById('mn-modal');
+    if (mod) mod.classList.remove('active');
+  }
+
+  // ── Rendering ──
+  function _fmtRange(anchorIso) {
+    var m = new Date(anchorIso + 'T00:00:00');
+    var end = _addDays(m, 6);
+    var months = ['ene','feb','mar','abr','may','jun','jul','ago','sep','oct','nov','dic'];
+    return m.getDate() + ' ' + months[m.getMonth()] + ' – ' + end.getDate() + ' ' + months[end.getMonth()];
+  }
+
+  function _render() {
+    var wrap = document.getElementById('mn-wrap');
+    if (!wrap) return;
+    if (!_weekAnchor) _weekAnchor = _iso(_mondayOf(new Date()));
+
+    var data = _load();
+    var week = _getWeek(data, _weekAnchor);
+    var todayDay = _todayDayId();
+    var todayInThisWeek = _iso(_mondayOf(new Date())) === _weekAnchor;
+
+    // Toolbar
+    var lockTxt = _parentUnlocked ? '🔓 Editando' : '🔒 Desbloquear para editar';
+    var tools =
+      '<div class="mn-toolbar no-print">' +
+        '<button onclick="WeeklyMenu.shiftWeek(-1)">◀</button>' +
+        '<button onclick="WeeklyMenu.thisWeek()">Esta semana</button>' +
+        '<button onclick="WeeklyMenu.shiftWeek(1)">▶</button>' +
+        '<button class="mn-tb-lock" onclick="WeeklyMenu.unlockParent()">' + lockTxt + '</button>' +
+        (_parentUnlocked ? '<button onclick="WeeklyMenu.copyLastWeek()">📋 Copiar semana anterior</button>' : '') +
+        (_parentUnlocked ? '<button onclick="WeeklyMenu.clearWeek()">🗑 Limpiar</button>' : '') +
+        '<button onclick="WeeklyMenu.shareOrPrint()">📤 Compartir</button>' +
+        '<button onclick="WeeklyMenu.printWeek()">🖨 Imprimir</button>' +
+      '</div>';
+
+    // Today card
+    var todayHtml = '';
+    if (todayInThisWeek) {
+      var t = week[todayDay];
+      var todayMeal = t.dinner || t.lunch || t.breakfast;
+      todayHtml =
+        '<div class="mn-today">' +
+          '<div class="mn-today-label">Hoy · ' + (DAYS.filter(function(d){return d.id===todayDay;})[0] || {name:''}).name + '</div>' +
+          (t.dinner
+            ? '<div class="mn-today-meal">🌙 ' + _esc(t.dinner) + '</div>'
+            : '<div class="mn-today-meal empty">Sin cena planificada</div>') +
+          (t.lunch
+            ? '<div class="mn-today-sub">🍽 ' + _esc(t.lunch) + '</div>'
+            : '') +
+        '</div>';
+    }
+
+    // Week grid
+    var days = DAYS.map(function(day, i) {
+      var date = _addDays(new Date(_weekAnchor + 'T00:00:00'), i);
+      var isToday = todayInThisWeek && day.id === todayDay;
+      var meals = MEALS.map(function(m) {
+        var v = week[day.id][m.id] || '';
+        var roCls = _parentUnlocked ? '' : ' read-only';
+        return '<div class="mn-meal' + roCls + '">' +
+          '<span class="mn-meal-label">' + m.label + '</span>' +
+          '<input type="text" maxlength="80" placeholder="—" value="' + _esc(v) + '" ' +
+                 (_parentUnlocked ? '' : 'disabled ') +
+                 'onchange="WeeklyMenu.setMeal(\'' + day.id + '\', \'' + m.id + '\', this.value)">' +
+        '</div>';
+      }).join('');
+      return '<div class="mn-day' + (isToday ? ' today' : '') + '">' +
+        '<div class="mn-day-head">' +
+          '<span class="mn-day-name">' + day.name + '</span>' +
+          '<span class="mn-day-date">' + date.getDate() + '/' + (date.getMonth() + 1) + '</span>' +
+        '</div>' +
+        '<div class="mn-meals">' + meals + '</div>' +
+      '</div>';
+    }).join('');
+
+    wrap.innerHTML =
+      '<div class="mn-header">' +
+        '<span class="mn-icon">🍽️</span>' +
+        '<h1>Menú Semanal</h1>' +
+        '<p>Semana del ' + _fmtRange(_weekAnchor) + '</p>' +
+      '</div>' +
+      tools +
+      todayHtml +
+      '<div class="mn-week">' + days + '</div>';
+  }
+
+  function _renderTodayCard() {
+    // Fast path used while parent types: refresh only the today banner
+    // so the hero stays in sync without losing input focus in the grid.
+    var wrap = document.getElementById('mn-wrap');
+    if (!wrap) return;
+    var data = _load();
+    var week = _getWeek(data, _weekAnchor);
+    var todayInThisWeek = _iso(_mondayOf(new Date())) === _weekAnchor;
+    if (!todayInThisWeek) return;
+    var todayDay = _todayDayId();
+    var t = week[todayDay];
+    var existing = wrap.querySelector('.mn-today');
+    if (!existing) return;
+    existing.innerHTML =
+      '<div class="mn-today-label">Hoy · ' + (DAYS.filter(function(d){return d.id===todayDay;})[0] || {name:''}).name + '</div>' +
+      (t.dinner
+        ? '<div class="mn-today-meal">🌙 ' + _esc(t.dinner) + '</div>'
+        : '<div class="mn-today-meal empty">Sin cena planificada</div>') +
+      (t.lunch
+        ? '<div class="mn-today-sub">🍽 ' + _esc(t.lunch) + '</div>'
+        : '');
+  }
+
+  // ── Init ──
+  function init() {
+    _parentUnlocked = false;
+    _weekAnchor = _iso(_mondayOf(new Date()));
+    _render();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  return {
+    unlockParent: unlockParent,
+    shiftWeek: shiftWeek,
+    thisWeek: thisWeek,
+    copyLastWeek: copyLastWeek,
+    setMeal: setMeal,
+    clearWeek: clearWeek,
+    shareOrPrint: shareOrPrint,
+    printWeek: printWeek,
+    _closeModal: _closeModal
+  };
+})();

--- a/menu.html
+++ b/menu.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Menú Semanal 🍽️</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/menu.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body>
+  <div class="atmo" style="width:400px;height:400px;background:rgba(239,68,68,0.06);top:-100px;left:-100px;"></div>
+  <div class="atmo" style="width:350px;height:350px;background:rgba(251,191,36,0.08);bottom:-80px;right:-80px;animation-delay:-8s;"></div>
+
+  <div class="app">
+    <div id="mn-wrap"></div>
+  </div>
+
+  <script src="js/debug.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/nav.js"></script>
+  <script src="js/menu.js"></script>
+  <script src="js/pwa.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Parent-editable 7-day × 3-meal grid (breakfast / lunch / dinner). Kid view is read-only until the parent unlocks with the existing PIN (session-level, reuses `requestPinThen`).

### Features
- **Week navigator**: ◀ prev / Esta semana / ▶ next
- **Today banner** at the top shows tonight's dinner (falls back to lunch or breakfast if dinner is empty)
- **Copy-last-week** — one click duplicates the previous week's menu into the current anchor
- **Clear week** and **Print** actions
- **Share/export**: uses `navigator.share` when present, else clipboard, else a modal with selectable plain text
- **Print layout**: `@media print` strips backgrounds and forces `break-inside: avoid` on each day card

### Storage
- Single key `zs_menu` with `{ weeks: { "YYYY-MM-DD": { mon: {...}, ... } } }`
- Week anchor is local-time Monday (same convention as Sunday Report and Routines)
- No per-kid split — shared household planning

### Files
- `menu.html`
- `css/menu.css`
- `js/menu.js`
- Hub button **🍽️ Menú Semanal** in the action-row footer

### Non-goals (intentional for v1)
- Nutrition tracking / calorie counting
- Food photos
- Auto-generated shopping list (Shopping List already exists; v2 can wire an "Add missing ingredients" export)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_