### PR TITLE
Cross-device profile deletion with household-synced tombstones

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=2"></script>
+  <script src="js/sync.js?v=3"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>
@@ -423,6 +423,6 @@
   <script src="js/routines.js?v=1"></script>
   <script src="js/family-calendar.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
-  <script src="js/index.js?v=2"></script>
+  <script src="js/index.js?v=3"></script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1708,11 +1708,33 @@
     if (!confirm('Delete ' + name + '?')) return;
     profiles.splice(editingIndex, 1);
     saveProfiles(profiles);
-    // Push the deletion to the server. syncProfiles() does an additive
-    // merge that would otherwise resurrect this profile on next sync.
+
+    // Write a household-synced tombstone so other devices know not to
+    // resurrect this profile from their local copy. zs_deleted_profiles
+    // is in HOUSEHOLD_KEYS, so CloudSync.push mirrors it to the VPS.
+    try {
+      var key = 'zs_deleted_profiles';
+      var existing = [];
+      try { existing = JSON.parse(localStorage.getItem(key) || '[]'); } catch (e) {}
+      if (!Array.isArray(existing)) existing = [];
+      // Drop any older tombstone for the same name, then add a fresh one.
+      var lname = name.toLowerCase();
+      existing = existing.filter(function(t) {
+        return !t || !t.name || t.name.toLowerCase() !== lname;
+      });
+      existing.push({ name: name, ts: Date.now() });
+      localStorage.setItem(key, JSON.stringify(existing));
+      if (typeof CloudSync !== 'undefined' && CloudSync.push) CloudSync.push(key);
+    } catch (e) {
+      if (typeof Debug !== 'undefined') Debug.error('[Profile] tombstone failed', e.message);
+    }
+
+    // Push the shorter profile list to the server so even devices that
+    // sync before they see the tombstone get a clean state.
     if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
       try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
     }
+
     closeEditModal();
     switchUser();
   }

--- a/js/sync.js
+++ b/js/sync.js
@@ -40,7 +40,8 @@ var CloudSync = (function() {
     'zs_menu':                  'menu',
     'zs_fcal_urls':             'fcal_urls',
     'zs_sports_matches_shared': 'sports_matches',
-    'zs_home_location':         'home_location'
+    'zs_home_location':         'home_location',
+    'zs_deleted_profiles':      'deleted_profiles'
   };
   var HOUSEHOLD_KID = '_household';
 
@@ -346,6 +347,20 @@ var CloudSync = (function() {
       .then(function(serverProfiles) {
         var localProfiles = (typeof getProfiles === 'function') ? getProfiles() : [];
         var profileMap = {};
+        // Read tombstones (zs_deleted_profiles) so a profile that was
+        // deleted on any device stays gone on this one. Tombstones are
+        // synced as part of HOUSEHOLD_KEYS so they reach every device.
+        var tombstones = {};
+        try {
+          var rawTomb = localStorage.getItem('zs_deleted_profiles');
+          var tombArr = rawTomb ? JSON.parse(rawTomb) : [];
+          if (Array.isArray(tombArr)) {
+            tombArr.forEach(function(t) {
+              if (t && t.name) tombstones[t.name.toLowerCase()] = Number(t.ts) || 0;
+            });
+          }
+        } catch (e) {}
+
         var merged = [].concat(serverProfiles || [], localProfiles);
         var finalProfiles = [];
         var nameToIdx = {};
@@ -354,6 +369,11 @@ var CloudSync = (function() {
           var p = merged[i];
           if (!p || !p.name) continue;
           var key = p.name.toLowerCase();
+          // Skip tombstoned names unless the profile was created after
+          // the deletion (createdAt > tombstone ts) — that lets you
+          // legitimately recreate a profile with the same name later.
+          if (tombstones[key] && (!p.createdAt || p.createdAt < tombstones[key])) continue;
+
           if (nameToIdx.hasOwnProperty(key)) {
             var existing = finalProfiles[nameToIdx[key]];
             if (p.age > existing.age) {
@@ -476,28 +496,29 @@ var CloudSync = (function() {
           var path = window.location.pathname;
           var isHub = path.indexOf('index.html') !== -1 || path === '/' || (path.length > 0 && path[path.length - 1] === '/');
 
-          // Always pull the household-shared bucket so shopping list,
-          // weekly menu, calendar URLs, and shared sports matches mirror
-          // across devices regardless of which page just loaded.
+          // Pull household-shared state first (shopping list, menu,
+          // calendar URLs, sports matches, home location, *and the
+          // profile-deletion tombstones*) before profile sync, so the
+          // syncProfiles merge can honor the latest tombstones.
           state.pullHousehold().then(function() {
             try { window.dispatchEvent(new CustomEvent('zs:household-synced')); } catch (e) {}
-          });
 
-          if (isHub) {
-            state.syncProfiles()
-              .then(function() {
-                var loginScr = document.getElementById('login-screen');
-                if (typeof renderLogin === 'function' && loginScr && loginScr.style.display !== 'none') {
-                  renderLogin();
-                }
-              });
-          } else {
-            var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
-            if (user) {
-              var kidKey = user.name.toLowerCase().replace(/\s+/g, '_');
-              state.pullAll(kidKey);
+            if (isHub) {
+              state.syncProfiles()
+                .then(function() {
+                  var loginScr = document.getElementById('login-screen');
+                  if (typeof renderLogin === 'function' && loginScr && loginScr.style.display !== 'none') {
+                    renderLogin();
+                  }
+                });
+            } else {
+              var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
+              if (user) {
+                var kidKey = user.name.toLowerCase().replace(/\s+/g, '_');
+                state.pullAll(kidKey);
+              }
             }
-          }
+          });
         } else {
           state.online = false;
           _updatePill('offline');

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v2';
+const CACHE_VERSION = 'zs-suite-v3';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Symptom
Deleting a profile on Device A persisted there but reappeared on Device B.

## Cause
The earlier fix (`CloudSync.overwriteProfiles` after the local splice) only kept **Device A** in shape. Device B never saw a tombstone, so `syncProfiles` merged its still-local copy of the profile with whatever the server had and pushed it back, resurrecting the deletion globally on the next sync.

## Fix — household-synced tombstones
- **`HOUSEHOLD_KEYS`** gains `zs_deleted_profiles` → `deleted_profiles`, so the tombstone list is shared across every device the same way shopping list and calendar URLs are.
- **`deleteEditingProfile`** writes a `{name, ts}` tombstone and pushes it via `CloudSync.push` so other devices pick it up on their next sync.
- **`syncProfiles`** reads the tombstone list before merging and skips any profile whose lowercase name is tombstoned, *unless* the profile has a `createdAt` later than the tombstone ts (so a parent can legitimately recreate a profile with the same name later).
- **`pullHousehold`** now runs *before* `syncProfiles` so the latest tombstones are on disk when the merge happens.
- Cache busted on `sw.js` (v3), `index.html` (`index.js?v=3`, `sync.js?v=3`) so every device picks up the change without manual cache clearing.

## Local merge logic verified
| Case | Result |
| --- | --- |
| Tombstone for "Mateo" present, both server + local have him | `Ana` only |
| Tombstone present, but local has a newer Mateo (`createdAt > tombstone.ts`) | `Ana` + new `Mateo` |
| No tombstones | both profiles kept |

## Test plan
- [ ] Hard-refresh both devices.
- [ ] On Device A: ✏️ on a profile → Delete → confirm. Profile gone immediately.
- [ ] On Device B: hard-refresh (or wait for the next ping). The deleted profile is gone there too.
- [ ] On Device A: re-add a profile with the same name → reload Device B → it appears.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_