### PR TITLE
sync: parse server _syncedAt as ISO string (fixes calendar / shopping / menu cross-device sync)

### DIFF
--- a/family.html
+++ b/family.html
@@ -47,13 +47,13 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=3"></script>
+  <script src="js/sync.js?v=4"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/chilean-calendar.js?v=2"></script>
   <script src="js/routines.js?v=2"></script>
-  <script src="js/family-calendar.js?v=3"></script>
+  <script src="js/family-calendar.js?v=4"></script>
   <script src="js/family-wall.js?v=3"></script>
   <script src="js/pwa.js?v=2"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=3"></script>
+  <script src="js/sync.js?v=4"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/js/family-calendar.js
+++ b/js/family-calendar.js
@@ -438,6 +438,19 @@ var FamilyCalendar = (function() {
     renderHubWidget('family-calendar-widget');
   }
 
+  // When another device pushes new calendar URLs (handled by sync.js
+  // pullHousehold → fires `zs:household-synced`), re-render the hub
+  // widget. This also force-fetches any newly-pulled URLs that have
+  // no local cache entry yet.
+  if (typeof window !== 'undefined') {
+    window.addEventListener('zs:household-synced', function() {
+      renderHubWidget('family-calendar-widget');
+      // Also re-render any open editor so the row list updates.
+      var holder = document.querySelector('[data-fcal-editor]');
+      if (holder) { try { renderEditor(holder.id); } catch (e) {} }
+    });
+  }
+
   return {
     getUrls: getUrls,
     addUrl: addUrl,

--- a/js/sync.js
+++ b/js/sync.js
@@ -101,6 +101,18 @@ var CloudSync = (function() {
     return merged.sort(function(a, b) { return b.ts - a.ts; }).slice(0, 100);
   }
 
+  // Parse _syncedAt regardless of whether the producer wrote a number
+  // (client) or an ISO string (server.js stamps `new Date().toISOString()`
+  // on every PUT). Without this, Number(isoString) → NaN → 0, and the
+  // pull comparison `sTime > lTime` was always 0 > 0 = false. The
+  // server-stored copy was only ever written to a fresh device.
+  function _parseTs(v) {
+    if (!v) return 0;
+    if (typeof v === 'number') return v;
+    var n = new Date(v).getTime();
+    return isNaN(n) ? 0 : n;
+  }
+
   state.push = function(key) {
     if (!state.isConfigured() || !state.online) return Promise.resolve();
     var info = _getAppInfo(key);
@@ -194,8 +206,8 @@ var CloudSync = (function() {
           localData = rawLocal ? JSON.parse(rawLocal) : {};
         } catch(e) {}
         
-        var sTime = Number(serverData._syncedAt) || 0;
-        var lTime = Number(localData._syncedAt) || 0;
+        var sTime = _parseTs(serverData._syncedAt);
+        var lTime = _parseTs(localData._syncedAt);
         var localMissing = !localStorage.getItem(key);
 
         if (sTime > lTime || localMissing || info.appName === 'activity') {
@@ -255,8 +267,8 @@ var CloudSync = (function() {
               localData = rawLocal ? JSON.parse(rawLocal) : {};
             } catch(e) {}
             
-            var sTime = Number(serverData._syncedAt) || 0;
-            var lTime = Number(localData._syncedAt) || 0;
+            var sTime = _parseTs(serverData._syncedAt);
+            var lTime = _parseTs(localData._syncedAt);
             var localMissing = !localStorage.getItem(key);
 
             if (sTime > lTime || localMissing || appName === 'activity') {
@@ -296,8 +308,8 @@ var CloudSync = (function() {
             var rawRecital = localStorage.getItem(rKey);
             lData = rawRecital ? JSON.parse(rawRecital) : {};
           } catch(e) {}
-          var sTimeR = Number(sData._syncedAt) || 0;
-          var lTimeR = Number(lData._syncedAt) || 0;
+          var sTimeR = _parseTs(sData._syncedAt);
+          var lTimeR = _parseTs(lData._syncedAt);
           if (sTimeR > lTimeR || !localStorage.getItem(rKey)) {
             try {
               localStorage.setItem(rKey, JSON.stringify(sData));

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v3';
+const CACHE_VERSION = 'zs-suite-v4';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Symptom
Calendar URLs added on Device A weren't appearing on Device B's Family Wall after sync. Same root cause silently broke shopping list, weekly menu, sports matches, home location, and profile-deletion tombstones — anything that relied on household-synced state surviving on a device that already had any local copy.

## Cause
- Client push writes `_syncedAt` as a **number** (`Date.now()`).
- Server PUT handler overwrites that with `new Date().toISOString()` before persisting.
- Client pull then did `Number(serverData._syncedAt) || 0`. `Number("2026-04-28T…")` → NaN → 0. So `sTime` was always `0`.
- The pull comparison `if (sTime > lTime || localMissing)` only fired on the very first ever pull (when the local key was missing). Once **any** local copy existed, every subsequent server update was ignored.

That's why a calendar URL added on Device A appeared instantly on a brand-new Device B (no local copy → `localMissing` path took over) but wouldn't propagate to a Device B that had ever opened the app before — its empty local list won the comparison forever.

## Fix
- New **`_parseTs(v)`** helper that handles numbers and ISO strings. All 6 callsites switched over.
- **`FamilyCalendar`** listens for `zs:household-synced` (fired by `pullHousehold`) and re-renders the hub widget + Parents Corner editor, so newly-pulled URLs surface immediately without a manual reload. Family Wall already had the matching listener.
- Cache busted: `sw.js` → `v4`, `sync.js?v=4` on hub + family page, `family-calendar.js?v=4` on family page. Devices will pick up the new code automatically.

## Test plan
- [ ] Hard-refresh both devices.
- [ ] On Device A: add a calendar URL in Parents Corner. Hub widget shows events.
- [ ] On Device B (which already had local data, the previously broken case): hard-refresh once → events from Device A's URL now appear on the hub and the Family Wall calendar tile.
- [ ] On Device A: add a shopping item / edit a menu cell / delete a profile → Device B picks it up on its next sync ping (no longer needs to be a clean install).

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_