### PR TITLE
Family Wall · This week: cap height + show every event per day

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -296,11 +296,33 @@ body {
 }
 
 /* This-week card: stacked day buckets with sticky-ish day headers */
+.fw-card-week { max-height: 520px; }
+.fw-card-week .fw-card-head { flex-shrink: 0; }
+.fw-week-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+/* Subtle scrollbar so the scroll affordance is obvious without being loud */
+.fw-week-body::-webkit-scrollbar { width: 8px; }
+.fw-week-body::-webkit-scrollbar-track { background: transparent; }
+.fw-week-body::-webkit-scrollbar-thumb {
+  background: rgba(255,255,255,0.12);
+  border-radius: 4px;
+}
+.fw-week-body::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.22); }
+
 .fw-week-day { padding: 6px 0; border-bottom: 1px solid var(--fw-border); }
 .fw-week-day:last-child { border-bottom: none; }
 .fw-week-day-head {
   display: flex; align-items: baseline; justify-content: space-between;
   padding: 6px 0 4px;
+  position: sticky;
+  top: 0;
+  background: linear-gradient(to bottom, rgba(11,11,26,0.95), rgba(11,11,26,0.85));
+  backdrop-filter: blur(6px);
+  z-index: 1;
 }
 .fw-week-day-name {
   font-family: var(--font-display, sans-serif);
@@ -318,10 +340,6 @@ body {
   font-weight: 700;
   padding: 4px 0;
   font-style: italic;
-}
-.fw-week-more {
-  font-size: 0.74rem; color: var(--fw-muted);
-  font-weight: 700; padding: 4px 0 0;
 }
 .fw-shop-row .fw-summary { font-size: 0.88rem; }
 .fw-shop-more {

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -391,7 +391,7 @@ var FamilyWall = (function() {
     var endOfRange = new Date(today.getTime() + 7 * 86400000);
     var events;
     try {
-      events = FamilyCalendar.getUpcoming(200).filter(function(ev) {
+      events = FamilyCalendar.getUpcoming(500).filter(function(ev) {
         return ev.start && typeof ev.start.getTime === 'function' &&
                ev.start.getTime() >= today.getTime() &&
                ev.start.getTime() < endOfRange.getTime();
@@ -410,7 +410,7 @@ var FamilyWall = (function() {
       buckets[key].push(ev);
     });
 
-    var html = '';
+    var inner = '';
     for (var i = 0; i < 7; i++) {
       var d = new Date(today.getTime() + i * 86400000);
       var key = d.toDateString();
@@ -425,34 +425,31 @@ var FamilyWall = (function() {
         d.toLocaleDateString(undefined, { weekday: 'long' });
       var dateLabel = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 
-      html += '<div class="fw-week-day">' +
+      inner += '<div class="fw-week-day">' +
         '<div class="fw-week-day-head">' +
           '<span class="fw-week-day-name">' + _esc(dayLabel) + '</span>' +
           '<span class="fw-week-day-date">' + _esc(dateLabel) + '</span>' +
         '</div>';
       if (!dayEvents.length) {
-        html += '<div class="fw-week-empty">No events.</div>';
+        inner += '<div class="fw-week-empty">No events.</div>';
       } else {
-        dayEvents.slice(0, 4).forEach(function(ev) {
+        dayEvents.forEach(function(ev) {
           var when = ev.allDay ? 'All day'
             : ev.start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-          html += '<div class="fw-event-row">' +
+          inner += '<div class="fw-event-row">' +
             '<div class="fw-stripe" style="--stripe:' + _esc(ev.calColor || '#60A5FA') + '"></div>' +
             '<div class="fw-when">' + _esc(when) + '</div>' +
             '<div class="fw-summary">' + _esc(ev.summary) + '</div>' +
           '</div>';
         });
-        if (dayEvents.length > 4) {
-          html += '<div class="fw-week-more">+ ' + (dayEvents.length - 4) + ' more</div>';
-        }
       }
-      html += '</div>';
+      inner += '</div>';
     }
 
-    if (!html) {
+    if (!inner) {
       return '<div class="fw-card-empty">Nothing on the calendar for the next 7 days.</div>';
     }
-    return html;
+    return '<div class="fw-week-body">' + inner + '</div>';
   }
 
   function _paintWeek() {


### PR DESCRIPTION
## Summary
Two fixes from real-world use of the new "This week" tile:

1. **Fixed height + internal scroll.** The card grew tall enough to push the rest of the wall off-screen on a busy week. Cap it at `520px` and wrap the day buckets in a scrollable `.fw-week-body`. Day headers stay pinned with `position: sticky` so you always know which day you're scrolling through.
2. **Show every event.** The `+N more` overflow was hiding events the user actually wanted to see. Dropped the `dayEvents.slice(0, 4)` cap and the `+N` line — every event renders now, scrolling fits the rest.

## Test plan
- [ ] Hard-refresh `family.html`. The "This week" card no longer dominates the layout.
- [ ] On a busy day, all events render — no `+N more` truncation. Scroll works inside the card.
- [ ] Day headers ("Tomorrow", "Thursday"…) stay visible at the top of the card while you scroll.
- [ ] Mobile: card still stacks below "Today" cleanly with the same max-height.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_