### PR TITLE
Fix delete-user resurrection + let any profile edit Sports Arena matches

### DIFF
--- a/css/sports-arena.css
+++ b/css/sports-arena.css
@@ -240,6 +240,21 @@
     .match-score { font-weight: 800; font-size: 1.1rem; color: var(--green-light); }
     .match-date { font-size: 0.75rem; color: var(--text-muted); font-weight: 600; }
     .match-winner { font-size: 0.78rem; color: var(--gold); font-weight: 700; }
+    .match-actions { display: flex; gap: 4px; align-items: center; margin-left: 8px; }
+    .match-edit, .match-delete {
+      width: 32px; height: 32px;
+      background: rgba(255,255,255,0.04);
+      border: 1px solid var(--border-subtle);
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 0.95rem;
+      color: var(--text);
+      display: inline-flex; align-items: center; justify-content: center;
+      transition: background 0.15s, border-color 0.15s, transform 0.12s;
+    }
+    .match-edit:hover { background: rgba(96,165,250,0.15); border-color: var(--blue); }
+    .match-delete:hover { background: rgba(248,113,113,0.15); border-color: var(--red); }
+    .match-edit:active, .match-delete:active { transform: scale(0.92); }
 
     /* ---- Tournament bracket ---- */
     .tournament-match {

--- a/js/index.js
+++ b/js/index.js
@@ -1701,6 +1701,11 @@
     if (!confirm('Delete ' + name + '?')) return;
     profiles.splice(editingIndex, 1);
     saveProfiles(profiles);
+    // Push the deletion to the server. syncProfiles() does an additive
+    // merge that would otherwise resurrect this profile on next sync.
+    if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
+      try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
+    }
     closeEditModal();
     switchUser();
   }

--- a/js/sports-arena.js
+++ b/js/sports-arena.js
@@ -40,17 +40,89 @@ const SportsArena = (() => {
     return 'zs_sports_' + user.name.toLowerCase().replace(/\s+/g, '_');
   }
 
+  // Matches live in a shared family bucket so any profile can edit or
+  // delete a match the family played together (you don't have to switch
+  // to the kid who logged it). Per-kid bucket still holds personal
+  // counters (totalStars, custom sports, activities, tournaments).
+  const SHARED_MATCHES_KEY = 'zs_sports_matches_shared';
+  const MIGRATION_FLAG = 'zs_sports_matches_migrated_v1';
+
+  function _matchFingerprint(m) {
+    if (!m) return '';
+    const players = [String(m.player1 || ''), String(m.player2 || '')].sort().join('|');
+    return [m.date || '', m.sportId || '', players, m.score1, m.score2].join('::');
+  }
+
+  function _migrateMatchesIfNeeded() {
+    if (localStorage.getItem(MIGRATION_FLAG)) return;
+    try {
+      const seen = {};
+      const merged = [];
+      const existing = JSON.parse(localStorage.getItem(SHARED_MATCHES_KEY) || '[]');
+      if (Array.isArray(existing)) {
+        existing.forEach(function(m) {
+          const fp = _matchFingerprint(m);
+          if (!seen[fp]) { seen[fp] = 1; merged.push(m); }
+        });
+      }
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (!key || key.indexOf('zs_sports_') !== 0) continue;
+        if (key === SHARED_MATCHES_KEY || key === MIGRATION_FLAG) continue;
+        try {
+          const data = JSON.parse(localStorage.getItem(key));
+          if (data && Array.isArray(data.matches)) {
+            data.matches.forEach(function(m) {
+              const fp = _matchFingerprint(m);
+              if (!seen[fp]) { seen[fp] = 1; merged.push(m); }
+            });
+          }
+        } catch (e) {}
+      }
+      localStorage.setItem(SHARED_MATCHES_KEY, JSON.stringify(merged));
+      localStorage.setItem(MIGRATION_FLAG, '1');
+    } catch (e) {}
+  }
+
+  function _getSharedMatches() {
+    _migrateMatchesIfNeeded();
+    try {
+      const arr = JSON.parse(localStorage.getItem(SHARED_MATCHES_KEY) || '[]');
+      return Array.isArray(arr) ? arr : [];
+    } catch (e) { return []; }
+  }
+
+  function _saveSharedMatches(matches) {
+    try { localStorage.setItem(SHARED_MATCHES_KEY, JSON.stringify(matches || [])); } catch (e) {}
+  }
+
   function _getData() {
     const key = _key();
-    if (!key) return _emptyData();
+    if (!key) {
+      const empty = _emptyData();
+      empty.matches = _getSharedMatches();
+      return empty;
+    }
     try {
-      return JSON.parse(localStorage.getItem(key)) || _emptyData();
+      const data = JSON.parse(localStorage.getItem(key)) || _emptyData();
+      // Always project shared matches into the data view so callers that
+      // read data.matches keep working unchanged.
+      data.matches = _getSharedMatches();
+      return data;
     } catch { return _emptyData(); }
   }
 
   function _saveData(data) {
     const key = _key();
-    if (key) localStorage.setItem(key, JSON.stringify(data));
+    if (!key) {
+      // No active user — only the matches bucket is shared, so still save it.
+      if (data && Array.isArray(data.matches)) _saveSharedMatches(data.matches);
+      return;
+    }
+    if (data && Array.isArray(data.matches)) _saveSharedMatches(data.matches);
+    const perKid = Object.assign({}, data);
+    delete perKid.matches;
+    localStorage.setItem(key, JSON.stringify(perKid));
   }
 
   function _emptyData() {
@@ -104,6 +176,30 @@ const SportsArena = (() => {
     }
 
     return match;
+  }
+
+  function editMatch(matchId, patch) {
+    const matches = _getSharedMatches();
+    let touched = false;
+    for (let i = 0; i < matches.length; i++) {
+      if (matches[i].id === matchId) {
+        const m = Object.assign({}, matches[i], patch || {});
+        m.winner = _determineWinner(m);
+        matches[i] = m;
+        touched = true;
+        break;
+      }
+    }
+    if (touched) _saveSharedMatches(matches);
+    return touched;
+  }
+
+  function deleteMatch(matchId) {
+    const matches = _getSharedMatches();
+    const filtered = matches.filter(m => m.id !== matchId);
+    if (filtered.length === matches.length) return false;
+    _saveSharedMatches(filtered);
+    return true;
   }
 
   function _determineWinner(match) {
@@ -425,6 +521,8 @@ const SportsArena = (() => {
     addCustomSport,
     removeCustomSport,
     logMatch,
+    editMatch,
+    deleteMatch,
     getMatches,
     getRecentMatches,
     createTournament,

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -707,8 +707,17 @@
         const date = new Date(m.date);
         const dateStr = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
         const winner = m.winner === 'draw' ? 'Draw' : m.winner;
+        const id = escHtml(m.id || '');
+        // Tournament matches are managed inside the tournament view, so
+        // skip the inline edit/delete affordances there.
+        const canEdit = !m.tournamentName && !!m.id;
+        const actions = canEdit ? `
+          <div class="match-actions">
+            <button class="match-edit" title="Edit match" aria-label="Edit match" onclick="editMatchInline('${id}')">✏️</button>
+            <button class="match-delete" title="Delete match" aria-label="Delete match" onclick="deleteMatchInline('${id}')">🗑</button>
+          </div>` : '';
         return `
-          <div class="match-item">
+          <div class="match-item" data-match-id="${id}">
             <span class="match-sport">${sport ? sport.icon : '🏅'}</span>
             <div class="match-players">
               <div class="match-vs">${escHtml(m.player1)} vs ${escHtml(m.player2)}</div>
@@ -718,9 +727,37 @@
               <div class="match-score">${m.score1} – ${m.score2}</div>
               <div class="match-winner">${winner === 'Draw' ? '🤝 Draw' : '🏆 ' + escHtml(winner)}</div>
             </div>
+            ${actions}
           </div>`;
       }).join('');
     }
+  }
+
+  function editMatchInline(matchId) {
+    const all = SportsArena.getRecentMatches(500);
+    const m = all.find(x => x.id === matchId);
+    if (!m) return;
+    const newScore1 = prompt(`Score for ${m.player1}:`, m.score1);
+    if (newScore1 === null) return;
+    const newScore2 = prompt(`Score for ${m.player2}:`, m.score2);
+    if (newScore2 === null) return;
+    const s1 = parseInt(newScore1, 10);
+    const s2 = parseInt(newScore2, 10);
+    if (isNaN(s1) || isNaN(s2)) {
+      alert('Scores must be numbers.');
+      return;
+    }
+    SportsArena.editMatch(matchId, { score1: s1, score2: s2 });
+    renderHistory();
+  }
+
+  function deleteMatchInline(matchId) {
+    const all = SportsArena.getRecentMatches(500);
+    const m = all.find(x => x.id === matchId);
+    if (!m) return;
+    if (!confirm(`Delete this match?\n${m.player1} ${m.score1} – ${m.score2} ${m.player2}`)) return;
+    SportsArena.deleteMatch(matchId);
+    renderHistory();
   }
 
   // ════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Two real bugs surfaced by the diag logs and your direct feedback.
- **Delete user**: `deleteEditingProfile` saved the shorter list locally but never told the server. The next `CloudSync.syncProfiles()` then did an additive (server ∪ local) merge and resurrected the deleted profile, then pushed it back. Fix: also call `CloudSync.overwriteProfiles()` right after the local splice so the server reflects the deletion.
- **Sports Arena edit-by-anyone**: matches were per-user (`zs_sports_<name>`), so a Mateo-vs-Ana match was only visible/editable when logged in as the kid who entered it. Move matches to a shared bucket (`zs_sports_matches_shared`); per-kid storage still holds personal counters, custom sports, activities, and tournaments. One-time fingerprint dedup migration on first read.
- New `SportsArena.editMatch(id, patch)` and `deleteMatch(id)` APIs; Recent Matches list grows ✏️/🗑 buttons (anyone logged in can use them; tournament-bound matches stay managed inside the bracket).

## Test plan
- [ ] Login screen → ✏️ on a profile → Delete → confirm. Profile gone immediately. Reload page (with sync online): profile stays gone.
- [ ] Sports Arena → log a match as Mateo. Switch to Ana → Standings & History shows the match with ✏️ and 🗑.
- [ ] Edit changes the score and re-determines winner. Delete confirms then removes the row.
- [ ] On first load after upgrade: matches that existed under per-kid keys appear in the shared list (migration ran).
- [ ] Tournament matches inside a bracket are unchanged (no inline edit/delete buttons there).

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_