### PR TITLE
Family Calendar — proxy iCal fetches through the VPS for CORS (#150)

### DIFF
--- a/js/family-calendar.js
+++ b/js/family-calendar.js
@@ -217,6 +217,35 @@ var FamilyCalendar = (function() {
   }
 
   // ---- Fetch + cache ----
+  // Most public iCal hosts (Google Calendar, iCloud, Outlook) don't
+  // return CORS headers, so a direct browser fetch is blocked. When
+  // the Tailscale sync server is reachable we route through its
+  // /api/ical proxy (allowlisted, server-side fetch). Direct fetch is
+  // still attempted as a fallback for hosts that DO send CORS.
+  function _fetchIcs(url) {
+    var useProxy = (typeof CloudSync !== 'undefined') &&
+                   CloudSync.isConfigured && CloudSync.isConfigured() &&
+                   CloudSync.online && CloudSync.server;
+    var primary = useProxy
+      ? CloudSync.server + '/api/ical?url=' + encodeURIComponent(url)
+      : url;
+
+    return fetch(primary, { cache: 'no-store' })
+      .then(function(res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.text();
+      })
+      .catch(function(err) {
+        if (!useProxy) throw err;
+        // Proxy unreachable — try direct as a last resort (works for
+        // hosts that already serve CORS).
+        return fetch(url, { cache: 'no-store' }).then(function(res) {
+          if (!res.ok) throw new Error('HTTP ' + res.status);
+          return res.text();
+        });
+      });
+  }
+
   function refresh(force) {
     var urls = getUrls();
     if (!urls.length) return Promise.resolve([]);
@@ -228,11 +257,7 @@ var FamilyCalendar = (function() {
       if (!force && entry && entry.fetchedTs && (now - entry.fetchedTs) < CACHE_TTL_MS) {
         return Promise.resolve();
       }
-      return fetch(u.url, { cache: 'no-store' })
-        .then(function(res) {
-          if (!res.ok) throw new Error('HTTP ' + res.status);
-          return res.text();
-        })
+      return _fetchIcs(u.url)
         .then(function(text) {
           cache[u.url] = {
             fetchedTs: now,

--- a/vps/ical.js
+++ b/vps/ical.js
@@ -1,0 +1,135 @@
+/* ================================================================
+   ZS-SYNC — iCal proxy (#150)
+
+   Browsers can't fetch most iCal hosts (Google Calendar, iCloud,
+   Outlook) directly because those hosts don't return CORS headers.
+   This module proxies the request server-side and re-emits the body
+   with permissive CORS so Family Calendar in the suite can read it.
+
+   Mounted at GET /api/ical?url=<encoded-ics-url>.
+
+   Safety:
+   - Allowlist of hosts (extend as needed). No arbitrary URL fetches.
+   - https only (no http/file/ftp/etc).
+   - 30s timeout, 5 MB ceiling.
+   - 5-minute in-memory response cache to be kind to upstream.
+
+   No persistent storage (we don't want a copy of your calendar
+   floating around the box).
+   ================================================================ */
+
+'use strict';
+
+const ALLOWED_HOSTS = [
+  // Google Calendar
+  /^calendar\.google\.com$/,
+  /^www\.google\.com$/,         // older /calendar/ical paths
+  // Apple iCloud
+  /^p[0-9]+-caldav\.icloud\.com$/,
+  /\.icloud\.com$/,
+  // Microsoft Outlook
+  /^outlook\.live\.com$/,
+  /^outlook\.office365\.com$/,
+  /\.office365\.com$/,
+  /\.outlook\.com$/
+];
+
+const TTL_MS = 5 * 60 * 1000;       // 5 minutes
+const FETCH_TIMEOUT_MS = 30 * 1000; // 30 seconds
+const MAX_BYTES = 5 * 1024 * 1024;  // 5 MB
+
+const _cache = new Map(); // url -> { fetchedAt, status, body }
+
+function _hostAllowed(hostname) {
+  return ALLOWED_HOSTS.some(rx => rx.test(hostname));
+}
+
+function _validate(rawUrl) {
+  if (!rawUrl || typeof rawUrl !== 'string') return { ok: false, reason: 'missing url' };
+  let u;
+  try { u = new URL(rawUrl); } catch { return { ok: false, reason: 'invalid url' }; }
+  if (u.protocol !== 'https:') return { ok: false, reason: 'only https is allowed' };
+  if (!_hostAllowed(u.hostname)) return { ok: false, reason: 'host not on allowlist' };
+  return { ok: true, url: u.toString() };
+}
+
+async function _fetchUpstream(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      redirect: 'follow',
+      signal: controller.signal,
+      headers: {
+        'User-Agent': 'ZavalaSerra-iCal-Proxy/1.0',
+        'Accept': 'text/calendar, text/plain, */*'
+      }
+    });
+    if (!res.ok) {
+      return { status: res.status, body: '' };
+    }
+    // Cap the body so a hostile/oversized response can't OOM us.
+    const reader = res.body && res.body.getReader ? res.body.getReader() : null;
+    let body = '';
+    let bytes = 0;
+    if (reader) {
+      const decoder = new TextDecoder('utf-8');
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        bytes += value.length;
+        if (bytes > MAX_BYTES) {
+          try { reader.cancel(); } catch (e) {}
+          return { status: 413, body: '' };
+        }
+        body += decoder.decode(value, { stream: true });
+      }
+      body += decoder.decode();
+    } else {
+      body = await res.text();
+      if (body.length > MAX_BYTES) return { status: 413, body: '' };
+    }
+    return { status: 200, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function init(app) {
+  app.get('/api/ical', async (req, res) => {
+    const check = _validate(req.query.url);
+    if (!check.ok) {
+      return res.status(400).json({ error: check.reason });
+    }
+    const url = check.url;
+    const now = Date.now();
+
+    // Serve from cache when fresh.
+    const cached = _cache.get(url);
+    if (cached && (now - cached.fetchedAt) < TTL_MS) {
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.setHeader('X-Cache', 'HIT');
+      res.type('text/calendar; charset=utf-8');
+      return res.status(cached.status || 200).send(cached.body);
+    }
+
+    try {
+      const upstream = await _fetchUpstream(url);
+      _cache.set(url, { fetchedAt: now, status: upstream.status, body: upstream.body });
+      // Trim cache so it can't grow without bound.
+      if (_cache.size > 64) {
+        const oldestKey = _cache.keys().next().value;
+        if (oldestKey) _cache.delete(oldestKey);
+      }
+      res.setHeader('Cache-Control', 'public, max-age=300');
+      res.setHeader('X-Cache', 'MISS');
+      res.type('text/calendar; charset=utf-8');
+      return res.status(upstream.status).send(upstream.body);
+    } catch (e) {
+      const msg = e && e.name === 'AbortError' ? 'upstream timed out' : (e && e.message) || 'fetch failed';
+      return res.status(502).json({ error: msg });
+    }
+  });
+}
+
+module.exports = { init };

--- a/vps/server.js
+++ b/vps/server.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const media = require('./media');
 const diag = require('./diag');
+const ical = require('./ical');
 
 const app = express();
 const PORT = 3333;
@@ -21,6 +22,9 @@ media.init(app, DATA_DIR);
 
 // Register diag endpoints (error capture from browsers)
 diag.init(app, DATA_DIR);
+
+// Register iCal proxy (CORS-safe family calendar fetches)
+ical.init(app);
 
 app.get('/api/kids', (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- Browsers block direct fetches to Google Calendar, iCloud, and Outlook iCal feeds because those hosts don't send CORS. Without this PR the Family Calendar shipped in #216 silently 404s when parents paste a Google secret-iCal URL.
- New `vps/ical.js` proxies the request server-side. `GET /api/ical?url=<encoded>` validates against a host allowlist (Google, iCloud, Outlook), enforces https, 30s timeout, 5 MB ceiling, and a 5-min in-memory cache. The body is returned as `text/calendar` with permissive CORS.
- `family-calendar.js` now routes through `CloudSync.server + /api/ical` whenever the Tailscale sync server is configured and reachable. Direct fetch still runs as a fallback for hosts that already send CORS (e.g. self-hosted Nextcloud), and failures continue to surface inline in the Parents Corner editor.

## Server deploy steps (after merge)
On the droplet:
```
cd /opt/zavala-sync && git pull
sudo systemctl restart zavala-sync.service
curl 'http://127.0.0.1:3333/api/ical?url=https%3A%2F%2Fcalendar.google.com%2Fcalendar%2Fical%2F...basic.ics' | head
```
Expected: a `BEGIN:VCALENDAR…` body. Allowlist guard tested locally (missing url / `http://` / unknown host / `file://` / malformed → 400 with reason).

## Test plan
- [ ] Pull on droplet, restart service, confirm `/api/ping` still responds.
- [ ] Hit `/api/ical?url=` without a value → 400 `{"error":"missing url"}`.
- [ ] Hit it with a Google Calendar `.ics` URL → 200 with a `BEGIN:VCALENDAR` body.
- [ ] In the suite (Parents Corner → Family Calendar), paste a Google Calendar secret-iCal URL → events appear on the hub widget.

Closes the CORS gap noted in #150 / #216.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_