### PR TITLE
diag follow-up: folk quiz bank, BMC cache bust, push-error key

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -193,15 +193,15 @@
     </div>
   </div>
 
-  <script src="js/nav.js"></script>
-  <script src="js/auth.js"></script>
-  <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
-  <script src="js/sounds.js"></script>
-  <script src="js/activity-log.js"></script>
-  <script src="js/book-movie-check.js"></script>
-  <script src="js/pwa.js"></script>
+  <script src="js/nav.js?v=2"></script>
+  <script src="js/auth.js?v=2"></script>
+  <script src="js/a11y.js?v=2"></script>
+  <script src="js/sync.js?v=4"></script>
+  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/sounds.js?v=2"></script>
+  <script src="js/activity-log.js?v=2"></script>
+  <script src="js/book-movie-check.js?v=2"></script>
+  <script src="js/pwa.js?v=2"></script>
 
 </body>
 </html>

--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -445,6 +445,18 @@ const QB={
     {q:'¿Qué instrumento se usa para medir los sismos cerca de un volcán?',a:'Sismógrafo',o:['Sismógrafo','Termómetro','Telescopio','Barómetro'], tier:'advanced'},
     {q:'¿Qué volcán hizo erupción en 2015 en la Región de Los Lagos?',a:'Calbuco',o:['Calbuco','Villarrica','Osorno','Llaima'], tier:'expert'}
   ],
+  folk:[
+    {q:'¿Quién compuso "Gracias a la vida"?',a:'Violeta Parra',o:['Violeta Parra','Mercedes Sosa','Patricio Manns','Víctor Jara'], tier:'beginner'},
+    {q:'¿Cuál es el baile nacional de Chile?',a:'La Cueca',o:['La Cueca','El Tango','La Cumbia','El Vals'], tier:'beginner'},
+    {q:'¿En qué año fue declarada la cueca baile nacional?',a:'1979',o:['1979','1810','1950','2000'], tier:'expert'},
+    {q:'¿Qué pañuelo agitan los bailarines de cueca?',a:'Un pañuelo blanco',o:['Un pañuelo blanco','Una bandera','Un sombrero','Una flor'], tier:'beginner'},
+    {q:'¿Quién escribió "Si vas para Chile"?',a:'Chito Faró',o:['Chito Faró','Víctor Jara','Patricio Manns','Los Huasos Quincheros'], tier:'intermediate'},
+    {q:'¿Quién escribió "Arriba en la cordillera"?',a:'Patricio Manns',o:['Patricio Manns','Violeta Parra','Víctor Jara','Chito Faró'], tier:'intermediate'},
+    {q:'¿Qué tipo de canto rural se acompaña con guitarra?',a:'La tonada',o:['La tonada','La cueca','La sirilla','El corrido'], tier:'intermediate'},
+    {q:'¿Cuál de estos NO es una variante de la cueca?',a:'Cueca tropical',o:['Cueca tropical','Cueca brava','Cueca chilota','Cueca nortina'], tier:'advanced'},
+    {q:'¿Qué instrumento andino de cuerda tenía caparazón de armadillo antiguamente?',a:'El charango',o:['El charango','La guitarra','El bombo','La quena'], tier:'advanced'},
+    {q:'¿Qué grupo folclórico mantuvo vivo el repertorio de tonadas por más de 80 años?',a:'Los Huasos Quincheros',o:['Los Huasos Quincheros','Inti-Illimani','Quilapayún','Los Jaivas'], tier:'advanced'}
+  ],
   fiestas_patrias:[
     {q:'¿Qué fecha principal se celebra en las Fiestas Patrias?',a:'El 18 de septiembre',o:['El 18 de septiembre','El 21 de mayo','El 1 de enero','El 25 de diciembre'], tier:'beginner'},
     {q:'¿Qué baile tradicional se baila en las fondas?',a:'La Cueca',o:['La Cueca','La Cumbia','El Tango','El Reggaetón'], tier:'beginner'},

--- a/js/sync.js
+++ b/js/sync.js
@@ -176,7 +176,7 @@ var CloudSync = (function() {
         _updatePill('idle');
       });
     }).catch(function(e) {
-      if (typeof Debug !== 'undefined') Debug.error('[Sync] Push failed', e.message);
+      if (typeof Debug !== 'undefined') Debug.error('[Sync] Push failed: ' + key, e && e.message ? e.message : '(no message)');
       _updatePill('error');
     });
   };


### PR DESCRIPTION
## Summary
Three concrete items the latest `diag` window surfaced (after the WebMIDIBrowser noise filter cleared the way):

- **`descubre-chile`** — the `folk` topic (Canto y Folclor) was added to `TOPICS` but never to `QB`, so the new "missing bank" guard fired every time a kid tapped its quiz tile. Added a 10-question folk bank covering Violeta Parra, the cueca, Chito Faró, Patricio Manns, the charango, Los Huasos Quincheros — same age tiers as the rest of the banks.
- **`book-movie-check.html`** — the cache-buster bumps from #228 missed this page, so an iPad with a stale `js/book-movie-check.js` (which pre-dates `setSearchType`) was throwing `BMC.setSearchType is not a function` on every Anything / Book / Movie click. Every script src on this page now has `?v=N`.
- **`sync.js`** — the "Cloud push failed" `Debug.error` line had no detail, so diag entries were impossible to triage. Now logs the key that failed and the error message.

## Diag entries this addresses
| Day | Count | Symptom |
|---|---|---|
| 04-27 | 3 | `[Descubre Chile] No quiz bank for id: folk` |
| 04-27 | 2 | `TypeError: BMC.setSearchType is not a function` |
| 04-27 | 10 | `[Debug] Cloud push failed` (now logs the failing key) |

## Test plan
- [ ] Descubre Chile → tap "Canto y Folclor" → quiz starts and runs through 10 questions.
- [ ] Hard-refresh Book & Movie Check on iPad → tap Anything / 📕 Book / 🎬 Movie — buttons toggle without console error.
- [ ] On any push failure (eg. Tailscale offline), diag captures `Push failed: zs_<key>` plus the network message.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_