### PR TITLE
sync: include household state in Push/Pull All + auto-recover on first ping

### DIFF
--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -196,7 +196,7 @@
   <script src="js/nav.js?v=2"></script>
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=4"></script>
+  <script src="js/sync.js?v=5"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/family.html
+++ b/family.html
@@ -47,7 +47,7 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=4"></script>
+  <script src="js/sync.js?v=5"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=4"></script>
+  <script src="js/sync.js?v=5"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/js/sync.js
+++ b/js/sync.js
@@ -453,6 +453,11 @@ var CloudSync = (function() {
     for (var i = 0; i < profiles.length; i++) {
       promises.push(state.pushAll(profiles[i].name.toLowerCase().replace(/\s+/g, '_')));
     }
+    // Also push the household-shared bucket (shopping, menu, calendar
+    // URLs, sports matches, home location, profile tombstones). This
+    // is the recovery path for state that was added when CloudSync was
+    // still offline (e.g. before the initial Tailscale ping resolved).
+    promises.push(state.pushHousehold());
     return Promise.all(promises).then(function() { return state.syncProfiles(); });
   };
 
@@ -465,6 +470,9 @@ var CloudSync = (function() {
         for (var i = 0; i < profiles.length; i++) {
           promises.push(state.pullAll(profiles[i].name.toLowerCase().replace(/\s+/g, '_')));
         }
+        // And mirror the household bucket back so a fresh device picks
+        // up the same shopping list / menu / calendar URLs.
+        promises.push(state.pullHousehold());
         return Promise.all(promises);
       })
       .then(function() {
@@ -511,9 +519,13 @@ var CloudSync = (function() {
           // Pull household-shared state first (shopping list, menu,
           // calendar URLs, sports matches, home location, *and the
           // profile-deletion tombstones*) before profile sync, so the
-          // syncProfiles merge can honor the latest tombstones.
+          // syncProfiles merge can honor the latest tombstones. Then
+          // push any local household state that was changed while
+          // CloudSync was still offline (so this device's edits before
+          // the first ping resolved propagate to others).
           state.pullHousehold().then(function() {
             try { window.dispatchEvent(new CustomEvent('zs:household-synced')); } catch (e) {}
+            state.pushHousehold();
 
             if (isHub) {
               state.syncProfiles()

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -142,7 +142,7 @@
   <script src="js/auth.js?v=2"></script>
 
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=4"></script>
+  <script src="js/sync.js?v=5"></script>
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v4';
+const CACHE_VERSION = 'zs-suite-v5';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Summary
Tracking down why Device B was still seeing `null` for `zs_fcal_urls` after the previous sync fix:

If a parent added a calendar URL (or any household state) **before the initial Tailscale ping resolved**, `CloudSync.push` silently no-op'd because `state.online` was still false. The local state never reached the server, so other devices never received it. "Push All to Cloud" in Parents Corner didn't fix it either — that button only walked per-kid keys.

## Changes
1. **`pushAllKids` / `pullAllKids`** now also run `pushHousehold` / `pullHousehold`, so the existing "Push All / Pull All from Cloud" buttons in Parents Corner cover shopping list, weekly menu, family-calendar URLs, sports matches, home location, and profile tombstones too.
2. **On the first online ping**, after `pullHousehold` completes, also fire `pushHousehold` — auto-uploading anything edited while offline so the next Device B refresh actually finds it on the server.
3. Cache busted: `sw.js` → `v5`, `sync.js?v=5` across hub / family / book-movie-check / math-galaxy.

## Recovery for state already stuck
After this merges and devices refresh, on Device A (where the URL is stuck locally):
- Open Parents Corner → tap **⬆️ Push All to Cloud** once. Or just hard-refresh — the new auto-push on connect will do it for you within a few seconds.
- Then on Device B, refresh once. Within ~10s the calendar surfaces.

## Test plan
- [ ] Reproduce: clear server, add URL on Device A while offline, come online → auto-push fires → Device B refresh shows it.
- [ ] Push All / Pull All buttons in Parents Corner now move shopping / menu / calendar URLs / sports matches.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_