### PR TITLE
Add Accessibility pass v1 (#185)

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -175,6 +175,8 @@
   <div id="feedback" class="feedback-float"><span></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -195,6 +195,7 @@
 
   <script src="js/nav.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/sounds.js"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -127,6 +127,8 @@
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 
 <script src="js/auth.js"></script>
+
+<script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
 <script src="js/zs-diag.js"></script>
 <script src="js/nav.js"></script>

--- a/css/common.css
+++ b/css/common.css
@@ -252,3 +252,73 @@ body::before {
     transition-duration: 0.01ms !important;
   }
 }
+
+/* ============================================================
+   ACCESSIBILITY OVERRIDES (driven by js/a11y.js)
+   ============================================================ */
+
+/* Explicit reduced-motion class for kids who toggle it on a device
+   whose OS isn't set to "reduce motion". */
+html.zs-a11y-reduce-motion *,
+html.zs-a11y-reduce-motion *::before,
+html.zs-a11y-reduce-motion *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: 0.01ms !important;
+  scroll-behavior: auto !important;
+}
+
+/* Dyslexia-friendly typography: keep our display headings, but
+   switch body copy to a clean sans with extra spacing. We use the
+   system "OpenDyslexic"/"Atkinson Hyperlegible" if installed,
+   otherwise a generous fallback stack. */
+html.zs-a11y-dyslexia {
+  --font-body: 'OpenDyslexic', 'Atkinson Hyperlegible', 'Verdana', 'Tahoma', system-ui, sans-serif;
+  letter-spacing: 0.02em;
+}
+html.zs-a11y-dyslexia body { line-height: 1.55; }
+
+/* High-contrast mode: replace gradients with flat colours, push
+   text to pure white, and bump borders. Kept as an override of
+   the existing :root vars so individual apps don't need changes. */
+html.zs-a11y-hc {
+  --bg-deep: #000000;
+  --bg-surface: #050510;
+  --bg-card: #0F0F1F;
+  --border-subtle: rgba(255,255,255,0.6);
+  --text: #FFFFFF;
+  --text-primary: #FFFFFF;
+  --text-muted: #DEDEEF;
+  --purple: #C4B5FD;
+  --green:  #6EE7B7;
+  --red:    #FCA5A5;
+  --gold:   #FDE68A;
+  --blue:   #93C5FD;
+  --cyan:   #67E8F9;
+}
+html.zs-a11y-hc body::before,
+html.zs-a11y-hc .aurora,
+html.zs-a11y-hc .atmo,
+html.zs-a11y-hc .nebula {
+  display: none !important;
+}
+html.zs-a11y-hc * {
+  text-shadow: none !important;
+}
+html.zs-a11y-hc a,
+html.zs-a11y-hc button,
+html.zs-a11y-hc input,
+html.zs-a11y-hc select,
+html.zs-a11y-hc textarea {
+  outline-offset: 2px;
+}
+html.zs-a11y-hc :focus-visible {
+  outline: 2.5px solid #FDE68A !important;
+  outline-offset: 3px !important;
+}
+
+/* Always-visible focus ring across the suite — independent of HC. */
+:focus-visible {
+  outline: 2px solid var(--purple, #A78BFA);
+  outline-offset: 2px;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -875,6 +875,28 @@
     .pk-toggle { display: flex; align-items: center; gap: 10px; cursor: pointer; }
     .pk-toggle input { width: 18px; height: 18px; accent-color: var(--purple); }
 
+    .a11y-scale-row {
+      display: flex; gap: 6px; flex-wrap: wrap;
+    }
+    .a11y-scale-btn {
+      flex: 1; min-width: 56px;
+      padding: 8px 10px;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      color: var(--text);
+      font-family: var(--font-display, var(--font-body));
+      font-weight: 700; font-size: 0.85rem;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s, color 0.15s;
+    }
+    .a11y-scale-btn:hover { background: rgba(255,255,255,0.08); }
+    .a11y-scale-btn.active {
+      background: rgba(124,58,237,0.25);
+      border-color: var(--purple);
+      color: #fff;
+    }
+
     /* App Cards */
     .card-faith { 
       --card-accent: #F59E0B; 

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -73,6 +73,7 @@
 <div class="region-modal" id="regionModal" onclick="if(event.target===this)closeRegion()"><div class="region-card"><button class="close-modal" aria-label="Close" onclick="closeRegion()">✕</button><h2 id="rmTitle"></h2><div class="region-sub" id="rmSub"></div><div id="rmFacts"></div><div style="text-align:center;margin-top:16px"><button class="btn-red" onclick="closeRegion()">¡Entendido! ✓</button></div></div></div>
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
+<script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
 <script src="js/zs-diag.js"></script>
 <script src="js/nav.js"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -118,6 +118,8 @@
   </div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -95,6 +95,8 @@
   <div class="feedback" id="feedback"><span class="feedback-emoji" id="feedbackEmoji"></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -149,6 +149,8 @@
   <div id="feedback" class="feedback-float"><span></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -26,6 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/index.html
+++ b/index.html
@@ -390,6 +390,7 @@
   <script src="js/debug.js?v=2"></script>
   ...
   <script src="js/auth.js?v=2"></script>
+  <script src="js/a11y.js?v=2"></script>
   <script src="js/sync.js?v=2"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>

--- a/js/a11y.js
+++ b/js/a11y.js
@@ -1,0 +1,113 @@
+/* ================================================================
+   ACCESSIBILITY — a11y.js
+   Per-kid display preferences applied across the suite:
+     - text size  (S / M / L / XL)
+     - high-contrast mode
+     - reduced motion
+     - dyslexia-friendly font (system stack — no extra download)
+
+   Loaded on every page. Re-applies on each navigation by reading
+   localStorage, so settings persist even when offline.
+
+   Storage: zs_a11y
+     {
+       <userKey or "_default">: { scale: 'm', contrast: false,
+                                  motion: 'auto', dyslexia: false }
+     }
+   ================================================================ */
+
+var ZsA11y = (function() {
+  'use strict';
+  if (typeof window === 'undefined') return null;
+
+  var STORAGE_KEY = 'zs_a11y';
+  var SCALES = { s: 0.875, m: 1.0, l: 1.15, xl: 1.3 };
+  var DEFAULT = { scale: 'm', contrast: false, motion: 'auto', dyslexia: false };
+
+  function _userKey(name) {
+    if (name) return name.toLowerCase().replace(/\s+/g, '_');
+    if (typeof getActiveUser === 'function') {
+      var u = getActiveUser();
+      if (u) return u.name.toLowerCase().replace(/\s+/g, '_');
+    }
+    return '_default';
+  }
+
+  function _loadAll() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      return raw ? (JSON.parse(raw) || {}) : {};
+    } catch (e) { return {}; }
+  }
+
+  function _saveAll(all) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(all)); }
+    catch (e) {}
+  }
+
+  function getSettings(userName) {
+    var all = _loadAll();
+    var k = _userKey(userName);
+    var s = all[k] || {};
+    return {
+      scale:    SCALES[s.scale] ? s.scale : DEFAULT.scale,
+      contrast: typeof s.contrast === 'boolean' ? s.contrast : DEFAULT.contrast,
+      motion:   (s.motion === 'reduce' || s.motion === 'normal') ? s.motion : DEFAULT.motion,
+      dyslexia: typeof s.dyslexia === 'boolean' ? s.dyslexia : DEFAULT.dyslexia
+    };
+  }
+
+  function setSettings(patch, userName) {
+    if (!patch) return;
+    var all = _loadAll();
+    var k = _userKey(userName);
+    var current = Object.assign({}, DEFAULT, all[k] || {});
+    if (patch.scale && SCALES[patch.scale]) current.scale = patch.scale;
+    if (typeof patch.contrast === 'boolean') current.contrast = patch.contrast;
+    if (patch.motion === 'reduce' || patch.motion === 'normal' || patch.motion === 'auto') current.motion = patch.motion;
+    if (typeof patch.dyslexia === 'boolean') current.dyslexia = patch.dyslexia;
+    all[k] = current;
+    _saveAll(all);
+    apply();
+    return current;
+  }
+
+  // Apply current user's settings to the document. Idempotent —
+  // safe to call repeatedly (eg. after profile switch).
+  function apply() {
+    var s = getSettings();
+    var html = document.documentElement;
+    if (!html) return;
+
+    // Scale via root font-size — every rem unit follows.
+    var ratio = SCALES[s.scale] || 1.0;
+    html.style.fontSize = (16 * ratio) + 'px';
+
+    html.classList.toggle('zs-a11y-hc', !!s.contrast);
+    html.classList.toggle('zs-a11y-dyslexia', !!s.dyslexia);
+
+    if (s.motion === 'reduce')      html.classList.add('zs-a11y-reduce-motion');
+    else                            html.classList.remove('zs-a11y-reduce-motion');
+    // 'auto' defers to the OS via @media(prefers-reduced-motion).
+    // 'normal' explicitly removes the class above.
+  }
+
+  // Apply once on load, and again whenever a profile change might
+  // have occurred (storage event from another tab, or focus-back).
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', apply);
+  } else {
+    apply();
+  }
+  window.addEventListener('storage', function(e) {
+    if (e.key === STORAGE_KEY || e.key === 'zs_active_user') apply();
+  });
+  window.addEventListener('focus', apply);
+
+  return {
+    getSettings: getSettings,
+    setSettings: setSettings,
+    apply: apply,
+    SCALES: SCALES
+  };
+})();

--- a/js/index.js
+++ b/js/index.js
@@ -121,6 +121,16 @@
       if (label) label.textContent = Number(val).toFixed(2) + 'x';
     }
   };
+  window.updateKidA11y = function(idx, field, val) {
+    if (typeof ZsA11y === 'undefined') return;
+    var profiles = getProfiles();
+    var name = profiles[idx] && profiles[idx].name;
+    if (!name) return;
+    var patch = {};
+    patch[field] = val;
+    ZsA11y.setSettings(patch, name);
+    renderParentsCorner();
+  };
   window.updateParentPin = function() { updateParentPin(); };
   window.renderChoresList = function() { renderChoresList(); };
   window.completeChore = function(id) { if (typeof ChoresManager !== 'undefined') ChoresManager.completeChore(id); };
@@ -1202,6 +1212,7 @@
                 '</div>'
               ) : '') +
               (typeof Routines !== 'undefined' ? _renderRoutinesEditor(p, i) : '') +
+              (typeof ZsA11y !== 'undefined' ? _renderA11yEditor(p, i) : '') +
             '</div>';
         }).join('') +
       '</div>' +
@@ -1310,6 +1321,48 @@
       '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">📋 Routines</label>' +
       block('morning', '🌅', 'Morning') +
       block('evening', '🌙', 'Night') +
+    '</div>';
+  }
+
+  function _renderA11yEditor(profile, idx) {
+    var s = ZsA11y.getSettings(profile.name);
+    var scales = [
+      { k: 's',  label: 'S' },
+      { k: 'm',  label: 'M' },
+      { k: 'l',  label: 'L' },
+      { k: 'xl', label: 'XL' }
+    ];
+    var scaleBtns = scales.map(function(sc) {
+      var on = s.scale === sc.k;
+      return '<button type="button" class="a11y-scale-btn' + (on ? ' active' : '') + '" ' +
+             'onclick="updateKidA11y(' + idx + ', \'scale\', \'' + sc.k + '\')" ' +
+             'aria-pressed="' + (on ? 'true' : 'false') + '">' + sc.label + '</button>';
+    }).join('');
+    var motionVal = s.motion;
+    return '<div class="pk-setting" style="margin-top:16px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.06);">' +
+      '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">♿ Accessibility</label>' +
+
+      '<label style="display:block; font-size:0.78rem; color:var(--text-muted); font-weight:700; margin-bottom:6px;">Text size</label>' +
+      '<div class="a11y-scale-row" role="group" aria-label="Text size for ' + escHtml(profile.name) + '">' + scaleBtns + '</div>' +
+
+      '<label class="pk-toggle" style="font-size:0.9rem; margin-top:12px;">' +
+        '<input type="checkbox" ' + (s.contrast ? 'checked' : '') + ' ' +
+               'onchange="updateKidA11y(' + idx + ', \'contrast\', this.checked)">' +
+        ' 🌓 High-contrast mode' +
+      '</label>' +
+
+      '<label class="pk-toggle" style="font-size:0.9rem; margin-top:8px;">' +
+        '<input type="checkbox" ' + (s.dyslexia ? 'checked' : '') + ' ' +
+               'onchange="updateKidA11y(' + idx + ', \'dyslexia\', this.checked)">' +
+        ' 📖 Dyslexia-friendly font' +
+      '</label>' +
+
+      '<label style="display:block; font-size:0.78rem; color:var(--text-muted); font-weight:700; margin-top:12px; margin-bottom:6px;">Animations</label>' +
+      '<div class="a11y-scale-row" role="group" aria-label="Animations for ' + escHtml(profile.name) + '">' +
+        '<button type="button" class="a11y-scale-btn' + (motionVal === 'auto'   ? ' active' : '') + '" onclick="updateKidA11y(' + idx + ', \'motion\', \'auto\')">Auto</button>' +
+        '<button type="button" class="a11y-scale-btn' + (motionVal === 'normal' ? ' active' : '') + '" onclick="updateKidA11y(' + idx + ', \'motion\', \'normal\')">On</button>' +
+        '<button type="button" class="a11y-scale-btn' + (motionVal === 'reduce' ? ' active' : '') + '" onclick="updateKidA11y(' + idx + ', \'motion\', \'reduce\')">Reduce</button>' +
+      '</div>' +
     '</div>';
   }
 

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -65,6 +65,8 @@
   <div class="feedback" id="feedback"><span class="feedback-emoji" id="feedbackEmoji"></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -14192,6 +14192,8 @@ document.addEventListener('DOMContentLoaded', () => {
 </script>
 
 <script src="js/auth.js?v=2"></script>
+
+<script src="js/a11y.js?v=2"></script>
 <script src="js/sync.js?v=2"></script>
 <script src="js/zs-diag.js?v=2"></script>
 <script src="js/timer.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -128,6 +128,8 @@
   </div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/menu.html
+++ b/menu.html
@@ -26,6 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -41,6 +41,8 @@
   </div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -72,6 +72,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -243,6 +243,8 @@
 </div>
 
 <script src="js/auth.js"></script>
+
+<script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
 <script src="js/zs-diag.js"></script>
 <script src="js/nav.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -84,6 +84,8 @@
   <div class="feedback" id="feedback"><span class="feedback-emoji" id="feedbackEmoji"></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -26,6 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/activity-log.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -45,6 +45,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -73,6 +73,8 @@
   <div class="feedback" id="feedback"><span class="feedback-emoji" id="feedbackEmoji"></span></div>
 
   <script src="js/auth.js"></script>
+
+  <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js"></script>
   <script src="js/nav.js"></script>


### PR DESCRIPTION
## Summary
- New `js/a11y.js` (loaded right after `auth.js` on every page) applies per-kid display preferences globally:
  - Text size scale: S / M / L / XL via `font-size` on `<html>` (every `rem` follows).
  - High-contrast mode: overrides palette, hides decorative atmospheres, forces stronger focus rings.
  - Dyslexia-friendly font: system stack (OpenDyslexic / Atkinson) — no extra download.
  - Reduced motion: auto / on / reduce.
- Settings stored at `zs_a11y` keyed per profile and re-applied on profile switch via storage events.
- Parents Corner gets an Accessibility editor block per kid: scale buttons, high-contrast toggle, dyslexia toggle, motion picker.
- CSS additions live in `css/common.css` (overrides) and `css/index.css` (Parents Corner controls).

## Test plan
- [ ] Open Parents Corner, change a kid's text scale to XL → log in as that kid → all `rem`-sized text grows.
- [ ] Toggle high-contrast → palette + focus rings update; toggle off → restored.
- [ ] Toggle dyslexia font → body font swaps; toggle off → restored.
- [ ] Set Animations to "Reduce" → aurora + nebula stop animating; "Auto" honors OS prefers-reduced-motion.
- [ ] Switch profiles between kids — the active kid's settings apply on every page.

Closes #185

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_