### PR TITLE
Bust JS + SW caches so city search button works

### DIFF
--- a/family.html
+++ b/family.html
@@ -45,16 +45,16 @@
     </div>
   </div>
 
-  <script src="js/auth.js"></script>
-  <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
-  <script src="js/timer.js"></script>
-  <script src="js/activity-log.js"></script>
-  <script src="js/chilean-calendar.js"></script>
-  <script src="js/routines.js"></script>
-  <script src="js/family-calendar.js"></script>
-  <script src="js/family-wall.js"></script>
-  <script src="js/pwa.js"></script>
+  <script src="js/auth.js?v=2"></script>
+  <script src="js/a11y.js?v=2"></script>
+  <script src="js/sync.js?v=3"></script>
+  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/timer.js?v=2"></script>
+  <script src="js/activity-log.js?v=2"></script>
+  <script src="js/chilean-calendar.js?v=2"></script>
+  <script src="js/routines.js?v=2"></script>
+  <script src="js/family-calendar.js?v=3"></script>
+  <script src="js/family-wall.js?v=3"></script>
+  <script src="js/pwa.js?v=2"></script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v1';
+const CACHE_VERSION = 'zs-suite-v2';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Symptom
After merging #227, the city search field appeared on the Family Wall location modal but the Search button did nothing when clicked.

## Cause
HTML loads network-first via the service worker, so `family.html` immediately reflected the new modal markup. JS files load with stale-while-revalidate, so the browser served the **previous** cached `js/family-wall.js` — which didn't expose `runLocationSearch` yet. `FamilyWall.runLocationSearch()` from the inline `onclick` was therefore `undefined`, click did nothing visible.

## Fix
- `family.html` script tags get a `?v=N` bump (v=3 on the actively-changing `family-wall`, `family-calendar`, `sync`; v=2 on the rest) so every browser fetches fresh copies.
- `sw.js` `CACHE_VERSION` bumped from `zs-suite-v1` → `zs-suite-v2`, which evicts every old cached asset on the next service-worker activate.

## Test plan
- [ ] Hard-refresh `family.html`. The "Change location" modal opens, type a city → click Search → results appear.
- [ ] DevTools → Application → Service Workers → version updates to `zs-suite-v2`. Old caches deleted.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_