### PR TITLE
Translate Routines to English

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1296,20 +1296,20 @@
       return '<div class="rn-ed-block">' +
         '<div class="rn-ed-head">' +
           '<span>' + icon + ' ' + label + '</span>' +
-          '<button type="button" class="rn-ed-reset" onclick="resetRoutine(' + idx + ', \'' + which + '\')" title="Restaurar valores por defecto">↻ Default</button>' +
+          '<button type="button" class="rn-ed-reset" onclick="resetRoutine(' + idx + ', \'' + which + '\')" title="Restore defaults">↻ Default</button>' +
         '</div>' +
         rows +
         '<div class="rn-ed-row rn-ed-add">' +
-          '<input type="text" id="rn-add-' + which + '-' + idx + '" placeholder="Nueva tarea…" maxlength="80" ' +
+          '<input type="text" id="rn-add-' + which + '-' + idx + '" placeholder="New task…" maxlength="80" ' +
                  'onkeydown="if(event.key===\'Enter\'){event.preventDefault();addRoutineItem(' + idx + ', \'' + which + '\');}" />' +
-          '<button type="button" class="rn-ed-add-btn" onclick="addRoutineItem(' + idx + ', \'' + which + '\')">＋ Añadir</button>' +
+          '<button type="button" class="rn-ed-add-btn" onclick="addRoutineItem(' + idx + ', \'' + which + '\')">＋ Add</button>' +
         '</div>' +
       '</div>';
     }
     return '<div class="pk-setting" style="margin-top:16px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.06);">' +
-      '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">📋 Rutinas</label>' +
-      block('morning', '🌅', 'Mañana') +
-      block('evening', '🌙', 'Noche') +
+      '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">📋 Routines</label>' +
+      block('morning', '🌅', 'Morning') +
+      block('evening', '🌙', 'Night') +
     '</div>';
   }
 
@@ -1348,7 +1348,7 @@
     if (!name) return;
     var tpl = Routines.getTemplates(name)[which];
     if (!tpl[j]) return;
-    if (tpl.length <= 1) { alert('Deja al menos una tarea en esta rutina.'); return; }
+    if (tpl.length <= 1) { alert('Keep at least one task in this routine.'); return; }
     tpl.splice(j, 1);
     Routines.setTemplate(which, tpl, name);
     renderParentsCorner();
@@ -1359,7 +1359,7 @@
     var profiles = getProfiles();
     var name = profiles[idx] && profiles[idx].name;
     if (!name) return;
-    if (!confirm('¿Restaurar la rutina de la ' + (which === 'morning' ? 'mañana' : 'noche') + ' a los valores por defecto?')) return;
+    if (!confirm('Restore the ' + (which === 'morning' ? 'morning' : 'night') + ' routine to defaults?')) return;
     Routines.resetTemplate(which, name);
     renderParentsCorner();
   }

--- a/js/routines.js
+++ b/js/routines.js
@@ -23,20 +23,22 @@ var Routines = (function() {
   var STORAGE_PREFIX = 'zs_routines_';
 
   // Default morning/evening templates. Kid-authored text only.
+  // Labels are English by default; parents can edit (and translate)
+  // via the Routines editor in Parents Corner.
   var DEFAULTS = {
     morning: [
-      { id: 'bed',       label: 'Hacer la cama 🛏️' },
-      { id: 'teeth',     label: 'Cepillarse los dientes 🦷' },
-      { id: 'dressed',   label: 'Vestirse 👕' },
-      { id: 'breakfast', label: 'Desayunar 🥣' },
-      { id: 'backpack',  label: 'Preparar la mochila 🎒' }
+      { id: 'bed',       label: 'Make the bed 🛏️' },
+      { id: 'teeth',     label: 'Brush teeth 🦷' },
+      { id: 'dressed',   label: 'Get dressed 👕' },
+      { id: 'breakfast', label: 'Eat breakfast 🥣' },
+      { id: 'backpack',  label: 'Pack the backpack 🎒' }
     ],
     evening: [
-      { id: 'homework',  label: 'Tarea del cole ✏️' },
-      { id: 'tidy',      label: 'Ordenar el cuarto 🧸' },
-      { id: 'laundry',   label: 'Guardar la ropa 🧦' },
-      { id: 'teeth_pm',  label: 'Cepillarse los dientes 🦷' },
-      { id: 'read',      label: 'Leer un rato 📖' }
+      { id: 'homework',  label: 'Homework ✏️' },
+      { id: 'tidy',      label: 'Tidy the room 🧸' },
+      { id: 'laundry',   label: 'Put laundry away 🧦' },
+      { id: 'teeth_pm',  label: 'Brush teeth 🦷' },
+      { id: 'read',      label: 'Read for a bit 📖' }
     ]
   };
 
@@ -209,6 +211,7 @@ var Routines = (function() {
       if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
         ActivityLog.log('Routines', '✅', 'Day complete (streak ' + data.streak + ')');
       }
+      // Already English — left as-is.
     }
     _save(data);
     return getStatus();
@@ -230,15 +233,15 @@ var Routines = (function() {
 
     var which = getActiveRoutine();
     var block = which === 'morning' ? status.morning : status.evening;
-    var heading = which === 'morning' ? '🌅 Buenos días' : '🌙 Buenas noches';
+    var heading = which === 'morning' ? '🌅 Good morning' : '🌙 Good night';
 
     if (block.complete) {
       el.innerHTML =
         '<div class="rn-card rn-done" onclick="Routines._open(\'' + which + '\')">' +
           '<div class="rn-emoji">🎉</div>' +
           '<div class="rn-body">' +
-            '<div class="rn-title">' + heading + ' — ¡listo!</div>' +
-            '<div class="rn-sub">Racha: 🔥 ' + status.streak + ' día' + (status.streak === 1 ? '' : 's') + '</div>' +
+            '<div class="rn-title">' + heading + ' — all done!</div>' +
+            '<div class="rn-sub">Streak: 🔥 ' + status.streak + ' day' + (status.streak === 1 ? '' : 's') + '</div>' +
           '</div>' +
           '<div class="rn-arrow">→</div>' +
         '</div>';
@@ -251,7 +254,7 @@ var Routines = (function() {
         '<div class="rn-emoji">' + (which === 'morning' ? '🌅' : '🌙') + '</div>' +
         '<div class="rn-body">' +
           '<div class="rn-title">' + heading + '</div>' +
-          '<div class="rn-sub">' + remaining + ' cosa' + (remaining === 1 ? '' : 's') + ' por hacer' +
+          '<div class="rn-sub">' + remaining + ' thing' + (remaining === 1 ? '' : 's') + ' to do' +
           (status.streak > 0 ? ' · 🔥 ' + status.streak : '') + '</div>' +
           '<div class="rn-bar"><div class="rn-bar-fill" style="width:' + Math.round((block.doneCount / block.total) * 100) + '%"></div></div>' +
         '</div>' +
@@ -270,7 +273,7 @@ var Routines = (function() {
       '<div class="dash-panel" style="max-width:480px;">' +
         '<h2 style="display:flex;align-items:center;justify-content:space-between;">' +
           '<span id="routines-title">Routine</span>' +
-          '<button class="dash-close" onclick="Routines._close()" aria-label="Cerrar">✕</button>' +
+          '<button class="dash-close" onclick="Routines._close()" aria-label="Close">✕</button>' +
         '</h2>' +
         '<div id="routines-body"></div>' +
       '</div>';
@@ -292,9 +295,9 @@ var Routines = (function() {
   function _renderModal(which) {
     var status = getStatus();
     var block = which === 'morning' ? status.morning : status.evening;
-    var title = which === 'morning' ? '🌅 Rutina de la mañana' : '🌙 Rutina de la noche';
+    var title = which === 'morning' ? '🌅 Morning routine' : '🌙 Night routine';
     var other = which === 'morning' ? 'evening' : 'morning';
-    var otherLabel = which === 'morning' ? '🌙 Noche' : '🌅 Mañana';
+    var otherLabel = which === 'morning' ? '🌙 Night' : '🌅 Morning';
 
     var titleEl = document.getElementById('routines-title');
     if (titleEl) titleEl.textContent = title;
@@ -304,9 +307,9 @@ var Routines = (function() {
 
     var progressPct = Math.round((block.doneCount / block.total) * 100);
     var streakLine = status.streak > 0
-      ? '<div class="rn-streak">🔥 Racha de ' + status.streak + ' día' + (status.streak === 1 ? '' : 's') +
-        (status.bestStreak > status.streak ? ' · Mejor: ' + status.bestStreak : '') + '</div>'
-      : '<div class="rn-streak rn-streak-empty">Completa ambas rutinas para empezar una racha</div>';
+      ? '<div class="rn-streak">🔥 ' + status.streak + '-day streak' +
+        (status.bestStreak > status.streak ? ' · Best: ' + status.bestStreak : '') + '</div>'
+      : '<div class="rn-streak rn-streak-empty">Finish both routines in the same day to start a streak</div>';
 
     var itemsHtml = block.items.map(function(it) {
       return '<label class="rn-item ' + (it.done ? 'rn-done-item' : '') + '">' +
@@ -325,7 +328,7 @@ var Routines = (function() {
       '<div class="rn-list">' + itemsHtml + '</div>' +
       '<div class="rn-switch">' +
         '<button class="hub-action-btn secondary" onclick="Routines._open(\'' + other + '\')">' +
-          'Ver ' + otherLabel +
+          'See ' + otherLabel +
         '</button>' +
       '</div>';
   }


### PR DESCRIPTION
All user-facing strings in the Routines feature now read in English.

### `js/routines.js`
- **DEFAULTS** template labels (morning + evening)
- Hub widget: "Good morning / Good night", "— all done!", "Streak: 🔥 X day(s)", "X thing(s) to do"
- Modal title: "Morning routine / Night routine"
- Streak lines: "X-day streak · Best: Y" and "Finish both routines in the same day to start a streak"
- "See 🌙 Night / See 🌅 Morning" switch
- Close button aria-label

### `js/index.js` (Parents Corner editor)
- "📋 Routines" section label
- "🌅 Morning" / "🌙 Night" block headings
- "↻ Default" tooltip "Restore defaults"
- "New task…" placeholder + "＋ Add" button
- "Keep at least one task…" alert
- "Restore the morning/night routine to defaults?" confirm

### Migration
IDs are opaque and untouched, so existing custom templates and saved day-by-day completion data migrate cleanly — only visible labels change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_