### PR TITLE
Family Calendar: always route through proxy when configured (race fix)

### DIFF
--- a/js/family-calendar.js
+++ b/js/family-calendar.js
@@ -237,13 +237,17 @@ var FamilyCalendar = (function() {
   // ---- Fetch + cache ----
   // Most public iCal hosts (Google Calendar, iCloud, Outlook) don't
   // return CORS headers, so a direct browser fetch is blocked. When
-  // the Tailscale sync server is reachable we route through its
-  // /api/ical proxy (allowlisted, server-side fetch). Direct fetch is
-  // still attempted as a fallback for hosts that DO send CORS.
+  // a sync server URL is configured we route through its /api/ical
+  // proxy (allowlisted, server-side fetch). We do NOT gate on
+  // CloudSync.online — that flag is set asynchronously after a ping
+  // completes, and the first calendar refresh fires before the ping
+  // resolves, which used to cause a direct fetch and a CORS block.
+  // If the proxy is unreachable, fall back to direct (works for
+  // hosts that already send CORS, eg. self-hosted Nextcloud).
   function _fetchIcs(url) {
     var useProxy = (typeof CloudSync !== 'undefined') &&
                    CloudSync.isConfigured && CloudSync.isConfigured() &&
-                   CloudSync.online && CloudSync.server;
+                   CloudSync.server;
     var primary = useProxy
       ? CloudSync.server + '/api/ical?url=' + encodeURIComponent(url)
       : url;
@@ -255,8 +259,7 @@ var FamilyCalendar = (function() {
       })
       .catch(function(err) {
         if (!useProxy) throw err;
-        // Proxy unreachable — try direct as a last resort (works for
-        // hosts that already serve CORS).
+        // Proxy unreachable — try direct as a last resort.
         return fetch(url, { cache: 'no-store' }).then(function(res) {
           if (!res.ok) throw new Error('HTTP ' + res.status);
           return res.text();


### PR DESCRIPTION
## Symptom
Even after the iCal proxy was deployed on the VPS, the browser still hit `calendar.google.com` directly and CORS-blocked the response:

```
Cross-Origin Request Blocked: CORS header 'Access-Control-Allow-Origin' missing
  https://calendar.google.com/calendar/ical/.../basic.ics
```

The hub widget and Family Wall stayed empty.

## Cause
A race in `_fetchIcs`. We were gating "use the proxy" on `CloudSync.online`, which only flips to `true` after the async ping in `sync.js` completes. The first calendar refresh fires from `DOMContentLoaded` — before the ping resolves — so `useProxy` was `false`, the request went direct to Google, and CORS killed it.

## Fix
Drop the `CloudSync.online` check. As long as a sync server is configured (`CloudSync.server` is set), always try the proxy first. The existing fallback to direct fetch still kicks in if the proxy is unreachable (eg. browser not on Tailscale at all), so hosts that already serve CORS (self-hosted Nextcloud, etc.) keep working.

## Test plan
- [ ] Hard-refresh `index.html` and `family.html` after merge.
- [ ] DevTools → Network tab shows the request go to `real-options-dev.tail57521e.ts.net/api/ical?url=…` with `200 OK`, **not** to `calendar.google.com`.
- [ ] Hub widget shows the next 3 events; Family Wall calendar tile shows today's events.
- [ ] No CORS error in the console.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_