### PR TITLE
Family Wall: city search + cross-device home location sync

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -414,6 +414,60 @@ body {
   font-weight: 800; font-size: 0.78rem;
   margin: 14px 0 8px;
 }
+.fw-loc-search {
+  display: flex; gap: 8px; margin-bottom: 8px;
+}
+.fw-loc-search input {
+  flex: 1; min-width: 0;
+  padding: 10px 12px;
+  background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 10px;
+  color: var(--fw-text);
+  font-family: var(--font-body, sans-serif);
+  font-size: 0.9rem;
+}
+.fw-loc-search input:focus {
+  outline: none;
+  border-color: var(--fw-accent);
+}
+.fw-loc-search .fw-btn { width: auto; padding: 10px 14px; }
+
+.fw-loc-results {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 12px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+.fw-loc-result {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px;
+  background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 10px;
+  cursor: pointer;
+  text-align: left;
+  color: var(--fw-text);
+  font-family: inherit;
+  transition: border-color 0.15s, background 0.15s;
+}
+.fw-loc-result:hover {
+  border-color: var(--fw-accent);
+  background: rgba(167,139,250,0.10);
+}
+.fw-loc-result-label { font-weight: 700; font-size: 0.9rem; }
+.fw-loc-result-coords {
+  font-size: 0.72rem; color: var(--fw-muted); font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.fw-loc-empty {
+  padding: 8px 4px;
+  font-size: 0.82rem;
+  color: var(--fw-muted);
+  font-weight: 700;
+  font-style: italic;
+}
+
 .fw-loc-cities {
   display: grid; grid-template-columns: 1fr 1fr; gap: 8px;
   margin-bottom: 16px;

--- a/family.html
+++ b/family.html
@@ -25,10 +25,20 @@
   <div id="fw-loc-modal" class="fw-modal" onclick="if(event.target===this)FamilyWall.closeLocationModal()">
     <div class="fw-modal-card">
       <h2>Set Home Location 📍</h2>
-      <p>Used for the weather card. Stored on this device only.</p>
+      <p>Used for the weather card. Synced across all family devices.</p>
       <button class="fw-btn fw-btn-primary" onclick="FamilyWall.requestGeo()">📍 Use my current location</button>
-      <div class="fw-or">or pick a city</div>
+
+      <div class="fw-or">or search for a city</div>
+      <div class="fw-loc-search">
+        <input type="text" id="fw-loc-query" placeholder="e.g. Antofagasta, Madrid, Buenos Aires"
+               onkeydown="if(event.key==='Enter'){event.preventDefault();FamilyWall.runLocationSearch();}" />
+        <button class="fw-btn fw-btn-ghost" onclick="FamilyWall.runLocationSearch()">Search</button>
+      </div>
+      <div id="fw-loc-results" class="fw-loc-results"></div>
+
+      <div class="fw-or">or pick a preset</div>
       <div id="fw-loc-cities" class="fw-loc-cities"></div>
+
       <div class="fw-modal-btns">
         <button class="fw-btn fw-btn-ghost" onclick="FamilyWall.closeLocationModal()">Cancel</button>
       </div>

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -79,12 +79,42 @@ var FamilyWall = (function() {
 
   function setLocation(loc) {
     if (!loc || typeof loc.lat !== 'number' || typeof loc.lon !== 'number') return;
-    localStorage.setItem(LOCATION_KEY, JSON.stringify({
+    var record = {
       lat: loc.lat, lon: loc.lon, label: loc.label || 'Home', ts: Date.now()
-    }));
+    };
+    localStorage.setItem(LOCATION_KEY, JSON.stringify(record));
+    // Mirror to the household bucket so other family devices pick it up.
+    if (typeof CloudSync !== 'undefined' && CloudSync.push) CloudSync.push(LOCATION_KEY);
     // Force a fresh weather fetch
     localStorage.removeItem(WEATHER_KEY);
     fetchWeather().then(_paint).catch(_paint);
+  }
+
+  // Open-Meteo geocoding — no API key, CORS-friendly. Pass a place
+  // name like "Antofagasta" or "Punta Arenas, Chile" and we get
+  // back lat/lon plus the formatted name (city, region, country).
+  function searchPlaces(query) {
+    var q = String(query || '').trim();
+    if (!q) return Promise.resolve([]);
+    var url = 'https://geocoding-api.open-meteo.com/v1/search' +
+              '?name=' + encodeURIComponent(q) +
+              '&count=6&language=en&format=json';
+    return fetch(url, { cache: 'no-store' })
+      .then(function(res) { return res.ok ? res.json() : { results: [] }; })
+      .then(function(payload) {
+        var results = (payload && payload.results) || [];
+        return results.map(function(r) {
+          var parts = [r.name];
+          if (r.admin1 && r.admin1 !== r.name) parts.push(r.admin1);
+          if (r.country) parts.push(r.country);
+          return {
+            label: parts.join(', '),
+            lat: Math.round(r.latitude * 100) / 100,
+            lon: Math.round(r.longitude * 100) / 100
+          };
+        });
+      })
+      .catch(function() { return []; });
   }
 
   // ---- Weather (Open-Meteo, free, no key) ----
@@ -573,6 +603,31 @@ var FamilyWall = (function() {
     _paint();
   }
 
+  function runLocationSearch() {
+    var input = document.getElementById('fw-loc-query');
+    var resultsEl = document.getElementById('fw-loc-results');
+    if (!input || !resultsEl) return;
+    var q = input.value.trim();
+    if (!q) {
+      resultsEl.innerHTML = '';
+      return;
+    }
+    resultsEl.innerHTML = '<div class="fw-loc-empty">Searching…</div>';
+    searchPlaces(q).then(function(results) {
+      if (!results.length) {
+        resultsEl.innerHTML = '<div class="fw-loc-empty">No matches. Try a nearby town or different spelling.</div>';
+        return;
+      }
+      resultsEl.innerHTML = results.map(function(r) {
+        return '<button class="fw-loc-result" onclick="FamilyWall._pickCity(' +
+          r.lat + ',' + r.lon + ',\'' + _escAttr(r.label) + '\')">' +
+          '<span class="fw-loc-result-label">' + _esc(r.label) + '</span>' +
+          '<span class="fw-loc-result-coords">' + r.lat.toFixed(2) + ', ' + r.lon.toFixed(2) + '</span>' +
+        '</button>';
+      }).join('');
+    });
+  }
+
   function requestGeo() {
     if (!navigator.geolocation) {
       alert('Geolocation is not supported by this browser. Pick a city instead.');
@@ -604,6 +659,16 @@ var FamilyWall = (function() {
     _paint();
   }
 
+  // Repaint when another device pushes a household update (eg. shared
+  // home location changed on the iPad while we're looking at the laptop).
+  if (typeof window !== 'undefined') {
+    window.addEventListener('zs:household-synced', function() {
+      // Wipe the local weather cache so the new location's forecast loads.
+      try { localStorage.removeItem(WEATHER_KEY); } catch (e) {}
+      _paint();
+    });
+  }
+
   return {
     paint: _paint,
     loginAs: loginAs,
@@ -613,6 +678,8 @@ var FamilyWall = (function() {
     requestGeo: requestGeo,
     setLocation: setLocation,
     getLocation: getLocation,
+    searchPlaces: searchPlaces,
+    runLocationSearch: runLocationSearch,
     _pickCity: _pickCity
   };
 })();

--- a/js/sync.js
+++ b/js/sync.js
@@ -39,7 +39,8 @@ var CloudSync = (function() {
     'zs_shopping_list':         'shopping',
     'zs_menu':                  'menu',
     'zs_fcal_urls':             'fcal_urls',
-    'zs_sports_matches_shared': 'sports_matches'
+    'zs_sports_matches_shared': 'sports_matches',
+    'zs_home_location':         'home_location'
   };
   var HOUSEHOLD_KID = '_household';
 


### PR DESCRIPTION
## Summary
Two requests rolled into one PR:

1. **City search.** The home location picker now has a "Search for a city" box that hits the Open-Meteo geocoding API (no key, CORS-friendly) and shows up to 6 results — Antofagasta, Madrid, Buenos Aires, your nearest beach town, whatever. Tap a result to set it as home.
2. **Cross-device sync.** `zs_home_location` is now a household-shared key in `HOUSEHOLD_KEYS`, so the iPad on the fridge, the parent laptop, and the kids' tablets all show the same weather. Also re-paints in place when another device pushes a new location via the existing `zs:household-synced` event.

The original **Use my current location** button and city presets (Santiago / Viña / Concepción / La Serena / Punta Arenas / Miami) remain as quick-pick fallbacks above the search.

## Test plan
- [ ] Open Family Wall → tap "Change location". Search "Iquique" → result appears → tap → weather card updates.
- [ ] Open Family Wall on a second family device → after the next sync ping (or hard-refresh) the same Iquique forecast is showing.
- [ ] Geolocation button still works.
- [ ] City presets still work.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_