### PR TITLE
Fix Sports Arena Standings to aggregate across the whole family

### DIFF
--- a/js/sports-arena.js
+++ b/js/sports-arena.js
@@ -116,14 +116,71 @@ const SportsArena = (() => {
   }
 
   function getMatches(sportId) {
+    // Per-active-user. Kept for callers that really want one kid's
+    // matches (eg. tournament views). Aggregate views use
+    // _getAllFamilyMatches below.
     const data = _getData();
     if (!sportId) return data.matches || [];
     return (data.matches || []).filter(m => m.sportId === sportId);
   }
 
   function getRecentMatches(limit) {
-    const data = _getData();
-    return (data.matches || []).slice(-(limit || 10)).reverse();
+    // Standings screen is family-wide; merge across every profile.
+    return _getAllFamilyMatches()
+      .slice(-(limit || 10))
+      .reverse();
+  }
+
+  // Iterate every profile's zs_sports_<kid> blob and merge match
+  // arrays. Deduplicates when the same match was logged twice (once
+  // by each kid) using a fingerprint of date + sport + ordered
+  // player/score pair, so "Leo vs Ana 3-1" and "Ana vs Leo 1-3"
+  // collapse into one row.
+  function _getAllFamilyMatches(sportId) {
+    if (typeof getProfiles !== 'function') {
+      // Fallback to current-user behaviour if profiles API isn't loaded.
+      return getMatches(sportId);
+    }
+    const profiles = getProfiles();
+    const seen = {};
+    const merged = [];
+
+    profiles.forEach(p => {
+      const key = 'zs_sports_' + p.name.toLowerCase().replace(/\s+/g, '_');
+      let data;
+      try { data = JSON.parse(localStorage.getItem(key)) || {}; }
+      catch (e) { data = {}; }
+      const list = Array.isArray(data.matches) ? data.matches : [];
+
+      list.forEach(m => {
+        if (sportId && m.sportId !== sportId) return;
+        // Fingerprint ignores player-order and score-order.
+        const names = [String(m.player1 || ''), String(m.player2 || '')].sort();
+        const scores = [Number(m.score1) || 0, Number(m.score2) || 0];
+        // Pair names with their original scores, then sort by name so
+        // the fingerprint is order-insensitive.
+        const pairs = [
+          [String(m.player1 || ''), Number(m.score1) || 0],
+          [String(m.player2 || ''), Number(m.score2) || 0]
+        ].sort((a, b) => a[0].localeCompare(b[0]));
+        const day = (m.date || '').slice(0, 10); // YYYY-MM-DD
+        const fp = [
+          day,
+          String(m.sportId || ''),
+          pairs[0][0] + ':' + pairs[0][1],
+          pairs[1][0] + ':' + pairs[1][1]
+        ].join('|');
+
+        if (seen[fp]) return;
+        seen[fp] = true;
+        merged.push(m);
+      });
+    });
+
+    // Sort ascending by date so .slice(-N).reverse() still means
+    // "N most recent, newest first" — matches the prior contract.
+    merged.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+    return merged;
   }
 
   // ── Round Robin Tournament ──
@@ -270,7 +327,10 @@ const SportsArena = (() => {
   // ── Global Standings (across all matches) ──
 
   function getGlobalStandings(sportId) {
-    const matches = getMatches(sportId);
+    // Aggregate every family profile's matches, deduplicated, so the
+    // Standings screen is genuinely family-wide regardless of which
+    // kid is currently active.
+    const matches = _getAllFamilyMatches(sportId);
     const stats = {};
 
     matches.forEach(m => {

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -191,7 +191,7 @@
   <div class="screen" id="screen-standings">
     <div class="section-header">
       <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
-      <div class="section-title">📊 Standings & History</div>
+      <div class="section-title">📊 Family Standings & History</div>
     </div>
 
     <div class="form-group">


### PR DESCRIPTION
Standings and Recent Matches both only showed the **active user's** matches. "Family" was implied by the UI text but never actually computed from anyone else's data.

### Fix
- New internal `_getAllFamilyMatches(sportId)` walks every profile via `getProfiles()` and merges each kid's `zs_sports_<name>.matches` into one list.
- **Dedupe** when the same match was logged twice (once by each kid): fingerprint = `YYYY-MM-DD | sportId | [player+score]` pair sorted by name. So "Leo vs Ana 3-1" and "Ana vs Leo 1-3" logged on 2026-04-24 collapse to one row.
- `getGlobalStandings()` now reads from the merged list.
- `getRecentMatches()` now does too.
- `getMatches()` (exported) kept as current-user-only for anywhere that wants one kid's matches — e.g. tournament views.
- Screen title is now **📊 Family Standings & History** so the expectation is unambiguous.

### No storage changes
Existing per-kid data is unaffected; the merge reads what's already there.

### Flag for review
Dedup is lossless for honest double-logs. If kids split-record intentionally (rare), one of the duplicates will drop. The fingerprint is deliberately strict; if you hit false merges we can loosen it later.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_