### PR TITLE
Add Family Wall — shared dashboard for the iPad-on-the-fridge

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -1,0 +1,382 @@
+/* ================================================================
+   FAMILY WALL — shared dashboard
+   Tablet-first layout (iPad on the fridge), responsive down to phone.
+   ================================================================ */
+
+:root {
+  --fw-bg: #0B0B1A;
+  --fw-card: rgba(255,255,255,0.04);
+  --fw-card-strong: rgba(255,255,255,0.07);
+  --fw-border: rgba(255,255,255,0.08);
+  --fw-text: #F0EDFF;
+  --fw-muted: rgba(240,237,255,0.55);
+  --fw-accent: #A78BFA;
+  --fw-gold: #FBBF24;
+  --fw-green: #34D399;
+  --fw-blue: #60A5FA;
+  --fw-pink: #F472B6;
+  --fw-orange: #FB923C;
+  --fw-red: #F87171;
+}
+
+body {
+  margin: 0;
+  background: var(--fw-bg);
+  color: var(--fw-text);
+  font-family: var(--font-body, 'Nunito', sans-serif);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+#fw-root {
+  position: relative;
+  z-index: 1;
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 20px 24px 60px;
+}
+
+/* ---- Top bar: avatars + date ---- */
+.fw-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+.fw-top-left { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.fw-back {
+  width: 40px; height: 40px;
+  background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 12px;
+  color: var(--fw-text);
+  font-size: 1.1rem;
+  cursor: pointer;
+  text-decoration: none;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+.fw-back:hover { background: var(--fw-card-strong); }
+
+.fw-avatars { display: flex; gap: 8px; flex-wrap: wrap; }
+.fw-avatar {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 22px;
+  background: var(--fw-card);
+  border: 2.5px solid var(--avatar-color, var(--fw-accent));
+  cursor: pointer;
+  position: relative;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+.fw-avatar:hover { transform: translateY(-2px); }
+.fw-avatar.active {
+  box-shadow: 0 0 0 3px var(--avatar-color, var(--fw-accent)),
+              0 6px 16px -6px var(--avatar-color, var(--fw-accent));
+}
+.fw-avatar-name {
+  position: absolute;
+  bottom: -18px; left: 50%; transform: translateX(-50%);
+  font-size: 0.62rem; font-weight: 700;
+  color: var(--fw-muted); white-space: nowrap;
+}
+
+.fw-date-block { text-align: right; }
+.fw-date {
+  font-family: var(--font-display, 'Baloo 2', sans-serif);
+  font-weight: 800;
+  font-size: clamp(1.1rem, 2.2vw, 1.5rem);
+  background: linear-gradient(135deg, var(--fw-accent), var(--fw-gold));
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.fw-greeting { font-size: 0.85rem; color: var(--fw-muted); font-weight: 700; }
+
+/* ---- Grid layout ---- */
+.fw-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+@media (min-width: 760px) {
+  .fw-grid {
+    grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+    grid-auto-flow: dense;
+  }
+  .fw-card-routines { grid-column: span 2; }
+}
+@media (min-width: 1100px) {
+  .fw-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .fw-card-routines { grid-column: span 3; }
+  .fw-card-weather { grid-column: span 1; }
+  .fw-card-calendar { grid-column: span 1; }
+  .fw-card-menu { grid-column: span 1; }
+  .fw-card-shopping { grid-column: span 1; }
+  .fw-card-quick { grid-column: span 2; }
+}
+
+/* ---- Card ---- */
+.fw-card {
+  background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 22px;
+  padding: 18px 20px;
+  animation: fw-fade 0.4s ease-out both;
+  min-height: 0;
+  display: flex; flex-direction: column;
+}
+@keyframes fw-fade {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.fw-card-head {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800; font-size: 1.05rem;
+  margin-bottom: 12px;
+}
+.fw-card-icon { font-size: 1.3rem; }
+.fw-card-empty { color: var(--fw-muted); font-weight: 700; font-size: 0.88rem; }
+
+/* ---- Weather card ---- */
+.fw-weather-now { display: flex; align-items: center; gap: 14px; }
+.fw-weather-icon { font-size: 3.4rem; line-height: 1; }
+.fw-weather-temp {
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800;
+  font-size: 2.2rem;
+  line-height: 1;
+}
+.fw-weather-meta { font-size: 0.82rem; color: var(--fw-muted); font-weight: 700; }
+.fw-weather-suggest {
+  margin-top: 14px;
+  padding: 10px 12px;
+  background: rgba(251,191,36,0.10);
+  border-left: 3px solid var(--fw-gold);
+  border-radius: 8px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+.fw-weather-suggest.cold {
+  background: rgba(96,165,250,0.10);
+  border-left-color: var(--fw-blue);
+}
+.fw-weather-suggest.rain {
+  background: rgba(96,165,250,0.10);
+  border-left-color: var(--fw-blue);
+}
+.fw-weather-suggest.warm {
+  background: rgba(251,191,36,0.10);
+  border-left-color: var(--fw-gold);
+}
+.fw-weather-suggest .when { color: var(--fw-muted); font-weight: 800; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; display: block; margin-bottom: 2px; }
+.fw-weather-cta { margin-top: 10px; font-size: 0.82rem; color: var(--fw-muted); font-weight: 700; }
+.fw-weather-cta a { color: var(--fw-blue); text-decoration: underline; cursor: pointer; }
+
+/* ---- Routines grid ---- */
+.fw-routines {
+  display: grid;
+  grid-template-columns: minmax(120px, max-content) minmax(0, 1fr);
+  gap: 12px 20px;
+}
+.fw-routines-head { display: contents; }
+.fw-routines-head > div {
+  font-size: 0.74rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fw-muted);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--fw-border);
+}
+.fw-r-kid {
+  display: flex; align-items: center; gap: 10px;
+}
+.fw-r-kid-avatar {
+  width: 36px; height: 36px; border-radius: 50%;
+  background: var(--fw-card-strong);
+  border: 2px solid var(--avatar-color, var(--fw-accent));
+  display: flex; align-items: center; justify-content: center;
+  font-size: 18px;
+}
+.fw-r-kid-name {
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800;
+  font-size: 0.95rem;
+}
+.fw-r-streak { font-size: 0.72rem; color: var(--fw-gold); font-weight: 800; }
+
+.fw-r-tasks {
+  display: flex; flex-wrap: wrap; gap: 6px;
+  align-items: center;
+}
+.fw-r-section {
+  display: inline-flex; flex-wrap: wrap; align-items: center; gap: 4px;
+  padding: 4px 8px;
+  background: rgba(255,255,255,0.02);
+  border-radius: 10px;
+}
+.fw-r-section + .fw-r-section { margin-left: 6px; }
+.fw-r-section-label {
+  font-size: 0.7rem; font-weight: 800;
+  color: var(--fw-muted);
+  margin-right: 4px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.fw-r-task {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 9px;
+  background: rgba(255,255,255,0.04);
+  border: 1px solid var(--fw-border);
+  border-radius: 99px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+  color: var(--fw-text);
+}
+.fw-r-task:hover { background: var(--fw-card-strong); }
+.fw-r-task.done {
+  background: rgba(52,211,153,0.18);
+  border-color: var(--fw-green);
+  color: var(--fw-green);
+  text-decoration: line-through;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rgba(52,211,153,0.5);
+}
+.fw-r-check {
+  width: 14px; height: 14px;
+  border: 1.5px solid var(--fw-muted);
+  border-radius: 4px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-size: 10px; line-height: 1;
+}
+.fw-r-task.done .fw-r-check {
+  background: var(--fw-green);
+  border-color: var(--fw-green);
+  color: #073b27;
+}
+
+/* ---- Calendar / Menu / Shopping rows ---- */
+.fw-event-row, .fw-menu-row, .fw-shop-row {
+  display: flex; align-items: baseline; gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--fw-border);
+}
+.fw-event-row:last-child, .fw-menu-row:last-child, .fw-shop-row:last-child {
+  border-bottom: none;
+}
+.fw-when {
+  font-size: 0.74rem; font-weight: 800; color: var(--fw-muted);
+  min-width: 70px;
+}
+.fw-summary { font-weight: 700; font-size: 0.9rem; flex: 1; }
+.fw-stripe {
+  width: 4px; align-self: stretch; min-height: 18px; border-radius: 2px;
+  background: var(--stripe, var(--fw-blue));
+}
+
+.fw-menu-meal {
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800; font-size: 0.85rem; color: var(--fw-muted);
+  min-width: 80px;
+}
+.fw-menu-text { font-weight: 700; font-size: 0.95rem; flex: 1; }
+.fw-menu-text.empty { color: var(--fw-muted); font-style: italic; font-weight: 600; }
+
+.fw-shop-row .fw-shop-cat {
+  font-size: 0.7rem; font-weight: 800; text-transform: uppercase;
+  color: var(--fw-muted); letter-spacing: 0.04em; min-width: 70px;
+}
+.fw-shop-row .fw-summary { font-size: 0.88rem; }
+.fw-shop-more {
+  margin-top: 6px; font-size: 0.78rem; color: var(--fw-muted); font-weight: 700;
+}
+
+/* ---- Quick links row ---- */
+.fw-quick {
+  display: flex; flex-wrap: wrap; gap: 8px;
+}
+.fw-quick a {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 14px;
+  background: var(--fw-card-strong);
+  border: 1px solid var(--fw-border);
+  border-radius: 12px;
+  color: var(--fw-text);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: transform 0.15s, border-color 0.15s;
+}
+.fw-quick a:hover { transform: translateY(-2px); border-color: var(--fw-accent); }
+.fw-quick a span.icon { font-size: 1.1rem; }
+
+/* ---- Modal (location picker) ---- */
+.fw-modal {
+  position: fixed; inset: 0;
+  background: rgba(11,11,26,0.7);
+  backdrop-filter: blur(8px);
+  display: none; align-items: center; justify-content: center;
+  z-index: 1000;
+  padding: 20px;
+}
+.fw-modal.active { display: flex; }
+.fw-modal-card {
+  background: #1A1A3E;
+  border: 1px solid var(--fw-border);
+  border-radius: 22px;
+  padding: 24px;
+  max-width: 420px;
+  width: 100%;
+}
+.fw-modal-card h2 {
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800; font-size: 1.4rem;
+  margin: 0 0 6px;
+}
+.fw-modal-card p {
+  color: var(--fw-muted); font-weight: 700; margin: 0 0 16px;
+  font-size: 0.85rem;
+}
+.fw-or {
+  text-align: center; color: var(--fw-muted);
+  font-weight: 800; font-size: 0.78rem;
+  margin: 14px 0 8px;
+}
+.fw-loc-cities {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
+  margin-bottom: 16px;
+}
+.fw-loc-city {
+  padding: 10px; background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  color: var(--fw-text);
+}
+.fw-loc-city:hover { border-color: var(--fw-accent); }
+.fw-modal-btns { display: flex; gap: 8px; justify-content: flex-end; }
+.fw-btn {
+  padding: 10px 18px; border-radius: 10px;
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800; font-size: 0.9rem;
+  cursor: pointer;
+  border: 1px solid var(--fw-border);
+}
+.fw-btn-primary { background: linear-gradient(135deg, var(--fw-accent), var(--fw-blue)); color: #fff; border-color: transparent; width: 100%; padding: 14px; }
+.fw-btn-ghost { background: transparent; color: var(--fw-text); }
+
+/* ---- Aurora decorative blobs (cosmetic only) ---- */
+.aurora { position: fixed; border-radius: 50%; filter: blur(100px); pointer-events: none; z-index: 0; opacity: 0.5; }
+.aurora-1 { width: 480px; height: 480px; background: rgba(124,58,237,0.18); top: -120px; left: -100px; }
+.aurora-2 { width: 380px; height: 380px; background: rgba(52,211,153,0.12); bottom: -80px; right: -60px; }

--- a/family.html
+++ b/family.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Family Wall 🏠</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/family-wall.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#7C3AED">
+  <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
+  <link rel="apple-touch-icon" href="icons/icon.svg">
+  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+</head>
+<body>
+  <div class="aurora aurora-1"></div>
+  <div class="aurora aurora-2"></div>
+
+  <div id="fw-root"></div>
+
+  <div id="fw-loc-modal" class="fw-modal" onclick="if(event.target===this)FamilyWall.closeLocationModal()">
+    <div class="fw-modal-card">
+      <h2>Set Home Location 📍</h2>
+      <p>Used for the weather card. Stored on this device only.</p>
+      <button class="fw-btn fw-btn-primary" onclick="FamilyWall.requestGeo()">📍 Use my current location</button>
+      <div class="fw-or">or pick a city</div>
+      <div id="fw-loc-cities" class="fw-loc-cities"></div>
+      <div class="fw-modal-btns">
+        <button class="fw-btn fw-btn-ghost" onclick="FamilyWall.closeLocationModal()">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="js/auth.js"></script>
+  <script src="js/a11y.js"></script>
+  <script src="js/sync.js"></script>
+  <script src="js/zs-diag.js"></script>
+  <script src="js/timer.js"></script>
+  <script src="js/activity-log.js"></script>
+  <script src="js/chilean-calendar.js"></script>
+  <script src="js/routines.js"></script>
+  <script src="js/family-calendar.js"></script>
+  <script src="js/family-wall.js"></script>
+  <script src="js/pwa.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
 
       <!-- Parent access from login screen (no kid login needed) -->
       <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:8px;">
+        <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="family.html">
+          🏠 Family Wall
+        </a>
         <button class="parent-btn" style="margin-top:0;" onclick="requestPinThen(function() { openParentsCorner(); })">
           🔒 Parents Corner
         </button>
@@ -245,6 +248,9 @@
       </div>
 
       <div style="display:flex;flex-wrap:wrap;gap:12px;justify-content:center;margin-top:32px;">
+        <a class="parent-btn" style="margin-top:0;text-decoration:none;display:inline-flex;align-items:center;gap:8px;" href="family.html">
+          🏠 Family Wall
+        </a>
         <button class="parent-btn" style="margin-top:0;" onclick="openChores()">
           🏠 Tareas del Hogar
         </button>

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -1,0 +1,514 @@
+/* ================================================================
+   FAMILY WALL — shared dashboard for the iPad-on-the-fridge
+   - Avatar strip up top (tap to log in as that kid)
+   - Today's date + greeting
+   - Weather card with morning/afternoon clothing suggestion
+   - Routines grid: rows = kids, columns = morning + evening tasks
+     with checkable chips (trust-based; PIN gate optional via parent
+     settings — out of scope for v1)
+   - Today's calendar (FamilyCalendar.getUpcoming filtered to today)
+   - Today's menu (zs_menu)
+   - Active shopping list summary (zs_shopping_list)
+   - Quick links: Menu, Shopping, Routines, full app hub
+
+   Storage:
+     zs_home_location = { lat, lon, label, ts }
+     zs_fw_weather    = { fetchedAt, payload, location }
+   ================================================================ */
+
+var FamilyWall = (function() {
+  'use strict';
+
+  var WEATHER_KEY = 'zs_fw_weather';
+  var LOCATION_KEY = 'zs_home_location';
+  var WEATHER_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+  // Pre-set city options so the location picker works without
+  // browser geolocation. Lat/lon to 2 decimals — plenty for weather.
+  var CITY_PRESETS = [
+    { label: 'Santiago, CL', lat: -33.45, lon: -70.66 },
+    { label: 'Viña del Mar, CL', lat: -33.02, lon: -71.55 },
+    { label: 'Concepción, CL', lat: -36.83, lon: -73.05 },
+    { label: 'La Serena, CL', lat: -29.90, lon: -71.25 },
+    { label: 'Punta Arenas, CL', lat: -53.16, lon: -70.91 },
+    { label: 'Miami, US', lat: 25.76, lon: -80.19 }
+  ];
+
+  function _esc(s) {
+    return String(s == null ? '' : s)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
+  function _todayIsoLocal() {
+    var d = new Date();
+    return d.getFullYear() + '-' +
+      String(d.getMonth() + 1).padStart(2, '0') + '-' +
+      String(d.getDate()).padStart(2, '0');
+  }
+
+  function _mondayIsoOf(d) {
+    var day = d.getDay();
+    var off = day === 0 ? -6 : 1 - day;
+    var m = new Date(d.getFullYear(), d.getMonth(), d.getDate() + off);
+    return m.getFullYear() + '-' + String(m.getMonth()+1).padStart(2,'0') + '-' + String(m.getDate()).padStart(2,'0');
+  }
+
+  function _todayDayId() {
+    return ['sun','mon','tue','wed','thu','fri','sat'][new Date().getDay()];
+  }
+
+  function _greeting() {
+    var h = new Date().getHours();
+    if (h < 12) return 'Good morning, family!';
+    if (h < 18) return 'Good afternoon, family!';
+    return 'Good evening, family!';
+  }
+
+  function _formatDate() {
+    return new Date().toLocaleDateString(undefined, {
+      weekday: 'long', month: 'long', day: 'numeric'
+    });
+  }
+
+  // ---- Location ----
+  function getLocation() {
+    try { return JSON.parse(localStorage.getItem(LOCATION_KEY) || 'null'); }
+    catch (e) { return null; }
+  }
+
+  function setLocation(loc) {
+    if (!loc || typeof loc.lat !== 'number' || typeof loc.lon !== 'number') return;
+    localStorage.setItem(LOCATION_KEY, JSON.stringify({
+      lat: loc.lat, lon: loc.lon, label: loc.label || 'Home', ts: Date.now()
+    }));
+    // Force a fresh weather fetch
+    localStorage.removeItem(WEATHER_KEY);
+    fetchWeather().then(_paint).catch(_paint);
+  }
+
+  // ---- Weather (Open-Meteo, free, no key) ----
+  function fetchWeather() {
+    var loc = getLocation();
+    if (!loc) return Promise.resolve(null);
+    var cached = null;
+    try { cached = JSON.parse(localStorage.getItem(WEATHER_KEY) || 'null'); } catch (e) {}
+    if (cached && cached.fetchedAt && (Date.now() - cached.fetchedAt) < WEATHER_TTL_MS &&
+        cached.location && cached.location.lat === loc.lat && cached.location.lon === loc.lon) {
+      return Promise.resolve(cached);
+    }
+    var url = 'https://api.open-meteo.com/v1/forecast' +
+      '?latitude=' + loc.lat + '&longitude=' + loc.lon +
+      '&current_weather=true' +
+      '&daily=temperature_2m_max,temperature_2m_min,precipitation_sum,uv_index_max,weathercode' +
+      '&timezone=auto&forecast_days=2';
+    return fetch(url, { cache: 'no-store' })
+      .then(function(res) {
+        if (!res.ok) throw new Error('weather HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function(payload) {
+        var record = { fetchedAt: Date.now(), payload: payload, location: loc };
+        try { localStorage.setItem(WEATHER_KEY, JSON.stringify(record)); } catch (e) {}
+        return record;
+      })
+      .catch(function(e) {
+        return cached || { error: String(e && e.message || e), location: loc };
+      });
+  }
+
+  // ---- Open-Meteo weathercode → emoji + description ----
+  // https://open-meteo.com/en/docs (WMO codes)
+  function _wxLabel(code) {
+    var map = {
+      0:  ['☀️', 'Clear'],
+      1:  ['🌤', 'Mainly clear'],
+      2:  ['⛅', 'Partly cloudy'],
+      3:  ['☁️', 'Overcast'],
+      45: ['🌫', 'Fog'],
+      48: ['🌫', 'Fog'],
+      51: ['🌦', 'Light drizzle'],
+      53: ['🌦', 'Drizzle'],
+      55: ['🌧', 'Heavy drizzle'],
+      61: ['🌦', 'Light rain'],
+      63: ['🌧', 'Rain'],
+      65: ['🌧', 'Heavy rain'],
+      71: ['🌨', 'Light snow'],
+      73: ['🌨', 'Snow'],
+      75: ['❄️', 'Heavy snow'],
+      80: ['🌦', 'Rain showers'],
+      81: ['🌧', 'Rain showers'],
+      82: ['⛈', 'Violent rain'],
+      95: ['⛈', 'Thunderstorm'],
+      96: ['⛈', 'Thunder + hail'],
+      99: ['⛈', 'Thunder + hail']
+    };
+    return map[code] || ['🌡', 'Weather'];
+  }
+
+  function _suggest(weather) {
+    if (!weather || !weather.payload || !weather.payload.daily) return null;
+    var d = weather.payload.daily;
+    var hour = new Date().getHours();
+    var morning = hour < 14;
+    var idx = morning ? 0 : 1; // today vs tomorrow
+    if (!d.temperature_2m_max || !d.temperature_2m_max[idx]) idx = 0;
+
+    var maxT = d.temperature_2m_max && d.temperature_2m_max[idx];
+    var minT = d.temperature_2m_min && d.temperature_2m_min[idx];
+    var precip = (d.precipitation_sum && d.precipitation_sum[idx]) || 0;
+    var uv = (d.uv_index_max && d.uv_index_max[idx]) || 0;
+
+    var when = morning ? 'Today' : 'Tomorrow';
+
+    if (precip >= 2) {
+      return { mood: 'rain', when: when, text: '🧥 Bring a raincoat — ' + precip.toFixed(1) + ' mm of rain expected.' };
+    }
+    if (typeof minT === 'number' && minT < 8) {
+      return { mood: 'cold', when: when, text: '🧣 Bring a parka — low of ' + Math.round(minT) + '°C.' };
+    }
+    if (typeof maxT === 'number' && maxT >= 26 && uv >= 6) {
+      return { mood: 'warm', when: when, text: '🧴 Apply sunscreen — UV ' + Math.round(uv) + ', high of ' + Math.round(maxT) + '°C.' };
+    }
+    if (typeof maxT === 'number' && maxT >= 28) {
+      return { mood: 'warm', when: when, text: '💧 Hot day — bring a water bottle.' };
+    }
+    if (uv >= 7) {
+      return { mood: 'warm', when: when, text: '🧴 High UV (' + Math.round(uv) + ') — apply sunscreen.' };
+    }
+    return { mood: 'warm', when: when, text: '👍 Mild weather — no special gear needed.' };
+  }
+
+  // ---- Render ----
+  function _paint() {
+    var root = document.getElementById('fw-root');
+    if (!root) return;
+    var profiles = (typeof getProfiles === 'function') ? getProfiles() : [];
+    var active = (typeof getActiveUser === 'function') ? getActiveUser() : null;
+
+    var avatars = profiles.map(function(p) {
+      var on = active && active.name === p.name;
+      return '<div class="fw-avatar ' + (on ? 'active' : '') + '" ' +
+               'style="--avatar-color:' + _esc(p.color || '#A78BFA') + '" ' +
+               'onclick="FamilyWall.loginAs(\'' + _esc(p.name).replace(/\\/g, '\\\\').replace(/\'/g, '\\\'') + '\')">' +
+        _esc(p.avatar || '🦊') +
+        '<span class="fw-avatar-name">' + _esc(p.name) + '</span>' +
+      '</div>';
+    }).join('');
+
+    root.innerHTML =
+      '<div class="fw-top">' +
+        '<div class="fw-top-left">' +
+          '<a class="fw-back" href="index.html" aria-label="Back to hub">←</a>' +
+          '<div class="fw-avatars">' + avatars + '</div>' +
+        '</div>' +
+        '<div class="fw-date-block">' +
+          '<div class="fw-date">' + _esc(_formatDate()) + '</div>' +
+          '<div class="fw-greeting">' + _esc(_greeting()) + '</div>' +
+        '</div>' +
+      '</div>' +
+
+      '<div class="fw-grid">' +
+        _renderWeatherCard() +
+        _renderRoutinesCard(profiles) +
+        _renderCalendarCard() +
+        _renderMenuCard() +
+        _renderShoppingCard() +
+        _renderQuickCard() +
+      '</div>';
+
+    // After paint, populate location modal cities and lazy-fetch calendar.
+    _populateCityList();
+    if (typeof FamilyCalendar !== 'undefined' && FamilyCalendar.refresh) {
+      FamilyCalendar.refresh(false).then(_paintCalendar).catch(function() {});
+    }
+  }
+
+  // ---- Card renderers ----
+  function _renderWeatherCard() {
+    var loc = getLocation();
+    if (!loc) {
+      return '<div class="fw-card fw-card-weather">' +
+        '<div class="fw-card-head"><span class="fw-card-icon">⛅</span> Weather</div>' +
+        '<div class="fw-card-empty">Set a home location to see today\'s forecast.</div>' +
+        '<div class="fw-weather-cta"><a onclick="FamilyWall.openLocationModal()">Set home location 📍</a></div>' +
+      '</div>';
+    }
+    var cached = null;
+    try { cached = JSON.parse(localStorage.getItem(WEATHER_KEY) || 'null'); } catch (e) {}
+    if (!cached || cached.error) {
+      // Fire fetch and render placeholder; _paint will re-run when it returns.
+      fetchWeather().then(_paint).catch(_paint);
+      return '<div class="fw-card fw-card-weather">' +
+        '<div class="fw-card-head"><span class="fw-card-icon">⛅</span> Weather</div>' +
+        '<div class="fw-card-empty">Loading…</div>' +
+      '</div>';
+    }
+    var p = cached.payload || {};
+    var current = p.current_weather || {};
+    var labelInfo = _wxLabel(current.weathercode);
+    var emoji = labelInfo[0], desc = labelInfo[1];
+    var d = p.daily || {};
+    var hi = d.temperature_2m_max && d.temperature_2m_max[0];
+    var lo = d.temperature_2m_min && d.temperature_2m_min[0];
+    var sug = _suggest(cached);
+
+    return '<div class="fw-card fw-card-weather">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">⛅</span> ' + _esc(loc.label || 'Weather') + '</div>' +
+      '<div class="fw-weather-now">' +
+        '<div class="fw-weather-icon">' + emoji + '</div>' +
+        '<div>' +
+          '<div class="fw-weather-temp">' + Math.round(current.temperature || 0) + '°</div>' +
+          '<div class="fw-weather-meta">' + _esc(desc) +
+            (typeof hi === 'number' && typeof lo === 'number'
+              ? ' · H ' + Math.round(hi) + '° / L ' + Math.round(lo) + '°'
+              : '') +
+          '</div>' +
+        '</div>' +
+      '</div>' +
+      (sug ? '<div class="fw-weather-suggest ' + _esc(sug.mood) + '">' +
+        '<span class="when">' + _esc(sug.when) + '</span>' +
+        _esc(sug.text) +
+      '</div>' : '') +
+      '<div class="fw-weather-cta"><a onclick="FamilyWall.openLocationModal()">Change location</a></div>' +
+    '</div>';
+  }
+
+  function _renderRoutinesCard(profiles) {
+    if (!profiles.length || typeof Routines === 'undefined' || !Routines.getStatusFor) {
+      return '<div class="fw-card fw-card-routines">' +
+        '<div class="fw-card-head"><span class="fw-card-icon">📋</span> Routines</div>' +
+        '<div class="fw-card-empty">Add a profile to start tracking routines.</div>' +
+      '</div>';
+    }
+    var rows = profiles.map(function(p) {
+      var status = Routines.getStatusFor(p.name);
+      if (!status) return '';
+      var morningChips = status.morning.items.map(function(it) {
+        return '<button class="fw-r-task ' + (it.done ? 'done' : '') + '" ' +
+                 'onclick="FamilyWall.toggleRoutine(\'' + _escAttr(p.name) + '\', \'morning\', \'' + _escAttr(it.id) + '\')">' +
+          '<span class="fw-r-check">' + (it.done ? '✓' : '') + '</span>' +
+          _esc(it.label) +
+        '</button>';
+      }).join('');
+      var eveningChips = status.evening.items.map(function(it) {
+        return '<button class="fw-r-task ' + (it.done ? 'done' : '') + '" ' +
+                 'onclick="FamilyWall.toggleRoutine(\'' + _escAttr(p.name) + '\', \'evening\', \'' + _escAttr(it.id) + '\')">' +
+          '<span class="fw-r-check">' + (it.done ? '✓' : '') + '</span>' +
+          _esc(it.label) +
+        '</button>';
+      }).join('');
+      return '<div class="fw-r-kid" style="--avatar-color:' + _esc(p.color || '#A78BFA') + '">' +
+          '<div class="fw-r-kid-avatar">' + _esc(p.avatar || '🦊') + '</div>' +
+          '<div>' +
+            '<div class="fw-r-kid-name">' + _esc(p.name) + '</div>' +
+            (status.streak > 0 ? '<div class="fw-r-streak">🔥 ' + status.streak + ' day streak</div>' : '') +
+          '</div>' +
+        '</div>' +
+        '<div class="fw-r-tasks">' +
+          (morningChips ? '<div class="fw-r-section"><span class="fw-r-section-label">🌅 AM</span>' + morningChips + '</div>' : '') +
+          (eveningChips ? '<div class="fw-r-section"><span class="fw-r-section-label">🌙 PM</span>' + eveningChips + '</div>' : '') +
+        '</div>';
+    }).join('');
+
+    return '<div class="fw-card fw-card-routines">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">📋</span> Routines · today</div>' +
+      '<div class="fw-routines">' +
+        '<div class="fw-routines-head"><div>Kid</div><div>Tasks</div></div>' +
+        rows +
+      '</div>' +
+    '</div>';
+  }
+
+  function _renderCalendarCard() {
+    return '<div class="fw-card fw-card-calendar" id="fw-calendar-card">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">📅</span> Today</div>' +
+      _calendarBodyHtml() +
+    '</div>';
+  }
+
+  function _calendarBodyHtml() {
+    if (typeof FamilyCalendar === 'undefined' || !FamilyCalendar.getUpcoming) {
+      return '<div class="fw-card-empty">Family Calendar not loaded.</div>';
+    }
+    var todayStr = new Date().toDateString();
+    var events = FamilyCalendar.getUpcoming(50).filter(function(ev) {
+      return ev.start.toDateString() === todayStr;
+    });
+    if (!events.length) {
+      var urls = FamilyCalendar.getUrls();
+      if (!urls.length) {
+        return '<div class="fw-card-empty">No calendars yet — add one in Parents Corner on the hub.</div>';
+      }
+      return '<div class="fw-card-empty">No events scheduled for today.</div>';
+    }
+    return events.slice(0, 6).map(function(ev) {
+      var when = ev.allDay ? 'All day'
+        : ev.start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+      return '<div class="fw-event-row">' +
+        '<div class="fw-stripe" style="--stripe:' + _esc(ev.calColor || '#60A5FA') + '"></div>' +
+        '<div class="fw-when">' + _esc(when) + '</div>' +
+        '<div class="fw-summary">' + _esc(ev.summary) + '</div>' +
+      '</div>';
+    }).join('');
+  }
+
+  function _paintCalendar() {
+    var card = document.getElementById('fw-calendar-card');
+    if (!card) return;
+    card.innerHTML = '<div class="fw-card-head"><span class="fw-card-icon">📅</span> Today</div>' + _calendarBodyHtml();
+  }
+
+  function _renderMenuCard() {
+    var raw;
+    try { raw = JSON.parse(localStorage.getItem('zs_menu') || '{}'); } catch (e) { raw = {}; }
+    var weeks = raw.weeks || {};
+    var monIso = _mondayIsoOf(new Date());
+    var week = weeks[monIso] || {};
+    var dayId = _todayDayId();
+    var meals = week[dayId] || { breakfast: '', lunch: '', dinner: '' };
+
+    function row(emoji, label, value) {
+      var v = (value || '').trim();
+      return '<div class="fw-menu-row">' +
+        '<div class="fw-menu-meal">' + emoji + ' ' + label + '</div>' +
+        '<div class="fw-menu-text ' + (v ? '' : 'empty') + '">' + (v ? _esc(v) : 'Sin asignar') + '</div>' +
+      '</div>';
+    }
+    var anyMeal = !!(meals.breakfast || meals.lunch || meals.dinner);
+
+    return '<div class="fw-card fw-card-menu">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">🍽️</span> Today\'s menu</div>' +
+      (anyMeal
+        ? row('🥣', 'Desayuno', meals.breakfast) +
+          row('🍽', 'Almuerzo', meals.lunch) +
+          row('🌙', 'Cena', meals.dinner)
+        : '<div class="fw-card-empty">No meals planned for today. <a href="menu.html">Plan the week →</a></div>') +
+    '</div>';
+  }
+
+  function _renderShoppingCard() {
+    var items;
+    try { items = JSON.parse(localStorage.getItem('zs_shopping_list') || '[]'); }
+    catch (e) { items = []; }
+    if (!Array.isArray(items)) items = [];
+    var pending = items.filter(function(it) { return !it.checked; });
+    if (!pending.length) {
+      return '<div class="fw-card fw-card-shopping">' +
+        '<div class="fw-card-head"><span class="fw-card-icon">🛒</span> Shopping list</div>' +
+        '<div class="fw-card-empty">All caught up. <a href="shopping-list.html">Add items →</a></div>' +
+      '</div>';
+    }
+    var top = pending.slice(0, 6).map(function(it) {
+      return '<div class="fw-shop-row">' +
+        '<div class="fw-shop-cat">' + _esc(it.category || 'Other') + '</div>' +
+        '<div class="fw-summary">' + _esc(it.name || it.label || '') + '</div>' +
+      '</div>';
+    }).join('');
+    var more = pending.length > 6 ? '<div class="fw-shop-more">+ ' + (pending.length - 6) + ' more</div>' : '';
+    return '<div class="fw-card fw-card-shopping">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">🛒</span> Shopping list · ' + pending.length + ' items</div>' +
+      top + more +
+    '</div>';
+  }
+
+  function _renderQuickCard() {
+    return '<div class="fw-card fw-card-quick">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">🚀</span> Jump in</div>' +
+      '<div class="fw-quick">' +
+        '<a href="menu.html"><span class="icon">🍽️</span> Weekly menu</a>' +
+        '<a href="shopping-list.html"><span class="icon">🛒</span> Shopping list</a>' +
+        '<a href="home-timer.html"><span class="icon">⏱</span> Home timer</a>' +
+        '<a href="vacation.html"><span class="icon">✈️</span> Vacation</a>' +
+        '<a href="index.html"><span class="icon">🏠</span> All apps</a>' +
+      '</div>' +
+    '</div>';
+  }
+
+  // ---- Avatar tap → log in as that kid and go to hub ----
+  function loginAs(name) {
+    if (!name) return;
+    var profiles = (typeof getProfiles === 'function') ? getProfiles() : [];
+    var p = profiles.filter(function(x) { return x.name === name; })[0];
+    if (!p) return;
+    if (typeof setActiveUser === 'function') setActiveUser(p);
+    try { window._activeUserCached = false; } catch (e) {}
+    window.location.href = 'index.html';
+  }
+
+  // ---- Routine toggle ----
+  function toggleRoutine(name, routine, itemId) {
+    if (typeof Routines === 'undefined' || !Routines.toggleFor) return;
+    Routines.toggleFor(name, routine, itemId);
+    _paint();
+  }
+
+  // ---- Location modal ----
+  function openLocationModal() {
+    var m = document.getElementById('fw-loc-modal');
+    if (m) m.classList.add('active');
+  }
+  function closeLocationModal() {
+    var m = document.getElementById('fw-loc-modal');
+    if (m) m.classList.remove('active');
+  }
+
+  function _populateCityList() {
+    var el = document.getElementById('fw-loc-cities');
+    if (!el) return;
+    el.innerHTML = CITY_PRESETS.map(function(c) {
+      return '<button class="fw-loc-city" onclick="FamilyWall._pickCity(' + c.lat + ',' + c.lon + ',\'' + _escAttr(c.label) + '\')">' +
+        _esc(c.label) +
+      '</button>';
+    }).join('');
+  }
+
+  function _pickCity(lat, lon, label) {
+    setLocation({ lat: lat, lon: lon, label: label });
+    closeLocationModal();
+    _paint();
+  }
+
+  function requestGeo() {
+    if (!navigator.geolocation) {
+      alert('Geolocation is not supported by this browser. Pick a city instead.');
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      function(pos) {
+        setLocation({
+          lat: Math.round(pos.coords.latitude * 100) / 100,
+          lon: Math.round(pos.coords.longitude * 100) / 100,
+          label: 'Home'
+        });
+        closeLocationModal();
+        _paint();
+      },
+      function(err) { alert('Could not get your location: ' + err.message); },
+      { timeout: 10000 }
+    );
+  }
+
+  function _escAttr(s) {
+    return String(s == null ? '' : s).replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '&quot;');
+  }
+
+  // ---- Init ----
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', _paint);
+  } else {
+    _paint();
+  }
+
+  return {
+    paint: _paint,
+    loginAs: loginAs,
+    toggleRoutine: toggleRoutine,
+    openLocationModal: openLocationModal,
+    closeLocationModal: closeLocationModal,
+    requestGeo: requestGeo,
+    setLocation: setLocation,
+    getLocation: getLocation,
+    _pickCity: _pickCity
+  };
+})();

--- a/js/routines.js
+++ b/js/routines.js
@@ -339,8 +339,87 @@ var Routines = (function() {
     renderHubWidget('routines-widget');
   }
 
+  // Status + toggle for any kid by name (used by Family Wall, where
+  // multiple kids' routines render side-by-side without switching the
+  // active user). Reads/writes zs_routines_<kid>.
+  function getStatusFor(userName) {
+    if (!userName) return null;
+    var k = STORAGE_PREFIX + userName.toLowerCase().replace(/\s+/g, '_');
+    var data;
+    try { data = JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { data = {}; }
+    if (!data.days) data.days = {};
+    if (typeof data.streak !== 'number') data.streak = 0;
+    if (typeof data.bestStreak !== 'number') data.bestStreak = 0;
+    var today = _today();
+    if (!data.days[today]) data.days[today] = { morning: [], evening: [] };
+    var day = data.days[today];
+    var morningTpl = _getTemplate(data, 'morning');
+    var eveningTpl = _getTemplate(data, 'evening');
+    return {
+      userName: userName,
+      date: today,
+      streak: data.streak,
+      bestStreak: data.bestStreak,
+      morning: {
+        items: morningTpl.map(function(c) {
+          return { id: c.id, label: c.label, done: day.morning.indexOf(c.id) !== -1 };
+        }),
+        doneCount: day.morning.length,
+        total: morningTpl.length,
+        complete: day.morning.length >= morningTpl.length
+      },
+      evening: {
+        items: eveningTpl.map(function(c) {
+          return { id: c.id, label: c.label, done: day.evening.indexOf(c.id) !== -1 };
+        }),
+        doneCount: day.evening.length,
+        total: eveningTpl.length,
+        complete: day.evening.length >= eveningTpl.length
+      }
+    };
+  }
+
+  function toggleFor(userName, routine, itemId) {
+    if (!userName) return null;
+    if (routine !== 'morning' && routine !== 'evening') return getStatusFor(userName);
+    var k = STORAGE_PREFIX + userName.toLowerCase().replace(/\s+/g, '_');
+    var data;
+    try { data = JSON.parse(localStorage.getItem(k)) || {}; } catch (e) { data = {}; }
+    if (!data.days) data.days = {};
+    var today = _today();
+    if (!data.days[today]) data.days[today] = { morning: [], evening: [] };
+    var day = data.days[today];
+    var list = day[routine];
+    var tpl = _getTemplate(data, routine);
+    var idx = list.indexOf(itemId);
+    if (idx === -1) {
+      var isKnown = tpl.some(function(c) { return c.id === itemId; });
+      if (!isKnown) return getStatusFor(userName);
+      list.push(itemId);
+    } else {
+      list.splice(idx, 1);
+    }
+
+    // Update streak when both routines are complete for the day.
+    var morningTpl = _getTemplate(data, 'morning');
+    var eveningTpl = _getTemplate(data, 'evening');
+    var bothDone = day.morning.length >= morningTpl.length &&
+                   day.evening.length >= eveningTpl.length;
+    if (bothDone && data.lastFullDay !== today) {
+      if (data.lastFullDay === _yesterday()) data.streak = (data.streak || 0) + 1;
+      else data.streak = 1;
+      data.lastFullDay = today;
+      if (data.streak > (data.bestStreak || 0)) data.bestStreak = data.streak;
+    }
+
+    try { localStorage.setItem(k, JSON.stringify(data)); } catch (e) {}
+    return getStatusFor(userName);
+  }
+
   return {
     getStatus: getStatus,
+    getStatusFor: getStatusFor,
+    toggleFor: toggleFor,
     getActiveRoutine: getActiveRoutine,
     toggle: toggle,
     renderHubWidget: renderHubWidget,


### PR DESCRIPTION
## Summary
A new `family.html` page that surfaces shared household state in one glance — designed for a tablet sitting on the kitchen counter:

- **Avatar strip** up top: tap any kid to log in as them and jump to the app hub. Active user is highlighted.
- **Date + greeting** that adapts to morning / afternoon / evening.
- **Weather card** (Open-Meteo, no API key) with a contextual clothing suggestion:
  - rain expected → raincoat
  - low temps → parka
  - hot + high UV → sunscreen
  - Morning view shows today; afternoon switches to tomorrow.
  - Home location set via geolocation or a small picker (Chilean cities + Miami). Stored in `zs_home_location`.
- **Routines grid**: rows = each profile, columns = today's morning + night chips. Tap a chip to mark it done — trust-based, no PIN. Streak counter per kid. Built on a new `Routines.toggleFor` / `getStatusFor` API so we can update any kid's state without switching the active user.
- **Today's calendar events** filtered from `FamilyCalendar.getUpcoming()`.
- **Today's menu** (`zs_menu`) — breakfast / lunch / dinner.
- **Active shopping list summary** (`zs_shopping_list`) — pending items grouped by category.
- **Quick-jump links** to menu, shopping, home timer, vacation, full hub.

## Entry points
A "Family Wall" button on both the login screen and the hub. The login-screen entry is the key one — parents can open it in the morning without picking a kid first.

## Weather note
Open-Meteo is the only new external dependency. It's free, has no API key, and serves CORS, so direct browser fetch works (no VPS proxy needed). 30-min client cache to be kind to the upstream.

## Test plan
- [ ] Open `family.html` (or click 🏠 Family Wall on login screen) → page renders even with no profiles.
- [ ] With 1+ profiles: avatars appear; active user highlighted; clicking another avatar logs in and jumps to hub.
- [ ] Routines grid: tap a chip → it crosses out and persists across reload. State is per-kid (toggling Mateo doesn't affect Ana).
- [ ] Weather card: shows "Set home location" CTA → pick a city → weather populates. Geolocation flow works on iOS.
- [ ] Today's calendar surfaces only events whose start date is today.
- [ ] Menu card shows today's breakfast/lunch/dinner from the current week's anchor (Monday). Empty state links to `menu.html`.
- [ ] Shopping list shows pending items only, with a "+N more" line when over 6.
- [ ] Mobile (≤760px): everything stacks to one column. Tablet+: routines spans full width with sidebar widgets.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_