### PR TITLE
Add Vacation Planner (#154)

### DIFF
--- a/css/vacation.css
+++ b/css/vacation.css
@@ -1,0 +1,327 @@
+/* ============================================================
+   VACATION PLANNER
+   ============================================================ */
+
+.vc-header { text-align: center; margin: 16px 0 24px; }
+.vc-icon { font-size: 56px; display: block; margin-bottom: 8px; }
+.vc-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 5vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, #60A5FA, #FBBF24, #F472B6);
+  background-size: 200% 200%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: gradShift 6s ease-in-out infinite;
+}
+.vc-header p {
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  margin-top: 4px;
+}
+
+.vc-toolbar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 18px;
+}
+.vc-toolbar button {
+  padding: 8px 14px;
+  border-radius: 99px;
+  border: 1.5px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.82rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.vc-toolbar button:hover { border-color: #60A5FA; color: #60A5FA; }
+.vc-toolbar .vc-tb-primary {
+  background: linear-gradient(135deg, #7C3AED, #A78BFA);
+  border-color: transparent;
+  color: #fff;
+}
+
+/* Trip list */
+.vc-trips {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+.vc-trip {
+  padding: 16px 18px;
+  background: var(--bg-surface);
+  border: 1.5px solid rgba(255,255,255,0.06);
+  border-radius: 16px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.vc-trip:hover {
+  transform: translateY(-2px);
+  border-color: rgba(96,165,250,0.4);
+}
+.vc-trip.past { opacity: 0.6; }
+.vc-trip.upcoming { border-color: rgba(251,191,36,0.35); }
+
+.vc-trip-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+}
+.vc-trip-icon { font-size: 1.6rem; flex-shrink: 0; }
+.vc-trip-name {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.1rem;
+  flex: 1;
+  min-width: 0;
+}
+.vc-trip-dest {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+.vc-countdown {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 99px;
+  background: rgba(251,191,36,0.12);
+  color: #FBBF24;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.85rem;
+}
+.vc-countdown.now { background: rgba(52,211,153,0.15); color: #34D399; }
+.vc-countdown.past { background: rgba(255,255,255,0.05); color: var(--text-muted); }
+
+.vc-empty {
+  text-align: center;
+  padding: 32px 16px;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+
+/* Trip detail */
+.vc-detail {
+  background: var(--bg-surface);
+  border: 1.5px solid rgba(255,255,255,0.06);
+  border-radius: 18px;
+  padding: 20px;
+}
+.vc-detail-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.vc-detail-icon { font-size: 2.4rem; }
+.vc-detail-title {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 800;
+  flex: 1;
+  min-width: 0;
+}
+.vc-detail-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+.vc-detail-meta span {
+  padding: 4px 10px;
+  border-radius: 99px;
+  background: rgba(255,255,255,0.04);
+}
+
+.vc-section { margin-bottom: 20px; }
+.vc-section-head {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+  margin-bottom: 8px;
+  color: var(--text);
+}
+.vc-section-head a {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #60A5FA;
+  text-decoration: none;
+  margin-left: 8px;
+}
+
+/* Packing list */
+.vc-pack-cols {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+.vc-pack-col {
+  padding: 10px 12px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 12px;
+}
+.vc-pack-col h4 {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.85rem;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+.vc-pack-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+.vc-pack-row label { flex: 1; cursor: pointer; }
+.vc-pack-row.done label { text-decoration: line-through; color: var(--text-muted); }
+.vc-pack-row input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  accent-color: #34D399;
+  cursor: pointer;
+}
+.vc-pack-row .vc-pack-del {
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.9rem;
+  opacity: 0.5;
+}
+.vc-pack-row:hover .vc-pack-del { opacity: 1; }
+
+.vc-pack-add {
+  display: flex;
+  gap: 4px;
+  margin-top: 6px;
+}
+.vc-pack-add input {
+  flex: 1;
+  padding: 6px 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.2);
+  color: var(--text);
+  font-size: 0.8rem;
+  outline: none;
+}
+.vc-pack-add button {
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: none;
+  background: rgba(52,211,153,0.15);
+  color: #34D399;
+  font-weight: 800;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+/* Itinerary */
+.vc-day {
+  padding: 10px 14px;
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 12px;
+  margin-bottom: 8px;
+}
+.vc-day-head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 4px;
+}
+.vc-day-num {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.9rem;
+}
+.vc-day-date {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  font-weight: 700;
+}
+.vc-day textarea {
+  width: 100%;
+  min-height: 50px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(0,0,0,0.2);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  outline: none;
+  resize: vertical;
+}
+.vc-day textarea:focus { border-color: #60A5FA; }
+
+/* Form */
+.vc-form .vc-field {
+  margin-bottom: 12px;
+}
+.vc-form label {
+  display: block;
+  font-weight: 700;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 4px;
+}
+.vc-form input, .vc-form select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(0,0,0,0.2);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  outline: none;
+}
+.vc-form input:focus, .vc-form select:focus { border-color: #60A5FA; }
+.vc-form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 16px;
+}
+.vc-form-actions button {
+  padding: 10px 18px;
+  border-radius: 10px;
+  border: none;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+.vc-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
+.vc-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); }
+.vc-btn-danger { background: rgba(248,113,113,0.12); color: #F87171; }
+
+@media (max-width: 480px) {
+  .vc-pack-cols { grid-template-columns: 1fr; }
+}
+
+@media print {
+  body { background: #fff !important; color: #000 !important; }
+  .no-print { display: none !important; }
+  .atmo { display: none !important; }
+}

--- a/index.html
+++ b/index.html
@@ -247,6 +247,9 @@
         <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="menu.html">
           🍽️ Menú Semanal
         </a>
+        <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="vacation.html">
+          ✈️ Vacation Planner
+        </a>
         <button class="parent-btn" style="margin-top:0;" onclick="requestPinThen(function() { openParentsCorner(); })">
           🔒 Parents Corner
         </button>

--- a/js/vacation.js
+++ b/js/vacation.js
@@ -1,0 +1,465 @@
+/* ================================================================
+   VACATION PLANNER — vacation.js
+   Family-shared trip planner: countdown, packing list, itinerary,
+   and one-tap jumps to relevant learning apps for the destination.
+
+   Storage key: zs_vacation
+     {
+       trips: [
+         { id, name, destination, country, icon,
+           startDate, endDate, notes,
+           packing: { shared: [...], <profileName>: [...] },
+                       // each item: { id, label, packed: bool }
+           itinerary: { "YYYY-MM-DD": "Activities text…" }
+         },
+         ...
+       ]
+     }
+
+   Uses parent PIN to unlock editing (reuses requestPinThen).
+   Read-only browsing by default.
+   ================================================================ */
+
+var Vacation = (function() {
+  'use strict';
+
+  var STORAGE_KEY = 'zs_vacation';
+  var _parentUnlocked = false;
+  var _viewing = null;  // currently-open trip id, or null
+  var _mode = 'list';   // 'list' | 'detail' | 'edit' | 'new'
+
+  // Default packing categories per kid + shared family items.
+  var DEFAULT_PACKING = {
+    shared: [
+      'Suitcase', 'Passports', 'Tickets',
+      'First-aid kit', 'Sunscreen'
+    ],
+    perKid: [
+      'Underwear', 'Socks', 'T-shirts',
+      'Pants/shorts', 'Pyjamas', 'Toothbrush',
+      'Hairbrush', 'Favourite stuffed animal'
+    ]
+  };
+
+  function _esc(s) {
+    return String(s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function _load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      var d = raw ? JSON.parse(raw) : {};
+      if (!Array.isArray(d.trips)) d.trips = [];
+      return d;
+    } catch (e) { return { trips: [] }; }
+  }
+
+  function _save(data) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+    catch (e) {}
+  }
+
+  function _uid() {
+    return 't_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 5);
+  }
+
+  function _today() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _daysBetween(from, to) {
+    var a = new Date(from + 'T00:00:00');
+    var b = new Date(to + 'T00:00:00');
+    return Math.round((b - a) / 86400000);
+  }
+
+  function _countdown(trip) {
+    if (!trip.startDate) return null;
+    var today = _today();
+    var d = _daysBetween(today, trip.startDate);
+    if (d > 0) return { kind: 'upcoming', text: d + ' day' + (d === 1 ? '' : 's') + ' to ' + trip.name };
+    if (d === 0) return { kind: 'now', text: 'Starts today!' };
+    if (trip.endDate) {
+      var e = _daysBetween(today, trip.endDate);
+      if (e >= 0) return { kind: 'now', text: 'Day ' + Math.abs(d) + ' of trip' };
+    }
+    return { kind: 'past', text: 'Past trip' };
+  }
+
+  function _isUpcomingOrCurrent(trip) {
+    if (!trip.endDate) return _daysBetween(_today(), trip.startDate || _today()) >= 0;
+    return _daysBetween(_today(), trip.endDate) >= 0;
+  }
+
+  // ── Public actions ──
+  function unlockParent() {
+    if (typeof requestPinThen === 'function') {
+      requestPinThen(function() { _parentUnlocked = true; _render(); });
+    } else {
+      _parentUnlocked = true; _render();
+    }
+  }
+
+  function newTrip() {
+    if (!_parentUnlocked) { unlockParent(); return; }
+    _mode = 'new';
+    _viewing = null;
+    _render();
+  }
+
+  function openTrip(id) {
+    _viewing = id;
+    _mode = 'detail';
+    _render();
+  }
+
+  function backToList() {
+    _viewing = null;
+    _mode = 'list';
+    _render();
+  }
+
+  function deleteTrip(id) {
+    if (!_parentUnlocked) return;
+    if (!confirm('Delete this trip and all its data?')) return;
+    var data = _load();
+    data.trips = data.trips.filter(function(t) { return t.id !== id; });
+    _save(data);
+    _viewing = null;
+    _mode = 'list';
+    _render();
+  }
+
+  function saveNewTrip() {
+    if (!_parentUnlocked) return;
+    var name = document.getElementById('vc-new-name').value.trim();
+    var dest = document.getElementById('vc-new-dest').value.trim();
+    var country = document.getElementById('vc-new-country').value.trim();
+    var start = document.getElementById('vc-new-start').value;
+    var end = document.getElementById('vc-new-end').value;
+    var icon = document.getElementById('vc-new-icon').value.trim() || '✈️';
+
+    if (!name || !start) {
+      alert('Pick a trip name and a start date.');
+      return;
+    }
+    var data = _load();
+    var profiles = typeof getProfiles === 'function' ? getProfiles() : [];
+    var packing = {
+      shared: DEFAULT_PACKING.shared.map(function(label, i) {
+        return { id: 'p_s_' + i, label: label, packed: false };
+      })
+    };
+    profiles.forEach(function(p) {
+      packing[p.name] = DEFAULT_PACKING.perKid.map(function(label, i) {
+        return { id: 'p_' + p.name + '_' + i, label: label, packed: false };
+      });
+    });
+
+    data.trips.push({
+      id: _uid(),
+      name: name,
+      destination: dest,
+      country: country,
+      icon: icon,
+      startDate: start,
+      endDate: end || start,
+      notes: '',
+      packing: packing,
+      itinerary: {}
+    });
+    _save(data);
+    _mode = 'list';
+    _render();
+  }
+
+  function togglePackItem(tripId, key, itemId) {
+    if (!_parentUnlocked) return;
+    var data = _load();
+    var trip = data.trips.find(function(t) { return t.id === tripId; });
+    if (!trip || !trip.packing[key]) return;
+    var item = trip.packing[key].find(function(it) { return it.id === itemId; });
+    if (!item) return;
+    item.packed = !item.packed;
+    _save(data);
+    _render();
+  }
+
+  function addPackItem(tripId, key) {
+    if (!_parentUnlocked) return;
+    var inp = document.getElementById('vc-add-' + key);
+    if (!inp) return;
+    var label = inp.value.trim();
+    if (!label) return;
+    var data = _load();
+    var trip = data.trips.find(function(t) { return t.id === tripId; });
+    if (!trip) return;
+    if (!trip.packing[key]) trip.packing[key] = [];
+    trip.packing[key].push({ id: 'pi_' + Date.now().toString(36), label: label, packed: false });
+    _save(data);
+    inp.value = '';
+    _render();
+  }
+
+  function removePackItem(tripId, key, itemId) {
+    if (!_parentUnlocked) return;
+    var data = _load();
+    var trip = data.trips.find(function(t) { return t.id === tripId; });
+    if (!trip || !trip.packing[key]) return;
+    trip.packing[key] = trip.packing[key].filter(function(it) { return it.id !== itemId; });
+    _save(data);
+    _render();
+  }
+
+  function setItinerary(tripId, dayKey, value) {
+    if (!_parentUnlocked) return;
+    var data = _load();
+    var trip = data.trips.find(function(t) { return t.id === tripId; });
+    if (!trip) return;
+    if (!trip.itinerary) trip.itinerary = {};
+    trip.itinerary[dayKey] = String(value).slice(0, 500);
+    _save(data);
+    // No re-render — preserve textarea focus/cursor while typing.
+  }
+
+  // Suggested learning-app jumps based on country.
+  // Currently: only Chile gets a Descubre Chile shortcut. Easy to
+  // extend per destination later.
+  function _learningLinks(trip) {
+    var links = [];
+    var country = String(trip.country || '').toLowerCase();
+    if (country === 'chile') {
+      links.push({ href: 'descubre-chile.html', label: '🇨🇱 Descubre Chile', sub: 'Learn about Chilean regions and culture' });
+    }
+    // World Explorer always offered as a generic geography jump.
+    if (country) {
+      links.push({ href: 'world-explorer.html', label: '🌍 World Explorer', sub: 'Find ' + trip.country + ' on the map' });
+    }
+    return links;
+  }
+
+  // ── Rendering ──
+  function _render() {
+    var wrap = document.getElementById('vc-wrap');
+    if (!wrap) return;
+
+    if (_mode === 'new') return _renderNewForm(wrap);
+    if (_mode === 'detail' && _viewing) return _renderDetail(wrap);
+    return _renderList(wrap);
+  }
+
+  function _renderList(wrap) {
+    var data = _load();
+    var trips = data.trips.slice();
+    // Sort: upcoming/current first by start date, then past
+    trips.sort(function(a, b) {
+      var aPast = !_isUpcomingOrCurrent(a);
+      var bPast = !_isUpcomingOrCurrent(b);
+      if (aPast !== bPast) return aPast ? 1 : -1;
+      return String(a.startDate || '').localeCompare(String(b.startDate || ''));
+    });
+
+    var lockTxt = _parentUnlocked ? '🔓 Editing' : '🔒 Unlock to edit';
+    wrap.innerHTML =
+      '<div class="vc-header">' +
+        '<span class="vc-icon">✈️</span>' +
+        '<h1>Vacation Planner</h1>' +
+        '<p>Countdowns, packing lists, and day-by-day plans for upcoming trips.</p>' +
+      '</div>' +
+      '<div class="vc-toolbar">' +
+        (_parentUnlocked
+          ? '<button class="vc-tb-primary" onclick="Vacation.newTrip()">＋ New trip</button>'
+          : '<button onclick="Vacation.unlockParent()">' + lockTxt + '</button>') +
+      '</div>' +
+      (trips.length === 0
+        ? '<div class="vc-empty">No trips yet. Tap "Unlock to edit" then "New trip" to add one.</div>'
+        : '<div class="vc-trips">' + trips.map(_tripCardHtml).join('') + '</div>');
+  }
+
+  function _tripCardHtml(trip) {
+    var cd = _countdown(trip);
+    var cls = cd ? cd.kind : 'upcoming';
+    return '<div class="vc-trip ' + cls + '" onclick="Vacation.openTrip(\'' + trip.id + '\')">' +
+      '<div class="vc-trip-head">' +
+        '<span class="vc-trip-icon">' + _esc(trip.icon || '✈️') + '</span>' +
+        '<span class="vc-trip-name">' + _esc(trip.name) + '</span>' +
+      '</div>' +
+      '<div class="vc-trip-dest">' + _esc(trip.destination || '') +
+        (trip.country ? ' · ' + _esc(trip.country) : '') + '</div>' +
+      (cd ? '<div class="vc-countdown ' + cd.kind + '">' + _esc(cd.text) + '</div>' : '') +
+    '</div>';
+  }
+
+  function _renderNewForm(wrap) {
+    wrap.innerHTML =
+      '<div class="vc-header">' +
+        '<span class="vc-icon">✈️</span>' +
+        '<h1>New trip</h1>' +
+      '</div>' +
+      '<div class="vc-detail">' +
+        '<div class="vc-form">' +
+          '<div class="vc-field"><label>Name</label><input type="text" id="vc-new-name" placeholder="e.g. Patagonia summer" maxlength="40"></div>' +
+          '<div class="vc-field"><label>Destination</label><input type="text" id="vc-new-dest" placeholder="e.g. Pucón" maxlength="60"></div>' +
+          '<div class="vc-field"><label>Country</label><input type="text" id="vc-new-country" placeholder="e.g. Chile" maxlength="40"></div>' +
+          '<div class="vc-field"><label>Icon (one emoji)</label><input type="text" id="vc-new-icon" maxlength="2" placeholder="✈️"></div>' +
+          '<div class="vc-field"><label>Start date</label><input type="date" id="vc-new-start"></div>' +
+          '<div class="vc-field"><label>End date (optional)</label><input type="date" id="vc-new-end"></div>' +
+          '<div class="vc-form-actions">' +
+            '<button class="vc-btn-secondary" onclick="Vacation.backToList()">Cancel</button>' +
+            '<button class="vc-btn-primary" onclick="Vacation.saveNewTrip()">Save trip</button>' +
+          '</div>' +
+        '</div>' +
+      '</div>';
+  }
+
+  function _renderDetail(wrap) {
+    var data = _load();
+    var trip = data.trips.find(function(t) { return t.id === _viewing; });
+    if (!trip) { backToList(); return; }
+
+    var cd = _countdown(trip);
+    var packingHtml = _renderPacking(trip);
+    var itinHtml = _renderItinerary(trip);
+    var linksHtml = _learningLinks(trip).map(function(l) {
+      return '<a class="vc-trip" href="' + _esc(l.href) + '" style="text-decoration:none;color:inherit;display:block;">' +
+        '<div class="vc-trip-head">' +
+          '<span class="vc-trip-icon">' + l.label.split(' ')[0] + '</span>' +
+          '<span class="vc-trip-name">' + _esc(l.label.replace(/^[^ ]+ /, '')) + '</span>' +
+        '</div>' +
+        '<div class="vc-trip-dest">' + _esc(l.sub) + '</div>' +
+      '</a>';
+    }).join('');
+
+    wrap.innerHTML =
+      '<div class="vc-toolbar">' +
+        '<button onclick="Vacation.backToList()">← All trips</button>' +
+        (_parentUnlocked
+          ? '<button class="vc-btn-danger" style="border-color:rgba(248,113,113,0.25);" onclick="Vacation.deleteTrip(\'' + trip.id + '\')">🗑 Delete</button>'
+          : '<button onclick="Vacation.unlockParent()">🔒 Unlock to edit</button>') +
+      '</div>' +
+      '<div class="vc-detail">' +
+        '<div class="vc-detail-head">' +
+          '<span class="vc-detail-icon">' + _esc(trip.icon || '✈️') + '</span>' +
+          '<div class="vc-detail-title">' + _esc(trip.name) + '</div>' +
+        '</div>' +
+        '<div class="vc-detail-meta">' +
+          (trip.destination ? '<span>📍 ' + _esc(trip.destination) + '</span>' : '') +
+          (trip.country ? '<span>' + _esc(trip.country) + '</span>' : '') +
+          (trip.startDate ? '<span>📅 ' + _esc(trip.startDate) +
+            (trip.endDate && trip.endDate !== trip.startDate ? ' → ' + _esc(trip.endDate) : '') + '</span>' : '') +
+          (cd ? '<span class="vc-countdown ' + cd.kind + '">' + _esc(cd.text) + '</span>' : '') +
+        '</div>' +
+        '<div class="vc-section">' +
+          '<div class="vc-section-head">🧳 Packing</div>' +
+          packingHtml +
+        '</div>' +
+        '<div class="vc-section">' +
+          '<div class="vc-section-head">🗓 Itinerary</div>' +
+          itinHtml +
+        '</div>' +
+        (linksHtml ? '<div class="vc-section">' +
+          '<div class="vc-section-head">📖 Learn before you go</div>' +
+          '<div class="vc-trips">' + linksHtml + '</div>' +
+        '</div>' : '') +
+      '</div>';
+  }
+
+  function _renderPacking(trip) {
+    var keys = Object.keys(trip.packing || {});
+    if (keys.length === 0) return '<div class="vc-empty" style="padding:12px 0;">No packing list yet.</div>';
+    keys.sort(function(a, b) {
+      // Shared first, then alphabetical
+      if (a === 'shared') return -1;
+      if (b === 'shared') return 1;
+      return a.localeCompare(b);
+    });
+    var cols = keys.map(function(k) {
+      var items = trip.packing[k] || [];
+      var rows = items.map(function(it) {
+        return '<div class="vc-pack-row ' + (it.packed ? 'done' : '') + '">' +
+          '<input type="checkbox" id="' + it.id + '" ' + (it.packed ? 'checked' : '') +
+            (_parentUnlocked ? '' : ' disabled') +
+            ' onchange="Vacation._togglePack(\'' + trip.id + '\', \'' + k + '\', \'' + it.id + '\')">' +
+          '<label for="' + it.id + '">' + _esc(it.label) + '</label>' +
+          (_parentUnlocked
+            ? '<button class="vc-pack-del" onclick="Vacation._delPack(\'' + trip.id + '\', \'' + k + '\', \'' + it.id + '\')" aria-label="Remove">✕</button>'
+            : '') +
+        '</div>';
+      }).join('');
+      var addRow = _parentUnlocked
+        ? '<div class="vc-pack-add">' +
+            '<input type="text" id="vc-add-' + k + '" placeholder="Add item…" maxlength="40" ' +
+                   'onkeydown="if(event.key===\'Enter\'){event.preventDefault();Vacation._addPack(\'' + trip.id + '\', \'' + k + '\');}">' +
+            '<button onclick="Vacation._addPack(\'' + trip.id + '\', \'' + k + '\')">＋</button>' +
+          '</div>'
+        : '';
+      var heading = k === 'shared' ? '🧳 Shared' : '👤 ' + k;
+      return '<div class="vc-pack-col">' +
+        '<h4>' + _esc(heading) + '</h4>' +
+        rows +
+        addRow +
+      '</div>';
+    }).join('');
+    return '<div class="vc-pack-cols">' + cols + '</div>';
+  }
+
+  function _renderItinerary(trip) {
+    if (!trip.startDate) return '<div class="vc-empty" style="padding:12px 0;">Add a start date to plan day-by-day.</div>';
+    var start = new Date(trip.startDate + 'T00:00:00');
+    var end = new Date((trip.endDate || trip.startDate) + 'T00:00:00');
+    var dayCount = Math.max(1, Math.round((end - start) / 86400000) + 1);
+    if (dayCount > 30) dayCount = 30; // sanity cap
+
+    var html = '';
+    for (var i = 0; i < dayCount; i++) {
+      var d = new Date(start.getTime() + i * 86400000);
+      var key = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+      var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+      var label = months[d.getMonth()] + ' ' + d.getDate();
+      var val = (trip.itinerary && trip.itinerary[key]) || '';
+      html +=
+        '<div class="vc-day">' +
+          '<div class="vc-day-head">' +
+            '<span class="vc-day-num">Day ' + (i + 1) + '</span>' +
+            '<span class="vc-day-date">' + label + '</span>' +
+          '</div>' +
+          '<textarea ' + (_parentUnlocked ? '' : 'disabled') +
+            ' placeholder="Activities, meals, places to visit…"' +
+            ' oninput="Vacation._setItin(\'' + trip.id + '\', \'' + key + '\', this.value)">' +
+            _esc(val) +
+          '</textarea>' +
+        '</div>';
+    }
+    return html;
+  }
+
+  // ── Init ──
+  function init() {
+    _parentUnlocked = false;
+    _viewing = null;
+    _mode = 'list';
+    _render();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  return {
+    unlockParent: unlockParent,
+    newTrip: newTrip,
+    openTrip: openTrip,
+    backToList: backToList,
+    deleteTrip: deleteTrip,
+    saveNewTrip: saveNewTrip,
+    _togglePack: togglePackItem,
+    _addPack: addPackItem,
+    _delPack: removePackItem,
+    _setItin: setItinerary
+  };
+})();

--- a/vacation.html
+++ b/vacation.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vacation Planner ✈️</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/vacation.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body>
+  <div class="atmo" style="width:400px;height:400px;background:rgba(96,165,250,0.08);top:-100px;left:-100px;"></div>
+  <div class="atmo" style="width:350px;height:350px;background:rgba(251,191,36,0.06);bottom:-80px;right:-80px;animation-delay:-8s;"></div>
+
+  <div class="app">
+    <div id="vc-wrap"></div>
+  </div>
+
+  <script src="js/debug.js"></script>
+  <script src="js/auth.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/nav.js"></script>
+  <script src="js/vacation.js"></script>
+  <script src="js/pwa.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New household utility under Parents Corner / hub: plan upcoming trips, manage packing lists, and sketch a day-by-day itinerary.
- Per-trip data: name, destination, country, icon, dates, packing (shared + per-kid lists), itinerary keyed by date.
- Countdown banner ("12 days to go!"), defaults seeded from a sensible starter packing list, and a learning-link shortcut to Descubre Chile / World Explorer based on the destination country.
- Print-friendly stylesheet so the packing list can come on the trip.

## Test plan
- [ ] Hub: Vacation Planner button appears under Parents Corner row.
- [ ] Create a trip → defaults populate; toggling and adding packing items persists.
- [ ] Edit itinerary by date; reload page; data still there.
- [ ] Delete a trip from detail view; PIN gate works.
- [ ] Print preview hides nav, shows packing list cleanly.

Closes #154

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_