### PR TITLE
Family Wall: tighter weekly view + time-of-day routines

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -262,6 +262,13 @@ body {
   border-color: var(--fw-green);
   color: #073b27;
 }
+.fw-r-empty {
+  font-size: 0.78rem;
+  color: var(--fw-muted);
+  font-weight: 700;
+  font-style: italic;
+  padding: 4px 0;
+}
 
 /* ---- Calendar / Menu / Shopping rows ---- */
 .fw-event-row, .fw-menu-row, .fw-shop-row {
@@ -296,7 +303,7 @@ body {
 }
 
 /* This-week card: stacked day buckets with sticky-ish day headers */
-.fw-card-week { max-height: 520px; }
+.fw-card-week { max-height: 320px; }
 .fw-card-week .fw-card-head { flex-shrink: 0; }
 .fw-week-body {
   flex: 1 1 auto;
@@ -313,28 +320,37 @@ body {
 }
 .fw-week-body::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.22); }
 
-.fw-week-day { padding: 6px 0; border-bottom: 1px solid var(--fw-border); }
+/* Compact two-column day row: label on the left, events on the right */
+.fw-week-day {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 10px;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--fw-border);
+  align-items: start;
+}
 .fw-week-day:last-child { border-bottom: none; }
 .fw-week-day-head {
-  display: flex; align-items: baseline; justify-content: space-between;
-  padding: 6px 0 4px;
-  position: sticky;
-  top: 0;
-  background: linear-gradient(to bottom, rgba(11,11,26,0.95), rgba(11,11,26,0.85));
-  backdrop-filter: blur(6px);
-  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 4px 0 0;
 }
 .fw-week-day-name {
   font-family: var(--font-display, sans-serif);
-  font-weight: 800; font-size: 0.92rem;
+  font-weight: 800; font-size: 0.9rem;
   text-transform: capitalize;
+  line-height: 1.1;
 }
 .fw-week-day-date {
-  font-size: 0.74rem;
+  font-size: 0.7rem;
   color: var(--fw-muted);
   font-weight: 800;
   letter-spacing: 0.04em;
+  margin-top: 1px;
 }
+.fw-week-events { display: flex; flex-direction: column; gap: 0; }
+.fw-week-events .fw-event-row { padding: 3px 0; border-bottom: none; }
 .fw-week-empty {
   font-size: 0.78rem; color: var(--fw-muted);
   font-weight: 700;

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -285,19 +285,20 @@ var FamilyWall = (function() {
         '<div class="fw-card-empty">Add a profile to start tracking routines.</div>' +
       '</div>';
     }
+    // Show only the routine that matches the current time of day:
+    //  - before 14:00  → morning
+    //  - 14:00 onwards → evening
+    var hour = new Date().getHours();
+    var which = hour < 14 ? 'morning' : 'evening';
+    var sectionLabel = which === 'morning' ? '🌅 Morning' : '🌙 Night';
+
     var rows = profiles.map(function(p) {
       var status = Routines.getStatusFor(p.name);
       if (!status) return '';
-      var morningChips = status.morning.items.map(function(it) {
+      var bucket = status[which];
+      var chips = bucket.items.map(function(it) {
         return '<button class="fw-r-task ' + (it.done ? 'done' : '') + '" ' +
-                 'onclick="FamilyWall.toggleRoutine(\'' + _escAttr(p.name) + '\', \'morning\', \'' + _escAttr(it.id) + '\')">' +
-          '<span class="fw-r-check">' + (it.done ? '✓' : '') + '</span>' +
-          _esc(it.label) +
-        '</button>';
-      }).join('');
-      var eveningChips = status.evening.items.map(function(it) {
-        return '<button class="fw-r-task ' + (it.done ? 'done' : '') + '" ' +
-                 'onclick="FamilyWall.toggleRoutine(\'' + _escAttr(p.name) + '\', \'evening\', \'' + _escAttr(it.id) + '\')">' +
+                 'onclick="FamilyWall.toggleRoutine(\'' + _escAttr(p.name) + '\', \'' + which + '\', \'' + _escAttr(it.id) + '\')">' +
           '<span class="fw-r-check">' + (it.done ? '✓' : '') + '</span>' +
           _esc(it.label) +
         '</button>';
@@ -310,13 +311,14 @@ var FamilyWall = (function() {
           '</div>' +
         '</div>' +
         '<div class="fw-r-tasks">' +
-          (morningChips ? '<div class="fw-r-section"><span class="fw-r-section-label">🌅 AM</span>' + morningChips + '</div>' : '') +
-          (eveningChips ? '<div class="fw-r-section"><span class="fw-r-section-label">🌙 PM</span>' + eveningChips + '</div>' : '') +
+          (chips
+            ? '<div class="fw-r-section"><span class="fw-r-section-label">' + sectionLabel + '</span>' + chips + '</div>'
+            : '<div class="fw-r-empty">No ' + which + ' tasks set.</div>') +
         '</div>';
     }).join('');
 
     return '<div class="fw-card fw-card-routines">' +
-      '<div class="fw-card-head"><span class="fw-card-icon">📋</span> Routines · today</div>' +
+      '<div class="fw-card-head"><span class="fw-card-icon">📋</span> Routines · ' + sectionLabel + '</div>' +
       '<div class="fw-routines">' +
         '<div class="fw-routines-head"><div>Kid</div><div>Tasks</div></div>' +
         rows +
@@ -425,25 +427,28 @@ var FamilyWall = (function() {
         d.toLocaleDateString(undefined, { weekday: 'long' });
       var dateLabel = d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 
-      inner += '<div class="fw-week-day">' +
-        '<div class="fw-week-day-head">' +
-          '<span class="fw-week-day-name">' + _esc(dayLabel) + '</span>' +
-          '<span class="fw-week-day-date">' + _esc(dateLabel) + '</span>' +
-        '</div>';
+      var eventsHtml = '';
       if (!dayEvents.length) {
-        inner += '<div class="fw-week-empty">No events.</div>';
+        eventsHtml = '<div class="fw-week-empty">No events.</div>';
       } else {
         dayEvents.forEach(function(ev) {
           var when = ev.allDay ? 'All day'
             : ev.start.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-          inner += '<div class="fw-event-row">' +
+          eventsHtml += '<div class="fw-event-row">' +
             '<div class="fw-stripe" style="--stripe:' + _esc(ev.calColor || '#60A5FA') + '"></div>' +
             '<div class="fw-when">' + _esc(when) + '</div>' +
             '<div class="fw-summary">' + _esc(ev.summary) + '</div>' +
           '</div>';
         });
       }
-      inner += '</div>';
+
+      inner += '<div class="fw-week-day">' +
+        '<div class="fw-week-day-head">' +
+          '<span class="fw-week-day-name">' + _esc(dayLabel) + '</span>' +
+          '<span class="fw-week-day-date">' + _esc(dateLabel) + '</span>' +
+        '</div>' +
+        '<div class="fw-week-events">' + eventsHtml + '</div>' +
+      '</div>';
     }
 
     if (!inner) {


### PR DESCRIPTION
## Summary
Three small UX adjustments from feedback on the Family Wall:

1. **"This week" card max-height** drops from `520px` → `320px` so it stops stealing real estate from the rest of the wall.
2. **Day rows are compact two-column grids**: 80px label (day name + date stacked vertically) on the left, event rows on the right. The previous design had a full banner row above each day's events; this saves a row per day.
3. **Routines card shows only the relevant half**: before 14:00 only morning tasks appear; from 14:00 onwards only evening. Card head reflects the active half ("Routines · Morning" / "Routines · Night"). Empty state for kids with no tasks set.

## Test plan
- [ ] Hard-refresh `family.html`. The "This week" card is noticeably smaller and scrolls when full.
- [ ] Each day shows day-name+date in a left column, events in a right column.
- [ ] Open the wall in the morning → only AM chips render. After ~14:00 → only PM chips. Card title updates accordingly.
- [ ] Toggling a chip still persists per-kid.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_