### PR TITLE
Fix Family Calendar cache rehydration — Wall went black after JSON round-trip

### DIFF
--- a/js/family-calendar.js
+++ b/js/family-calendar.js
@@ -69,7 +69,25 @@ var FamilyCalendar = (function() {
   }
 
   function _getCache() {
-    try { return JSON.parse(localStorage.getItem(CACHE_KEY) || '{}') || {}; }
+    try {
+      var raw = JSON.parse(localStorage.getItem(CACHE_KEY) || '{}') || {};
+      // Re-hydrate Date fields after JSON round-trip — saved events
+      // store start/end/rrule.until as Dates but JSON serializes them
+      // to ISO strings. Without this, _expand throws when calling
+      // start.getTime() on a string (#150 hot fix).
+      Object.keys(raw).forEach(function(url) {
+        var entry = raw[url];
+        if (!entry || !Array.isArray(entry.events)) return;
+        entry.events.forEach(function(ev) {
+          if (ev.start && !(ev.start instanceof Date)) ev.start = new Date(ev.start);
+          if (ev.end   && !(ev.end   instanceof Date)) ev.end   = new Date(ev.end);
+          if (ev.rrule && ev.rrule.until && !(ev.rrule.until instanceof Date)) {
+            ev.rrule.until = new Date(ev.rrule.until);
+          }
+        });
+      });
+      return raw;
+    }
     catch (e) { return {}; }
   }
 

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -331,10 +331,17 @@ var FamilyWall = (function() {
     if (typeof FamilyCalendar === 'undefined' || !FamilyCalendar.getUpcoming) {
       return '<div class="fw-card-empty">Family Calendar not loaded.</div>';
     }
-    var todayStr = new Date().toDateString();
-    var events = FamilyCalendar.getUpcoming(50).filter(function(ev) {
-      return ev.start.toDateString() === todayStr;
-    });
+    var events;
+    try {
+      var todayStr = new Date().toDateString();
+      events = FamilyCalendar.getUpcoming(50).filter(function(ev) {
+        return ev.start && typeof ev.start.toDateString === 'function' &&
+               ev.start.toDateString() === todayStr;
+      });
+    } catch (e) {
+      // A bad cached event shouldn't black out the whole wall.
+      return '<div class="fw-card-empty">Calendar unavailable right now.</div>';
+    }
     if (!events.length) {
       var urls = FamilyCalendar.getUrls();
       if (!urls.length) {


### PR DESCRIPTION
## Symptom
`family.html` (Family Wall) renders black with only the aurora blobs visible. Console:
```
TypeError: start.getTime is not a function
  at pushIfInRange (family-calendar.js:179)
  at _expand (family-calendar.js:186)
  at getUpcoming (family-calendar.js:289)
  at _calendarBodyHtml (family-wall.js:335)
```

## Cause
`parseIcs` returns events with `Date` instances on `start` / `end` / `rrule.until`. `_saveCache` JSON-stringifies the cache, which serializes those Dates to ISO strings. On the next page load we read them back unchanged and pass them into `_expand`, which assumes Dates → `start.getTime()` blows up. The error escapes `_paint` and the rest of the page never gets a chance to render.

## Fix
1. **`_getCache`**: hydrate `start`, `end`, and `rrule.until` to `Date` instances right after the JSON.parse. One pass at load time keeps every callsite simple — they keep getting Dates as before, like they did when the cache was still in memory from the original `parseIcs`.
2. **Defensive try/catch** around the calendar tile in `family-wall._calendarBodyHtml` so a single bad cached event can't blank the entire dashboard again. Surfaces "Calendar unavailable right now." instead of black-screening.

## Verified
Reproduced and fixed locally with a JSON round-trip simulation (`getUpcoming` returns events whose `.start` is a Date and whose `.start.getTime` works). Existing tests still pass.

## Test plan
- [ ] Reload `family.html`. The Wall renders fully, including the calendar tile with today's events.
- [ ] Reload the hub `index.html`. The hub Family Calendar widget continues to render the next 3 events.
- [ ] No `start.getTime is not a function` in the console.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_