### PR TITLE
Add Sibling Duel — pass-and-play Math Galaxy mode (#182 v1)

### DIFF
--- a/css/math-galaxy.css
+++ b/css/math-galaxy.css
@@ -324,9 +324,98 @@
     .card-sprint .rank-name { color: #FBBF24; }
     .card-words  { background: linear-gradient(135deg, rgba(167,139,250,0.08), rgba(96,165,250,0.08)); border-color: rgba(167,139,250,0.3); }
     .card-words .rank-name { color: #A78BFA; }
+    .card-duel  { background: linear-gradient(135deg, rgba(52,211,153,0.10), rgba(96,165,250,0.10)); border-color: rgba(52,211,153,0.3); }
+    .card-duel .rank-name { color: #34D399; }
     @keyframes pulseIcon { 0%,100% { transform: scale(1); } 50% { transform: scale(1.12); } }
 
-    .sprint-wrap, .words-wrap { display: flex; flex-direction: column; gap: 16px; }
+    .sprint-wrap, .words-wrap, .duel-wrap { display: flex; flex-direction: column; gap: 16px; }
+
+    /* Duel-specific UI */
+    .duel-picker { display: grid; grid-template-columns: 1fr auto 1fr; gap: 14px; align-items: center; }
+    .duel-side { display: flex; flex-direction: column; gap: 8px; }
+    .duel-side-label { font-family: var(--font-display); font-weight: 800; color: var(--text-muted); text-align: center; }
+    .duel-vs { font-family: var(--font-display); font-weight: 800; font-size: 1.4rem; color: #FBBF24; text-align: center; }
+    .duel-tiles { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
+    .duel-tile {
+      display: flex; flex-direction: column; align-items: center; gap: 4px;
+      padding: 10px 12px; min-width: 78px;
+      background: rgba(255,255,255,0.04);
+      border: 2px solid rgba(255,255,255,0.08);
+      border-radius: 14px;
+      cursor: pointer;
+      font-family: var(--font-display);
+      transition: transform 0.12s, border-color 0.15s, background 0.15s;
+      color: #F0EDFF;
+    }
+    .duel-tile:hover { transform: translateY(-2px); }
+    .duel-tile.active {
+      border-color: var(--accent, #34D399);
+      background: rgba(52,211,153,0.12);
+      box-shadow: 0 4px 16px -8px var(--accent, #34D399);
+    }
+    .duel-avatar { font-size: 1.5rem; }
+    .duel-pname { font-weight: 700; font-size: 0.85rem; }
+
+    .duel-tables { margin-top: 8px; text-align: center; }
+    .duel-tables-label { font-family: var(--font-display); font-weight: 800; color: var(--text-muted); margin-bottom: 8px; }
+    .duel-tables-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
+    .duel-table-btn {
+      padding: 8px 14px; min-width: 52px;
+      background: rgba(255,255,255,0.04);
+      border: 1.5px solid rgba(255,255,255,0.1);
+      border-radius: 10px;
+      color: #F0EDFF;
+      font-family: var(--font-display);
+      font-weight: 800;
+      cursor: pointer;
+    }
+    .duel-table-btn.active {
+      background: rgba(251,191,36,0.18);
+      border-color: #FBBF24;
+      color: #FBBF24;
+    }
+
+    .duel-last { text-align: center; color: var(--text-muted); font-weight: 700; font-size: 0.85rem; }
+    .duel-go { text-align: center; margin-top: 8px; }
+    .duel-go .action-btn.disabled { opacity: 0.45; cursor: not-allowed; }
+
+    .duel-handoff {
+      text-align: center; padding: 36px 20px;
+      animation: fadeIn 0.3s ease-out both;
+    }
+    .duel-handoff-emoji { font-size: 76px; display: block; margin-bottom: 8px; }
+    .duel-handoff-name {
+      font-family: var(--font-display);
+      font-weight: 800; font-size: 1.6rem;
+      color: var(--accent, #A78BFA);
+      margin-bottom: 4px;
+    }
+    .duel-handoff-sub { color: var(--text-muted); font-weight: 700; margin-bottom: 22px; }
+
+    .duel-winner-line {
+      text-align: center; font-family: var(--font-display);
+      font-weight: 800; font-size: 1.4rem; color: #FBBF24;
+      margin: 8px 0 18px;
+    }
+    .duel-scoreboard {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+      margin-bottom: 16px;
+    }
+    .duel-score-card {
+      padding: 18px 12px; text-align: center;
+      background: rgba(255,255,255,0.03);
+      border: 2px solid var(--accent, #A78BFA);
+      border-radius: 18px;
+    }
+    .duel-score-emoji { font-size: 2.6rem; }
+    .duel-score-name { font-family: var(--font-display); font-weight: 800; color: var(--accent, #A78BFA); }
+    .duel-score-num { font-family: var(--font-display); font-weight: 800; font-size: 2.6rem; color: #F0EDFF; }
+    .duel-score-sub { color: var(--text-muted); font-weight: 700; font-size: 0.8rem; }
+
+    @media (max-width: 480px) {
+      .duel-picker { grid-template-columns: 1fr; }
+      .duel-vs { padding: 8px 0; }
+    }
 
     .sprint-header {
       position: relative;

--- a/js/math-extras.js
+++ b/js/math-extras.js
@@ -70,6 +70,18 @@ var MathExtras = (function() {
         wordsEl.classList.add('empty');
       }
     }
+
+    var duelEl = document.getElementById('best-duel');
+    if (duelEl) {
+      var last = data.duel && data.duel.last;
+      if (last) {
+        duelEl.textContent = 'Last: ' + last.a + ' ' + last.scoreA + ' — ' + last.scoreB + ' ' + last.b;
+        duelEl.classList.remove('empty');
+      } else {
+        duelEl.textContent = 'Pick two players to begin!';
+        duelEl.classList.add('empty');
+      }
+    }
   }
 
   /* ============================================================
@@ -517,9 +529,295 @@ var MathExtras = (function() {
     return { open: open, start: start, toggleLang: toggleLang, _answer: _answer };
   })();
 
+  /* ============================================================
+     DUEL — pass-and-play sibling sprint (#182)
+     Both players get the SAME pre-generated 60s problem set so it's
+     fair. Player A plays first; Player B gets the same problems in
+     the same order; higher score wins.
+     ============================================================ */
+  var Duel = (function() {
+    var DUEL_SECONDS = 60;
+    var state = null;
+    // state = {
+    //   problems[], table, playerA, playerB,
+    //   scoreA, scoreB, current ('A'|'B'), idx, deadline, timerId
+    // }
+
+    function open() {
+      _showScreen('screen-duel');
+      _renderPicker();
+    }
+
+    function _profileList() {
+      var profs = (typeof getProfiles === 'function') ? getProfiles() : [];
+      // Guest option always available (lowercase to match _userKey style elsewhere).
+      return profs.concat([{ name: 'Guest', avatar: '🛸', color: '#60A5FA' }]);
+    }
+
+    var pickedA = null, pickedB = null, pickedTable = 0;
+
+    function _renderPicker() {
+      var wrap = document.getElementById('duel-wrap');
+      if (!wrap) return;
+      var profiles = _profileList();
+      var data = _load();
+      var lastDuel = (data.duel && data.duel.last) || null;
+
+      function tile(p, side) {
+        var sel = (side === 'A' ? pickedA : pickedB);
+        var on = sel && sel.name === p.name;
+        return '<button type="button" class="duel-tile ' + (on ? 'active' : '') + '" ' +
+                 'style="--accent:' + (p.color || '#A78BFA') + '" ' +
+                 'onclick="MathExtras.Duel._pick(\'' + side + '\', \'' + p.name.replace(/'/g, "\\'") + '\')">' +
+            '<span class="duel-avatar">' + (p.avatar || '🛸') + '</span>' +
+            '<span class="duel-pname">' + p.name + '</span>' +
+          '</button>';
+      }
+
+      var tablesRow = [0,2,3,4,5,6,7,8,9,10,11,12].map(function(t) {
+        var on = pickedTable === t;
+        var label = t === 0 ? 'Mix' : '×' + t;
+        return '<button type="button" class="duel-table-btn ' + (on ? 'active' : '') + '" ' +
+                 'onclick="MathExtras.Duel._setTable(' + t + ')">' + label + '</button>';
+      }).join('');
+
+      var canStart = pickedA && pickedB && pickedA.name !== pickedB.name;
+      var lastLine = lastDuel
+        ? '<div class="duel-last">Last duel: ' + lastDuel.a + ' ' + lastDuel.scoreA + ' — ' + lastDuel.scoreB + ' ' + lastDuel.b + ' (×' + (lastDuel.table || 'Mix') + ')</div>'
+        : '';
+
+      wrap.innerHTML =
+        '<div class="sprint-header">' +
+          '<button class="back-btn" onclick="MathExtras._goHome()" aria-label="Back">←</button>' +
+          '<h2>🤝 Sibling Duel</h2>' +
+          '<p>Pass-and-play. Same problems, same order — fair fight.</p>' +
+        '</div>' +
+        '<div class="duel-picker">' +
+          '<div class="duel-side"><div class="duel-side-label">Player 1</div>' +
+            '<div class="duel-tiles">' + profiles.map(function(p) { return tile(p, 'A'); }).join('') + '</div>' +
+          '</div>' +
+          '<div class="duel-vs">VS</div>' +
+          '<div class="duel-side"><div class="duel-side-label">Player 2</div>' +
+            '<div class="duel-tiles">' + profiles.map(function(p) { return tile(p, 'B'); }).join('') + '</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="duel-tables">' +
+          '<div class="duel-tables-label">Pick a table</div>' +
+          '<div class="duel-tables-row">' + tablesRow + '</div>' +
+        '</div>' +
+        lastLine +
+        '<div class="duel-go">' +
+          '<button class="action-btn btn-primary ' + (canStart ? '' : 'disabled') + '" ' +
+                  (canStart ? 'onclick="MathExtras.Duel._begin()"' : 'disabled') + '>' +
+            'Start Duel ⚔️' +
+          '</button>' +
+        '</div>';
+    }
+
+    function _pick(side, name) {
+      var p = _profileList().filter(function(x) { return x.name === name; })[0];
+      if (!p) return;
+      if (side === 'A') pickedA = p;
+      else pickedB = p;
+      _renderPicker();
+    }
+
+    function _setTable(t) {
+      pickedTable = t;
+      _renderPicker();
+    }
+
+    function _genProblems(table, count) {
+      var probs = [];
+      for (var i = 0; i < count; i++) {
+        var t = table === 0 ? (2 + Math.floor(Math.random() * 11)) : table;
+        var n = 1 + Math.floor(Math.random() * 12);
+        probs.push({ a: t, b: n, answer: t * n });
+      }
+      return probs;
+    }
+
+    function _begin() {
+      if (!pickedA || !pickedB || pickedA.name === pickedB.name) return;
+      state = {
+        problems: _genProblems(pickedTable, 80), // generous so neither runs out
+        table: pickedTable,
+        playerA: pickedA, playerB: pickedB,
+        scoreA: 0, scoreB: 0,
+        wrongA: 0, wrongB: 0,
+        current: 'A',
+        idx: 0,
+        deadline: 0,
+        timerId: null
+      };
+      _renderHandoff();
+    }
+
+    function _renderHandoff() {
+      var wrap = document.getElementById('duel-wrap');
+      if (!wrap || !state) return;
+      var who = state.current === 'A' ? state.playerA : state.playerB;
+      var label = state.current === 'A' ? 'goes first' : 'is up next';
+      wrap.innerHTML =
+        '<div class="duel-handoff">' +
+          '<div class="duel-handoff-emoji">' + (who.avatar || '🛸') + '</div>' +
+          '<div class="duel-handoff-name" style="--accent:' + (who.color || '#A78BFA') + '">' + who.name + '</div>' +
+          '<div class="duel-handoff-sub">' + label + ' — ' + DUEL_SECONDS + ' seconds, same problems for both.</div>' +
+          '<button class="action-btn btn-primary" onclick="MathExtras.Duel._startTurn()">I\'m ready ▶</button>' +
+        '</div>';
+    }
+
+    function _startTurn() {
+      if (!state) return;
+      state.idx = 0;
+      state.deadline = Date.now() + DUEL_SECONDS * 1000;
+      _renderTurn();
+      if (state.timerId) clearInterval(state.timerId);
+      state.timerId = setInterval(_tick, 250);
+      setTimeout(function() {
+        var inp = document.getElementById('duel-input');
+        if (inp) inp.focus();
+      }, 80);
+    }
+
+    function _tick() {
+      if (!state) return;
+      var rem = state.deadline - Date.now();
+      if (rem <= 0) { _endTurn(); return; }
+      var el = document.getElementById('duel-time');
+      if (el) el.textContent = Math.max(0, Math.ceil(rem / 1000)) + 's';
+    }
+
+    function _renderTurn() {
+      var wrap = document.getElementById('duel-wrap');
+      if (!wrap || !state) return;
+      var who = state.current === 'A' ? state.playerA : state.playerB;
+      var score = state.current === 'A' ? state.scoreA : state.scoreB;
+      var q = state.problems[state.idx];
+      wrap.innerHTML =
+        '<div class="sprint-header">' +
+          '<div class="sprint-chip" id="duel-time">' + DUEL_SECONDS + 's</div>' +
+          '<h2 style="color:' + (who.color || '#A78BFA') + ';">' + (who.avatar || '🛸') + ' ' + who.name + '</h2>' +
+          '<div class="sprint-chip correct">✓ ' + score + '</div>' +
+        '</div>' +
+        '<div class="sprint-question">' +
+          '<div class="sprint-q-text">' + q.a + ' × ' + q.b + ' = ?</div>' +
+          '<input type="number" id="duel-input" class="sprint-input" autocomplete="off" inputmode="numeric" />' +
+        '</div>' +
+        '<div class="sprint-hint">Press Enter to submit</div>';
+      var inp = document.getElementById('duel-input');
+      if (inp) {
+        inp.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter') { e.preventDefault(); _submit(); }
+        });
+      }
+    }
+
+    function _submit() {
+      if (!state) return;
+      var inp = document.getElementById('duel-input');
+      if (!inp) return;
+      var val = parseInt(inp.value, 10);
+      if (isNaN(val)) return;
+      var q = state.problems[state.idx];
+      var correct = val === q.answer;
+      if (state.current === 'A') {
+        if (correct) state.scoreA++; else state.wrongA++;
+      } else {
+        if (correct) state.scoreB++; else state.wrongB++;
+      }
+      if (correct && typeof SFX !== 'undefined' && SFX.tick) SFX.tick();
+      else if (!correct && typeof SFX !== 'undefined' && SFX.wrong) SFX.wrong();
+      state.idx++;
+      if (state.idx >= state.problems.length) { _endTurn(); return; }
+      _renderTurn();
+      var next = document.getElementById('duel-input');
+      if (next) next.focus();
+    }
+
+    function _endTurn() {
+      if (!state) return;
+      if (state.timerId) clearInterval(state.timerId);
+      state.timerId = null;
+      if (state.current === 'A') {
+        state.current = 'B';
+        _renderHandoff();
+      } else {
+        _finish();
+      }
+    }
+
+    function _finish() {
+      if (!state) return;
+      var winner;
+      if (state.scoreA > state.scoreB) winner = state.playerA;
+      else if (state.scoreB > state.scoreA) winner = state.playerB;
+      else winner = null; // tie
+
+      // Save last result for "rematch" memory
+      var data = _load();
+      if (!data.duel) data.duel = {};
+      data.duel.last = {
+        a: state.playerA.name, b: state.playerB.name,
+        scoreA: state.scoreA, scoreB: state.scoreB,
+        table: state.table, ts: Date.now()
+      };
+      _save(data);
+
+      if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
+        var summary = 'Duel ×' + (state.table || 'Mix') + ' — ' +
+          state.playerA.name + ' ' + state.scoreA + ' vs ' + state.scoreB + ' ' + state.playerB.name +
+          (winner ? ' (winner: ' + winner.name + ')' : ' (tie)');
+        ActivityLog.log('Math Galaxy', '🤝', summary);
+      }
+
+      var wrap = document.getElementById('duel-wrap');
+      var winLine = winner
+        ? '<div class="duel-winner-line">🏆 ' + (winner.avatar || '🛸') + ' ' + winner.name + ' wins!</div>'
+        : '<div class="duel-winner-line">🤝 It\'s a tie!</div>';
+
+      wrap.innerHTML =
+        '<div class="sprint-header">' +
+          '<button class="back-btn" onclick="MathExtras.Duel.open()" aria-label="Back">←</button>' +
+          '<h2>Duel results</h2>' +
+        '</div>' +
+        winLine +
+        '<div class="duel-scoreboard">' +
+          '<div class="duel-score-card" style="--accent:' + (state.playerA.color || '#A78BFA') + '">' +
+            '<div class="duel-score-emoji">' + (state.playerA.avatar || '🛸') + '</div>' +
+            '<div class="duel-score-name">' + state.playerA.name + '</div>' +
+            '<div class="duel-score-num">' + state.scoreA + '</div>' +
+            '<div class="duel-score-sub">' + state.wrongA + ' wrong</div>' +
+          '</div>' +
+          '<div class="duel-score-card" style="--accent:' + (state.playerB.color || '#A78BFA') + '">' +
+            '<div class="duel-score-emoji">' + (state.playerB.avatar || '🛸') + '</div>' +
+            '<div class="duel-score-name">' + state.playerB.name + '</div>' +
+            '<div class="duel-score-num">' + state.scoreB + '</div>' +
+            '<div class="duel-score-sub">' + state.wrongB + ' wrong</div>' +
+          '</div>' +
+        '</div>' +
+        '<div class="sprint-actions">' +
+          '<button class="action-btn btn-primary" onclick="MathExtras.Duel._begin()">Rematch ⚔️</button>' +
+          '<button class="action-btn btn-secondary" onclick="MathExtras.Duel.open()">New Duel</button>' +
+          '<button class="action-btn btn-secondary" onclick="MathExtras._goHome()">🪐 Home</button>' +
+        '</div>';
+
+      state = null;
+    }
+
+    return {
+      open: open,
+      _pick: _pick,
+      _setTable: _setTable,
+      _begin: _begin,
+      _startTurn: _startTurn
+    };
+  })();
+
   return {
     Sprint: Sprint,
     Words: Words,
+    Duel: Duel,
     _goHome: goHome,
     _refreshBestBadges: _refreshBestBadges
   };

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -75,6 +75,13 @@
           <div class="rank-topics">Real-world math · bilingual · 5 per tier</div>
           <div class="best-badge empty" id="best-words">Try your first problem!</div>
         </div>
+        <div class="level-card card-duel" onclick="MathExtras.Duel.open()">
+          <span class="rank-icon">🤝</span>
+          <div class="rank-name">Sibling Duel</div>
+          <div class="rank-ages">2 players · 60s each</div>
+          <div class="rank-topics">Pass-and-play · same problems · best score wins</div>
+          <div class="best-badge empty" id="best-duel">Pick two players to begin!</div>
+        </div>
       </div>
     </div>
 
@@ -86,6 +93,11 @@
     <!-- ============ WORD PROBLEMS SCREEN ============ -->
     <div class="screen" id="screen-words">
       <div id="words-wrap" class="words-wrap"></div>
+    </div>
+
+    <!-- ============ DUEL SCREEN ============ -->
+    <div class="screen" id="screen-duel">
+      <div id="duel-wrap" class="duel-wrap"></div>
     </div>
 
     <!-- ============ GAME SCREEN ============ -->


### PR DESCRIPTION
## Summary
- Pass-and-play sibling mode in Math Galaxy. Pick two profiles (or Guest), choose a multiplication table (or Mix), and play in turns.
- Both players get the **same** pre-generated 60-second problem set in the same order, so it's a fair fight — Player A goes first, then Player B sees the identical questions. Higher score wins (ties supported).
- Hub entry: new "Sibling Duel" card on the Math Galaxy level select. Last result is remembered for quick rematch context.

## Scope note
- v1 is Math Galaxy only. The picker UI and turn-handoff screen are written generically so Chess Quest and Guess Quest duel modes can lift them when those land in follow-ups.

## Test plan
- [ ] Pick two profiles, "Start Duel" → handoff screen for Player A → 60s sprint.
- [ ] At end of A's turn, handoff for B → B sees the same problems in the same order.
- [ ] Final scoreboard shows both totals + winner, with rematch / new-duel / home actions.
- [ ] Last result line on the Math Galaxy level-select card after the round.

Closes #182

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_