### PR TITLE
Add Money Master — currency identification, counting, change-making (#163)

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -567,6 +567,7 @@
     .card-guess { --card-accent: #F59E0B; --card-glow: rgba(251, 191, 36, 0.3); --card-icon-bg: linear-gradient(135deg, #D97706, #FBBF24); --card-tag-bg: rgba(251, 191, 36, 0.15); }
     .card-bmcheck { --card-accent: #60A5FA; --card-glow: rgba(96, 165, 250, 0.3); --card-icon-bg: linear-gradient(135deg, #2563EB, #60A5FA); --card-tag-bg: rgba(96, 165, 250, 0.15); }
     .card-trophy  { --card-accent: #FBBF24; --card-glow: rgba(251, 191, 36, 0.35); --card-icon-bg: linear-gradient(135deg, #B45309, #FBBF24); --card-tag-bg: rgba(251, 191, 36, 0.15); }
+    .card-money   { --card-accent: #34D399; --card-glow: rgba(52, 211, 153, 0.30); --card-icon-bg: linear-gradient(135deg, #047857, #34D399); --card-tag-bg: rgba(52, 211, 153, 0.15); }
 
     /* ── Hub Calendar Widget (liturgical + Chilean) ── */
     #calendar-widget { animation: fadeUp 0.6s ease-out both; }

--- a/css/money-master.css
+++ b/css/money-master.css
@@ -1,0 +1,330 @@
+/* ================================================================
+   MONEY MASTER — currency identification, change-making, counting
+   Theme: emerald + gold (treasury feel)
+   ================================================================ */
+
+.mm-header {
+  text-align: center;
+  padding: 24px 12px 12px;
+  animation: fadeUp 0.5s ease-out both;
+}
+.mm-header .icon {
+  font-size: 56px;
+  display: block;
+  margin-bottom: 4px;
+  filter: drop-shadow(0 4px 12px rgba(16,185,129,0.35));
+}
+.mm-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 2.4rem);
+  font-weight: 800;
+  background: linear-gradient(135deg, #34D399, #FBBF24);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+.mm-header p {
+  color: var(--text-muted, #8B86B0);
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+.mm-currency {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  margin: 18px 0 8px;
+  flex-wrap: wrap;
+}
+.mm-currency button {
+  min-width: 130px;
+  padding: 12px 18px;
+  background: rgba(255,255,255,0.04);
+  border: 2px solid rgba(255,255,255,0.08);
+  color: #F0EDFF;
+  border-radius: 14px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s, border-color 0.15s, background 0.15s;
+}
+.mm-currency button:hover { transform: translateY(-2px); }
+.mm-currency button.active {
+  background: rgba(16,185,129,0.18);
+  border-color: #34D399;
+  color: #fff;
+}
+
+.mm-mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin: 16px 0;
+}
+.mm-mode-card {
+  position: relative;
+  padding: 22px 18px;
+  background: rgba(255,255,255,0.03);
+  border: 2px solid rgba(16,185,129,0.18);
+  border-radius: 20px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  text-align: left;
+}
+.mm-mode-card:hover {
+  transform: translateY(-4px);
+  border-color: #34D399;
+  box-shadow: 0 12px 32px -8px rgba(16,185,129,0.25);
+}
+.mm-mode-icon {
+  font-size: 42px;
+  margin-bottom: 8px;
+  display: block;
+}
+.mm-mode-name {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.1rem;
+  color: #F0EDFF;
+  margin-bottom: 4px;
+}
+.mm-mode-desc {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--text-muted, #8B86B0);
+  line-height: 1.35;
+}
+.mm-mode-best {
+  margin-top: 10px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: #FBBF24;
+}
+
+/* Game screen */
+.mm-game {
+  padding: 20px 16px;
+  animation: fadeIn 0.3s ease-out both;
+}
+.mm-game-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+  gap: 10px;
+}
+.mm-back-btn {
+  background: rgba(255,255,255,0.06);
+  border: 1px solid rgba(255,255,255,0.1);
+  color: #F0EDFF;
+  width: 38px; height: 38px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+.mm-progress {
+  flex: 1;
+  height: 8px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.mm-progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #34D399, #FBBF24);
+  transition: width 0.3s ease;
+}
+.mm-score {
+  font-family: var(--font-display);
+  font-weight: 800;
+  color: #FBBF24;
+}
+
+.mm-question-card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 22px;
+  padding: 24px 18px;
+  text-align: center;
+  margin-bottom: 16px;
+}
+.mm-q-prompt {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-muted, #8B86B0);
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.mm-q-display {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  margin: 12px 0;
+}
+.mm-q-text {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 4vw, 2rem);
+  font-weight: 800;
+  color: #F0EDFF;
+}
+
+.mm-coin {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 78px; height: 78px;
+  border-radius: 50%;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.95rem;
+  border: 3px solid rgba(0,0,0,0.25);
+  box-shadow: inset 0 -4px 8px rgba(0,0,0,0.2), 0 4px 8px rgba(0,0,0,0.2);
+  text-align: center;
+  line-height: 1.05;
+  user-select: none;
+}
+.mm-bill {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: 110px; height: 64px;
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+  border: 2px solid rgba(0,0,0,0.3);
+  box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+  user-select: none;
+}
+.mm-coin small, .mm-bill small {
+  display: block;
+  font-size: 0.62rem;
+  font-weight: 700;
+  opacity: 0.85;
+  letter-spacing: 0.04em;
+}
+
+/* Currency-specific colors */
+.mm-c-clp-10    { background: linear-gradient(135deg,#A0522D,#CD853F); color:#fff;  }
+.mm-c-clp-50    { background: linear-gradient(135deg,#94A3B8,#CBD5E1); color:#1F2937; }
+.mm-c-clp-100   { background: linear-gradient(135deg,#FBBF24,#F59E0B); color:#7C2D12; }
+.mm-c-clp-500   { background: linear-gradient(135deg,#FB923C,#F97316); color:#7C2D12; }
+.mm-c-clp-1000  { background: linear-gradient(135deg,#16A34A,#22C55E); color:#FFF; }
+.mm-c-clp-2000  { background: linear-gradient(135deg,#A855F7,#D946EF); color:#FFF; }
+.mm-c-clp-5000  { background: linear-gradient(135deg,#DC2626,#EF4444); color:#FFF; }
+.mm-c-clp-10000 { background: linear-gradient(135deg,#2563EB,#3B82F6); color:#FFF; }
+.mm-c-clp-20000 { background: linear-gradient(135deg,#EA580C,#F97316); color:#FFF; }
+
+.mm-c-usd-1   { background: linear-gradient(135deg,#92400E,#B45309); color:#FFF; }
+.mm-c-usd-5   { background: linear-gradient(135deg,#94A3B8,#CBD5E1); color:#1F2937; }
+.mm-c-usd-10  { background: linear-gradient(135deg,#94A3B8,#CBD5E1); color:#1F2937; }
+.mm-c-usd-25  { background: linear-gradient(135deg,#94A3B8,#CBD5E1); color:#1F2937; }
+.mm-c-usd-100   { background: linear-gradient(135deg,#15803D,#16A34A); color:#FFF; }
+.mm-c-usd-500   { background: linear-gradient(135deg,#15803D,#16A34A); color:#FFF; }
+.mm-c-usd-1000  { background: linear-gradient(135deg,#15803D,#16A34A); color:#FFF; }
+.mm-c-usd-2000  { background: linear-gradient(135deg,#15803D,#16A34A); color:#FFF; }
+
+.mm-options {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+}
+.mm-option {
+  padding: 16px 12px;
+  background: rgba(255,255,255,0.04);
+  border: 2px solid rgba(255,255,255,0.08);
+  color: #F0EDFF;
+  border-radius: 14px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: transform 0.12s, border-color 0.15s, background 0.15s;
+  text-align: center;
+}
+.mm-option:hover { transform: translateY(-2px); border-color: #34D399; }
+.mm-option.correct { background: rgba(16,185,129,0.22); border-color: #10B981; }
+.mm-option.wrong   { background: rgba(239,68,68,0.18); border-color: #EF4444; }
+.mm-option:disabled { cursor: default; }
+
+.mm-hint {
+  margin-top: 12px;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  min-height: 1.2em;
+}
+
+/* Results */
+.mm-results {
+  text-align: center;
+  padding: 36px 18px;
+  animation: popIn 0.4s ease-out both;
+}
+.mm-results-emoji {
+  font-size: 80px;
+  display: block;
+  margin-bottom: 12px;
+}
+.mm-results-title {
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.8rem;
+  background: linear-gradient(135deg, #34D399, #FBBF24);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 6px;
+}
+.mm-results-sub {
+  color: var(--text-muted);
+  font-weight: 700;
+  margin-bottom: 18px;
+}
+.mm-stars-row {
+  font-size: 2.4rem;
+  margin: 14px 0;
+  letter-spacing: 6px;
+}
+.mm-results-btns {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+.mm-btn {
+  padding: 12px 22px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1rem;
+  border-radius: 14px;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.15s;
+}
+.mm-btn:hover { transform: translateY(-2px); }
+.mm-btn-primary {
+  background: linear-gradient(135deg, #10B981, #34D399);
+  color: #fff;
+  box-shadow: 0 6px 20px -6px rgba(16,185,129,0.5);
+}
+.mm-btn-secondary {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  color: #F0EDFF;
+}
+
+@media (max-width: 480px) {
+  .mm-options { grid-template-columns: 1fr; }
+  .mm-coin { width: 64px; height: 64px; font-size: 0.85rem; }
+  .mm-bill { min-width: 90px; height: 56px; font-size: 0.9rem; }
+}

--- a/index.html
+++ b/index.html
@@ -232,6 +232,15 @@
           <div class="card-tag">🏅 Achievements</div>
         </a>
 
+        <!-- 16. Money Master (NEW) -->
+        <a href="money-master.html" class="app-card card-money">
+          <div class="card-icon">💰</div>
+          <div class="card-title">Money Master</div>
+          <div class="card-desc">Coins, bills, and change-making — practice with CLP & USD.</div>
+          <div class="card-stats" id="stats-money"></div>
+          <div class="card-tag">🪙 Money</div>
+        </a>
+
       </div>
 
       <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:32px;">

--- a/js/index.js
+++ b/js/index.js
@@ -500,7 +500,8 @@
         world:  document.getElementById('stats-world'),
         story:  document.getElementById('stats-story'),
         quest:  document.getElementById('stats-quest'),
-        guess:  document.getElementById('stats-guess')
+        guess:  document.getElementById('stats-guess'),
+        money:  document.getElementById('stats-money')
       };
 
       var stats = precalculatedStats || (typeof getPlayerStats === 'function' ? getPlayerStats(user.name) : { appStats: {} });
@@ -643,6 +644,25 @@
           var gs = GuessQuest.getStats();
           if (gs.roundsPlayed > 0) {
             els.guess.innerHTML = '<span class="cs-item active">⭐ ' + gs.totalStars + '</span><span class="cs-item">🎮 ' + gs.roundsWon + '/' + gs.roundsPlayed + '</span>';
+          }
+        }
+      } catch (e) {}
+
+      try {
+        if (els.money) {
+          var mkey = 'zs_money_' + (user.name ? user.name.toLowerCase().replace(/\s+/g, '_') : '_default');
+          var mraw = localStorage.getItem(mkey);
+          var mdata = mraw ? (JSON.parse(mraw) || {}) : {};
+          var mStars = 0, mRounds = 0;
+          ['clp', 'usd'].forEach(function(c) {
+            var bucket = mdata[c] || {};
+            for (var mk in bucket) {
+              mStars += (bucket[mk].stars || 0);
+              if (bucket[mk].score) mRounds++;
+            }
+          });
+          if (mStars > 0 || mRounds > 0) {
+            els.money.innerHTML = '<span class="cs-item active">⭐ ' + mStars + '</span><span class="cs-item">🪙 ' + mRounds + ' modes</span>';
           }
         }
       } catch (e) {}

--- a/js/money-master.js
+++ b/js/money-master.js
@@ -1,0 +1,433 @@
+/* ================================================================
+   MONEY MASTER — Currency identification, change-making, counting.
+   Supports CLP (Chilean peso) and USD. Per-kid storage at zs_money_<key>.
+   Issue #163.
+   ================================================================ */
+
+(function() {
+  'use strict';
+
+  var ROUND_LEN = 10;
+
+  // USD denominations are stored in CENTS (so we can mix coins + bills cleanly).
+  var DENOMS = {
+    CLP: [
+      { v: 10,    label: '$10',     name: '10 pesos',     kind: 'coin' },
+      { v: 50,    label: '$50',     name: '50 pesos',     kind: 'coin' },
+      { v: 100,   label: '$100',    name: '100 pesos',    kind: 'coin' },
+      { v: 500,   label: '$500',    name: '500 pesos',    kind: 'coin' },
+      { v: 1000,  label: '$1.000',  name: '1.000 pesos',  kind: 'bill' },
+      { v: 2000,  label: '$2.000',  name: '2.000 pesos',  kind: 'bill' },
+      { v: 5000,  label: '$5.000',  name: '5.000 pesos',  kind: 'bill' },
+      { v: 10000, label: '$10.000', name: '10.000 pesos', kind: 'bill' },
+      { v: 20000, label: '$20.000', name: '20.000 pesos', kind: 'bill' }
+    ],
+    USD: [
+      { v: 1,    label: '1¢',  name: 'penny',     kind: 'coin' },
+      { v: 5,    label: '5¢',  name: 'nickel',    kind: 'coin' },
+      { v: 10,   label: '10¢', name: 'dime',      kind: 'coin' },
+      { v: 25,   label: '25¢', name: 'quarter',   kind: 'coin' },
+      { v: 100,  label: '$1',  name: 'one dollar',     kind: 'bill' },
+      { v: 500,  label: '$5',  name: 'five dollars',   kind: 'bill' },
+      { v: 1000, label: '$10', name: 'ten dollars',    kind: 'bill' },
+      { v: 2000, label: '$20', name: 'twenty dollars', kind: 'bill' }
+    ]
+  };
+
+  var MODES = [
+    { id: 'identify', icon: '🔎', name: 'Identify',   desc: 'Spot a coin or bill — what is it worth?' },
+    { id: 'count',    icon: '🧮', name: 'Count Up',   desc: 'Add up a small pile of coins and bills.' },
+    { id: 'change',   icon: '🛒', name: 'Make Change', desc: 'You buy something. How much change comes back?' }
+  ];
+
+  var STORAGE_PREFIX = 'zs_money_';
+  var PREF_KEY = 'zs_money_pref';
+
+  // ---- helpers ----
+  function _userKey() {
+    if (typeof getActiveUser === 'function') {
+      var u = getActiveUser();
+      if (u) return u.name.toLowerCase().replace(/\s+/g, '_');
+    }
+    return '_default';
+  }
+
+  function _load() {
+    try {
+      var raw = localStorage.getItem(STORAGE_PREFIX + _userKey());
+      return raw ? (JSON.parse(raw) || {}) : {};
+    } catch (e) { return {}; }
+  }
+
+  function _save(data) {
+    try { localStorage.setItem(STORAGE_PREFIX + _userKey(), JSON.stringify(data)); }
+    catch (e) {}
+  }
+
+  function _loadPref() {
+    try {
+      var raw = localStorage.getItem(PREF_KEY);
+      return raw ? (JSON.parse(raw) || {}) : {};
+    } catch (e) { return {}; }
+  }
+
+  function _savePref(p) {
+    try { localStorage.setItem(PREF_KEY, JSON.stringify(p)); } catch (e) {}
+  }
+
+  function _rand(n) { return Math.floor(Math.random() * n); }
+  function _pick(arr) { return arr[_rand(arr.length)]; }
+  function _shuffle(arr) {
+    var a = arr.slice();
+    for (var i = a.length - 1; i > 0; i--) {
+      var j = _rand(i + 1);
+      var t = a[i]; a[i] = a[j]; a[j] = t;
+    }
+    return a;
+  }
+
+  function _formatAmount(currency, valueCents) {
+    if (currency === 'USD') {
+      // Cents stored as integers. Show $X.XX, or NN¢ if under a dollar.
+      if (valueCents < 100) return valueCents + '¢';
+      var dollars = Math.floor(valueCents / 100);
+      var rem = valueCents % 100;
+      return '$' + dollars + (rem ? '.' + (rem < 10 ? '0' : '') + rem : '');
+    }
+    // CLP — integer pesos with thousands separator (Chile uses '.').
+    return '$' + String(valueCents).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+  }
+
+  function _renderDenom(currency, d) {
+    var cls = 'mm-c-' + currency.toLowerCase() + '-' + d.v;
+    if (d.kind === 'coin') {
+      return '<div class="mm-coin ' + cls + '">' + d.label + '</div>';
+    }
+    return '<div class="mm-bill ' + cls + '">' + d.label + '</div>';
+  }
+
+  // ---- state ----
+  var state = {
+    currency: 'CLP',
+    mode: null,
+    qIdx: 0,
+    score: 0,
+    correct: 0,
+    questions: []
+  };
+
+  // ---- screens ----
+  function _root() { return document.getElementById('mm-wrap'); }
+
+  function open() {
+    var pref = _loadPref();
+    state.currency = pref.currency || 'CLP';
+    _renderHome();
+  }
+
+  function _renderHome() {
+    var data = _load();
+    var bestKey = state.currency.toLowerCase();
+    var modeCards = MODES.map(function(m) {
+      var best = (data[bestKey] && data[bestKey][m.id]) || null;
+      var bestText = best && best.score
+        ? 'Best: ' + best.score + '/' + ROUND_LEN + ' · ⭐ ' + (best.stars || 0)
+        : 'No score yet';
+      return '<div class="mm-mode-card" onclick="MoneyMaster.start(\'' + m.id + '\')">' +
+        '<span class="mm-mode-icon">' + m.icon + '</span>' +
+        '<div class="mm-mode-name">' + m.name + '</div>' +
+        '<div class="mm-mode-desc">' + m.desc + '</div>' +
+        '<div class="mm-mode-best">' + bestText + '</div>' +
+      '</div>';
+    }).join('');
+
+    _root().innerHTML =
+      '<div class="mm-header">' +
+        '<span class="icon">💰</span>' +
+        '<h1>Money Master</h1>' +
+        '<p>Coins, bills, and change-making — pick a currency.</p>' +
+      '</div>' +
+      '<div class="mm-currency" role="group" aria-label="Choose currency">' +
+        '<button type="button" class="' + (state.currency === 'CLP' ? 'active' : '') + '" onclick="MoneyMaster.setCurrency(\'CLP\')">🇨🇱 Pesos (CLP)</button>' +
+        '<button type="button" class="' + (state.currency === 'USD' ? 'active' : '') + '" onclick="MoneyMaster.setCurrency(\'USD\')">🇺🇸 Dollars (USD)</button>' +
+      '</div>' +
+      '<div class="mm-mode-grid">' + modeCards + '</div>';
+  }
+
+  function setCurrency(c) {
+    if (c !== 'CLP' && c !== 'USD') return;
+    state.currency = c;
+    _savePref({ currency: c });
+    _renderHome();
+  }
+
+  // ---- question generators ----
+  function _genIdentify(currency) {
+    var denoms = DENOMS[currency];
+    var target = _pick(denoms);
+    // Pick 3 distractors at similar magnitudes when possible.
+    var others = denoms.filter(function(d) { return d.v !== target.v; });
+    var distractors = _shuffle(others).slice(0, 3);
+    var options = _shuffle([target].concat(distractors));
+    return {
+      type: 'identify',
+      prompt: 'How much is this worth?',
+      display: _renderDenom(currency, target),
+      options: options.map(function(o) { return { text: _formatAmount(currency, o.v), correct: o.v === target.v }; }),
+      answer: _formatAmount(currency, target.v)
+    };
+  }
+
+  function _genCount(currency) {
+    // Build a pile of 2-5 denoms, then ask for total.
+    var denoms = DENOMS[currency];
+    // Skip the very largest in count mode to keep totals tractable.
+    var pool = denoms.slice(0, denoms.length - 2);
+    var pileSize = 2 + _rand(4); // 2-5
+    var pile = [];
+    var total = 0;
+    for (var i = 0; i < pileSize; i++) {
+      var d = _pick(pool);
+      pile.push(d);
+      total += d.v;
+    }
+    pile.sort(function(a, b) { return b.v - a.v; });
+
+    // Build 3 distractors — close-but-wrong totals.
+    var distractors = [];
+    var seen = { };
+    seen[total] = 1;
+    var attempts = 0;
+    while (distractors.length < 3 && attempts < 30) {
+      attempts++;
+      var swap = _pick(denoms);
+      var alt = total - pile[0].v + swap.v;
+      if (alt > 0 && !seen[alt] && alt !== total) {
+        seen[alt] = 1;
+        distractors.push(alt);
+      }
+    }
+    while (distractors.length < 3) {
+      var fallback = total + (_rand(3) - 1) * (currency === 'USD' ? 25 : 100);
+      if (fallback > 0 && !seen[fallback]) { seen[fallback] = 1; distractors.push(fallback); }
+      else { distractors.push(total + 100 + distractors.length); }
+    }
+
+    var optionVals = _shuffle([total].concat(distractors));
+    return {
+      type: 'count',
+      prompt: 'Add it up!',
+      display: pile.map(function(d) { return _renderDenom(currency, d); }).join(''),
+      options: optionVals.map(function(v) { return { text: _formatAmount(currency, v), correct: v === total }; }),
+      answer: _formatAmount(currency, total)
+    };
+  }
+
+  function _genChange(currency) {
+    // Generate a "price" you would pay with cash.
+    var price, paid;
+    if (currency === 'USD') {
+      // Whole-dollar amounts under $20 paid with $5/$10/$20.
+      var dollarPrices = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 18];
+      var p = _pick(dollarPrices);
+      price = p * 100;
+      var paidOptions = [500, 1000, 2000].filter(function(x) { return x > price; });
+      paid = _pick(paidOptions);
+    } else {
+      // CLP — round to nearest $100 to keep arithmetic fair.
+      var clpPrices = [];
+      for (var c = 100; c <= 19000; c += 100) clpPrices.push(c);
+      price = _pick(clpPrices);
+      var bills = [1000, 2000, 5000, 10000, 20000].filter(function(x) { return x > price; });
+      paid = _pick(bills);
+    }
+    var change = paid - price;
+    var distractors = _shuffle([
+      change + (currency === 'USD' ? 100 : 1000),
+      Math.max(currency === 'USD' ? 5 : 10, change - (currency === 'USD' ? 100 : 1000)),
+      paid - change, // common mistake: subtract change from paid
+      change + (currency === 'USD' ? 50 : 500)
+    ].filter(function(x, i, a) { return x > 0 && x !== change && a.indexOf(x) === i; })).slice(0, 3);
+
+    while (distractors.length < 3) distractors.push(change + (distractors.length + 1) * (currency === 'USD' ? 25 : 250));
+
+    var options = _shuffle([change].concat(distractors));
+    return {
+      type: 'change',
+      prompt: 'Item costs ' + _formatAmount(currency, price) + '. You pay with ' + _formatAmount(currency, paid) + '. Change?',
+      display: '<div class="mm-q-text">' + _formatAmount(currency, paid) + ' − ' + _formatAmount(currency, price) + ' = ?</div>',
+      options: options.map(function(v) { return { text: _formatAmount(currency, v), correct: v === change }; }),
+      answer: _formatAmount(currency, change)
+    };
+  }
+
+  function _generateQuestions(mode, currency) {
+    var fns = { identify: _genIdentify, count: _genCount, change: _genChange };
+    var fn = fns[mode];
+    var qs = [];
+    var seen = {};
+    var safety = 0;
+    while (qs.length < ROUND_LEN && safety < 200) {
+      safety++;
+      var q = fn(currency);
+      // crude dedupe to avoid back-to-back repeats
+      var fp = q.prompt + '|' + q.answer;
+      if (seen[fp]) continue;
+      seen[fp] = 1;
+      qs.push(q);
+    }
+    return qs;
+  }
+
+  // ---- gameplay ----
+  function start(mode) {
+    state.mode = mode;
+    state.qIdx = 0;
+    state.score = 0;
+    state.correct = 0;
+    state.questions = _generateQuestions(mode, state.currency);
+    _renderQuestion();
+  }
+
+  function _renderQuestion() {
+    var q = state.questions[state.qIdx];
+    if (!q) return _renderResults();
+
+    var modeMeta = MODES.filter(function(m) { return m.id === state.mode; })[0] || {};
+    var pct = Math.round((state.qIdx / ROUND_LEN) * 100);
+    var optionsHtml = q.options.map(function(o, i) {
+      return '<button type="button" class="mm-option" data-correct="' + (o.correct ? '1' : '0') + '" onclick="MoneyMaster._answer(this, ' + i + ')">' +
+        o.text +
+      '</button>';
+    }).join('');
+
+    _root().innerHTML =
+      '<div class="mm-game">' +
+        '<div class="mm-game-top">' +
+          '<button class="mm-back-btn" aria-label="Back to modes" onclick="MoneyMaster.back()">←</button>' +
+          '<div class="mm-progress"><div class="mm-progress-fill" style="width:' + pct + '%"></div></div>' +
+          '<div class="mm-score">⭐ ' + state.score + '</div>' +
+        '</div>' +
+        '<div class="mm-question-card">' +
+          '<div class="mm-q-prompt">' + (modeMeta.icon || '') + ' ' + q.prompt + '</div>' +
+          '<div class="mm-q-display">' + q.display + '</div>' +
+          '<div style="font-size:0.78rem;color:var(--text-muted,#8B86B0);font-weight:700;">Question ' + (state.qIdx + 1) + ' of ' + ROUND_LEN + '</div>' +
+        '</div>' +
+        '<div class="mm-options" id="mm-opts">' + optionsHtml + '</div>' +
+        '<div class="mm-hint" id="mm-hint"></div>' +
+      '</div>';
+  }
+
+  function _answer(btn, idx) {
+    var q = state.questions[state.qIdx];
+    var correct = btn.getAttribute('data-correct') === '1';
+    var opts = document.querySelectorAll('#mm-opts .mm-option');
+    for (var i = 0; i < opts.length; i++) {
+      opts[i].disabled = true;
+      var isC = opts[i].getAttribute('data-correct') === '1';
+      if (isC) opts[i].classList.add('correct');
+    }
+    if (correct) {
+      btn.classList.add('correct');
+      state.score++;
+      state.correct++;
+      if (typeof Sounds !== 'undefined' && Sounds.correct) Sounds.correct();
+      _showFeedback('✅');
+    } else {
+      btn.classList.add('wrong');
+      if (typeof Sounds !== 'undefined' && Sounds.wrong) Sounds.wrong();
+      var hint = document.getElementById('mm-hint');
+      if (hint) hint.textContent = 'Correct answer: ' + q.answer;
+      _showFeedback('💡');
+    }
+
+    setTimeout(function() {
+      state.qIdx++;
+      if (state.qIdx >= ROUND_LEN) _renderResults();
+      else _renderQuestion();
+    }, correct ? 700 : 1400);
+  }
+
+  function _showFeedback(emoji) {
+    var fb = document.getElementById('feedback');
+    var em = document.getElementById('feedbackEmoji');
+    if (!fb || !em) return;
+    em.textContent = emoji;
+    fb.classList.add('show');
+    setTimeout(function() { fb.classList.remove('show'); }, 700);
+  }
+
+  function _starsFor(score) {
+    if (score >= ROUND_LEN) return 3;
+    if (score >= Math.ceil(ROUND_LEN * 0.7)) return 2;
+    if (score >= Math.ceil(ROUND_LEN * 0.4)) return 1;
+    return 0;
+  }
+
+  function _renderResults() {
+    var stars = _starsFor(state.score);
+    var data = _load();
+    var ck = state.currency.toLowerCase();
+    if (!data[ck]) data[ck] = {};
+    var prev = data[ck][state.mode] || { score: 0, stars: 0 };
+    var newRecord = state.score > (prev.score || 0);
+    if (newRecord || stars > (prev.stars || 0)) {
+      data[ck][state.mode] = {
+        score: Math.max(prev.score || 0, state.score),
+        stars: Math.max(prev.stars || 0, stars),
+        ts: Date.now()
+      };
+      _save(data);
+    }
+
+    if (typeof ActivityLog !== 'undefined' && ActivityLog.push) {
+      ActivityLog.push({
+        app: 'money',
+        kind: 'round',
+        meta: {
+          mode: state.mode,
+          currency: state.currency,
+          score: state.score,
+          stars: stars,
+          newRecord: newRecord
+        }
+      });
+    }
+
+    var emoji = stars >= 3 ? '🏆' : stars >= 2 ? '🌟' : stars >= 1 ? '💪' : '🎯';
+    var title = stars >= 3 ? 'Money Master!' : stars >= 2 ? 'Great work!' : stars >= 1 ? 'Nice try!' : 'Keep practicing';
+    var starsHtml = '';
+    for (var i = 0; i < 3; i++) starsHtml += (i < stars ? '⭐' : '☆');
+
+    _root().innerHTML =
+      '<div class="mm-results">' +
+        '<span class="mm-results-emoji">' + emoji + '</span>' +
+        '<div class="mm-results-title">' + title + '</div>' +
+        '<div class="mm-results-sub">' + state.score + ' / ' + ROUND_LEN + ' correct' +
+          (newRecord ? ' · 🎉 New best!' : '') +
+        '</div>' +
+        '<div class="mm-stars-row">' + starsHtml + '</div>' +
+        '<div class="mm-results-btns">' +
+          '<button class="mm-btn mm-btn-primary" onclick="MoneyMaster.start(\'' + state.mode + '\')">Play Again 🔁</button>' +
+          '<button class="mm-btn mm-btn-secondary" onclick="MoneyMaster.back()">Other Modes</button>' +
+        '</div>' +
+      '</div>';
+  }
+
+  function back() { _renderHome(); }
+
+  // ---- expose ----
+  window.MoneyMaster = {
+    open: open,
+    setCurrency: setCurrency,
+    start: start,
+    back: back,
+    _answer: _answer
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', open);
+  } else {
+    open();
+  }
+})();

--- a/money-master.html
+++ b/money-master.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Money Master 💰</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/money-master.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body>
+  <div class="atmo" style="width:400px;height:400px;background:rgba(16,185,129,0.10);top:-100px;left:-100px;"></div>
+  <div class="atmo" style="width:350px;height:350px;background:rgba(245,158,11,0.08);bottom:-80px;right:-80px;animation-delay:-8s;"></div>
+
+  <div class="app">
+    <div id="mm-wrap"></div>
+  </div>
+
+  <div class="feedback" id="feedback"><span class="feedback-emoji" id="feedbackEmoji"></span></div>
+
+  <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/nav.js"></script>
+  <script src="js/sounds.js"></script>
+  <script src="js/timer.js"></script>
+  <script src="js/activity-log.js"></script>
+  <script src="js/learning-checks.js"></script>
+  <script src="js/money-master.js"></script>
+  <script src="js/pwa.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- New educational app covering CLP (Chilean pesos) and USD with three modes (10 questions per round, 1/2/3 stars at 40 / 70 / 100 % correct):
  - **Identify** — spot a coin or bill, pick the matching value.
  - **Count Up** — add a small pile of mixed coins and bills.
  - **Make Change** — paid amount minus price (classic register math).
- CLP denominations: $10/$50/$100/$500 coins, $1.000/$2.000/$5.000/$10.000/$20.000 bills.
- USD denominations: 1¢/5¢/10¢/25¢ coins, $1/$5/$10/$20 bills (stored as cents internally so coins + bills mix cleanly).
- Currency preference + per-kid best scores in localStorage. Round results emit ActivityLog entries so the dashboard sees them.
- Hub card added to `index.html` with stats hookup; new `card-money` color theme (emerald + gold).

## Test plan
- [ ] Hub shows Money Master card; clicking opens app.
- [ ] Switch CLP ↔ USD; pref persists across reload.
- [ ] Run a round of each mode → questions/options render correctly, stars award per threshold.
- [ ] New best score + activity entry appear in Parent Dashboard "Recent Activity".
- [ ] Mobile: options collapse to single column; coins/bills resize.

Closes #163

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_