### PR TITLE
Family Wall: add a "This week" calendar card next to "Today"

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -114,9 +114,10 @@ body {
   .fw-card-routines { grid-column: span 3; }
   .fw-card-weather { grid-column: span 1; }
   .fw-card-calendar { grid-column: span 1; }
+  .fw-card-week { grid-column: span 1; }
   .fw-card-menu { grid-column: span 1; }
   .fw-card-shopping { grid-column: span 1; }
-  .fw-card-quick { grid-column: span 2; }
+  .fw-card-quick { grid-column: span 3; }
 }
 
 /* ---- Card ---- */
@@ -292,6 +293,35 @@ body {
 .fw-shop-row .fw-shop-cat {
   font-size: 0.7rem; font-weight: 800; text-transform: uppercase;
   color: var(--fw-muted); letter-spacing: 0.04em; min-width: 70px;
+}
+
+/* This-week card: stacked day buckets with sticky-ish day headers */
+.fw-week-day { padding: 6px 0; border-bottom: 1px solid var(--fw-border); }
+.fw-week-day:last-child { border-bottom: none; }
+.fw-week-day-head {
+  display: flex; align-items: baseline; justify-content: space-between;
+  padding: 6px 0 4px;
+}
+.fw-week-day-name {
+  font-family: var(--font-display, sans-serif);
+  font-weight: 800; font-size: 0.92rem;
+  text-transform: capitalize;
+}
+.fw-week-day-date {
+  font-size: 0.74rem;
+  color: var(--fw-muted);
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+.fw-week-empty {
+  font-size: 0.78rem; color: var(--fw-muted);
+  font-weight: 700;
+  padding: 4px 0;
+  font-style: italic;
+}
+.fw-week-more {
+  font-size: 0.74rem; color: var(--fw-muted);
+  font-weight: 700; padding: 4px 0 0;
 }
 .fw-shop-row .fw-summary { font-size: 0.88rem; }
 .fw-shop-more {

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -212,6 +212,7 @@ var FamilyWall = (function() {
         _renderWeatherCard() +
         _renderRoutinesCard(profiles) +
         _renderCalendarCard() +
+        _renderWeekCard() +
         _renderMenuCard() +
         _renderShoppingCard() +
         _renderQuickCard() +
@@ -220,7 +221,10 @@ var FamilyWall = (function() {
     // After paint, populate location modal cities and lazy-fetch calendar.
     _populateCityList();
     if (typeof FamilyCalendar !== 'undefined' && FamilyCalendar.refresh) {
-      FamilyCalendar.refresh(false).then(_paintCalendar).catch(function() {});
+      FamilyCalendar.refresh(false).then(function() {
+        _paintCalendar();
+        _paintWeek();
+      }).catch(function() {});
     }
   }
 
@@ -364,6 +368,97 @@ var FamilyWall = (function() {
     var card = document.getElementById('fw-calendar-card');
     if (!card) return;
     card.innerHTML = '<div class="fw-card-head"><span class="fw-card-icon">📅</span> Today</div>' + _calendarBodyHtml();
+  }
+
+  function _renderWeekCard() {
+    return '<div class="fw-card fw-card-week" id="fw-week-card">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">🗓</span> This week</div>' +
+      _weekBodyHtml() +
+    '</div>';
+  }
+
+  function _weekBodyHtml() {
+    if (typeof FamilyCalendar === 'undefined' || !FamilyCalendar.getUpcoming) {
+      return '<div class="fw-card-empty">Family Calendar not loaded.</div>';
+    }
+    var urls;
+    try { urls = FamilyCalendar.getUrls(); } catch (e) { urls = []; }
+    if (!urls.length) {
+      return '<div class="fw-card-empty">No calendars yet — add one in Parents Corner.</div>';
+    }
+
+    var today = new Date(); today.setHours(0, 0, 0, 0);
+    var endOfRange = new Date(today.getTime() + 7 * 86400000);
+    var events;
+    try {
+      events = FamilyCalendar.getUpcoming(200).filter(function(ev) {
+        return ev.start && typeof ev.start.getTime === 'function' &&
+               ev.start.getTime() >= today.getTime() &&
+               ev.start.getTime() < endOfRange.getTime();
+      });
+    } catch (e) {
+      return '<div class="fw-card-empty">Calendar unavailable right now.</div>';
+    }
+
+    // Bucket by YYYY-MM-DD so we can render 7 day groups in order.
+    var buckets = {};
+    events.forEach(function(ev) {
+      var d = new Date(ev.start);
+      d.setHours(0, 0, 0, 0);
+      var key = d.toDateString();
+      if (!buckets[key]) buckets[key] = [];
+      buckets[key].push(ev);
+    });
+
+    var html = '';
+    for (var i = 0; i < 7; i++) {
+      var d = new Date(today.getTime() + i * 86400000);
+      var key = d.toDateString();
+      var dayEvents = buckets[key] || [];
+      // Skip the first day (today) — already in the "Today" tile.
+      // Skip days with no events except tomorrow (so the kid has at
+      // least one anchor when nothing's happening this week).
+      if (i === 0) continue;
+      if (!dayEvents.length && i > 1) continue;
+
+      var dayLabel = i === 1 ? 'Tomorrow' :
+        d.toLocaleDateString(undefined, { weekday: 'long' });
+      var dateLabel = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+
+      html += '<div class="fw-week-day">' +
+        '<div class="fw-week-day-head">' +
+          '<span class="fw-week-day-name">' + _esc(dayLabel) + '</span>' +
+          '<span class="fw-week-day-date">' + _esc(dateLabel) + '</span>' +
+        '</div>';
+      if (!dayEvents.length) {
+        html += '<div class="fw-week-empty">No events.</div>';
+      } else {
+        dayEvents.slice(0, 4).forEach(function(ev) {
+          var when = ev.allDay ? 'All day'
+            : ev.start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+          html += '<div class="fw-event-row">' +
+            '<div class="fw-stripe" style="--stripe:' + _esc(ev.calColor || '#60A5FA') + '"></div>' +
+            '<div class="fw-when">' + _esc(when) + '</div>' +
+            '<div class="fw-summary">' + _esc(ev.summary) + '</div>' +
+          '</div>';
+        });
+        if (dayEvents.length > 4) {
+          html += '<div class="fw-week-more">+ ' + (dayEvents.length - 4) + ' more</div>';
+        }
+      }
+      html += '</div>';
+    }
+
+    if (!html) {
+      return '<div class="fw-card-empty">Nothing on the calendar for the next 7 days.</div>';
+    }
+    return html;
+  }
+
+  function _paintWeek() {
+    var card = document.getElementById('fw-week-card');
+    if (!card) return;
+    card.innerHTML = '<div class="fw-card-head"><span class="fw-card-icon">🗓</span> This week</div>' + _weekBodyHtml();
   }
 
   function _renderMenuCard() {


### PR DESCRIPTION
## Summary
Sits next to the "Today" tile on the Family Wall and fills out the week ahead with the next 6 days of family-calendar events grouped by day.

- Tomorrow always shows even when empty (so the tile doesn't look dead on slow weeks); other empty days are skipped.
- Up to 4 events per day with a `+N more` overflow line.
- Day headings: `Tomorrow`, `Wednesday`, `Thursday`… plus a `Apr 30` date stamp.
- Reuses the same event-row layout (color stripe + time + summary) from the "Today" tile.
- Same defensive try/catch as the calendar tile so a bad cached event surfaces "Calendar unavailable right now." instead of black-screening the wall.

At ≥1100px the row is now **Weather · Today · This week**, with Menu and Shopping wrapping below.

## Test plan
- [ ] Hard-refresh `family.html`. New "This week" card appears next to "Today".
- [ ] Tomorrow always shows; days with no events between Tue–Sat are collapsed; Sunday onwards skipped.
- [ ] Days with >4 events show first 4 plus a "+N more" line.
- [ ] Repaints after the 10-min iCal cache refresh resolves.
- [ ] Mobile (≤760px): card stacks below "Today" cleanly.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_