### PR TITLE
Math Galaxy: add a Submit button to Sprint and Sibling Duel

### DIFF
--- a/css/math-galaxy.css
+++ b/css/math-galaxy.css
@@ -474,6 +474,26 @@
       text-align: center; outline: none; transition: border-color 0.2s;
     }
     .sprint-input:focus { border-color: #FBBF24; }
+    .sprint-submit {
+      display: inline-block;
+      margin-left: 12px;
+      padding: 14px 22px;
+      border-radius: 16px;
+      border: 2px solid #FBBF24;
+      background: linear-gradient(135deg, #F59E0B, #FBBF24);
+      color: #1B1209;
+      font-family: var(--font-display);
+      font-weight: 800;
+      font-size: 1.1rem;
+      cursor: pointer;
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+      box-shadow: 0 4px 14px rgba(251,191,36,0.35);
+    }
+    .sprint-submit:hover { transform: translateY(-1px); }
+    .sprint-submit:active { transform: translateY(1px); box-shadow: 0 2px 8px rgba(251,191,36,0.3); }
+    @media (max-width: 480px) {
+      .sprint-submit { display: block; margin: 14px auto 0; width: 80%; }
+    }
     .sprint-hint { text-align: center; color: var(--text-muted); font-size: 0.85rem; font-weight: 700; }
 
     .sprint-result {

--- a/js/math-extras.js
+++ b/js/math-extras.js
@@ -169,8 +169,9 @@ var MathExtras = (function() {
         '<div class="sprint-question">' +
           '<div class="sprint-q-text">' + q.a + ' × ' + q.b + ' = ?</div>' +
           '<input type="number" id="sprint-input" class="sprint-input" autocomplete="off" inputmode="numeric" />' +
+          '<button type="button" class="sprint-submit" onclick="MathExtras.Sprint._submit()">Enviar ✓</button>' +
         '</div>' +
-        '<div class="sprint-hint">Presiona Enter para enviar</div>';
+        '<div class="sprint-hint">Toca Enviar o presiona Enter</div>';
       var inp = document.getElementById('sprint-input');
       if (inp) {
         inp.addEventListener('keydown', function(e) {
@@ -244,7 +245,7 @@ var MathExtras = (function() {
       state = null;
     }
 
-    return { open: open, start: start };
+    return { open: open, start: start, _submit: _submit };
   })();
 
   /* ============================================================
@@ -703,8 +704,9 @@ var MathExtras = (function() {
         '<div class="sprint-question">' +
           '<div class="sprint-q-text">' + q.a + ' × ' + q.b + ' = ?</div>' +
           '<input type="number" id="duel-input" class="sprint-input" autocomplete="off" inputmode="numeric" />' +
+          '<button type="button" class="sprint-submit" onclick="MathExtras.Duel._submit()">Submit ✓</button>' +
         '</div>' +
-        '<div class="sprint-hint">Press Enter to submit</div>';
+        '<div class="sprint-hint">Tap Submit or press Enter</div>';
       var inp = document.getElementById('duel-input');
       if (inp) {
         inp.addEventListener('keydown', function(e) {
@@ -810,7 +812,8 @@ var MathExtras = (function() {
       _pick: _pick,
       _setTable: _setTable,
       _begin: _begin,
-      _startTurn: _startTurn
+      _startTurn: _startTurn,
+      _submit: _submit
     };
   })();
 

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -139,18 +139,18 @@
     <span class="feedback-emoji" id="feedbackEmoji"></span>
   </div>
 
-  <script src="js/auth.js"></script>
+  <script src="js/auth.js?v=2"></script>
 
-  <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
-  <script src="js/nav.js"></script>
-  <script src="js/sounds.js"></script>
-  <script src="js/timer.js"></script>
-  <script src="js/activity-log.js"></script>
-  <script src="js/learning-checks.js"></script>
-  <script src="js/math-galaxy.js"></script>
-  <script src="js/math-extras.js"></script>
-  <script src="js/pwa.js"></script>
+  <script src="js/a11y.js?v=2"></script>
+  <script src="js/sync.js?v=4"></script>
+  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/nav.js?v=2"></script>
+  <script src="js/sounds.js?v=2"></script>
+  <script src="js/timer.js?v=2"></script>
+  <script src="js/activity-log.js?v=2"></script>
+  <script src="js/learning-checks.js?v=2"></script>
+  <script src="js/math-galaxy.js?v=2"></script>
+  <script src="js/math-extras.js?v=2"></script>
+  <script src="js/pwa.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
iPad keyboards in WebMIDIBrowser hide the Enter / Return key when `inputmode="numeric"`, so kids could type their answer in Sprint and Sibling Duel but never commit it. Adding a visible Submit button that calls the same `_submit` handler the keyboard Enter binding already uses.

- **Sprint** & **Duel** both render a gold/orange "Enviar ✓" / "Submit ✓" button next to the input. The hint line updates to "Tap Submit or press Enter".
- `Sprint._submit` and `Duel._submit` are now exposed on `MathExtras` so the inline `onclick` can find them.
- New `.sprint-submit` style shared by both modes — inline on tablets, stacked below the input on phones (≤480px) for thumb reach.
- `math-galaxy.html` script tags bumped to `?v=2` so devices pick up the new `math-extras.js` without manual cache clearing.

## Test plan
- [ ] Hard-refresh Math Galaxy on iPad/WebMIDIBrowser → Sprint → start any table → enter a number → tap Submit. Counter increments, next question loads.
- [ ] Same for Sibling Duel.
- [ ] On a desktop with a real keyboard, pressing Enter still submits.
- [ ] Mobile (≤480px): Submit appears below the input and stretches to ~80% width.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_