### PR TITLE
Routines: per-profile on/off toggle (parents can opt out)

### DIFF
--- a/family.html
+++ b/family.html
@@ -52,9 +52,9 @@
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/chilean-calendar.js?v=2"></script>
-  <script src="js/routines.js?v=2"></script>
+  <script src="js/routines.js?v=3"></script>
   <script src="js/family-calendar.js?v=4"></script>
-  <script src="js/family-wall.js?v=3"></script>
+  <script src="js/family-wall.js?v=4"></script>
   <script src="js/pwa.js?v=2"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -420,9 +420,9 @@
   <script src="js/recital.js?v=1"></script>
   <script src="js/chilean-calendar.js?v=1"></script>
   <script src="js/tts.js?v=1"></script>
-  <script src="js/routines.js?v=1"></script>
+  <script src="js/routines.js?v=3"></script>
   <script src="js/family-calendar.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
-  <script src="js/index.js?v=3"></script>
+  <script src="js/index.js?v=4"></script>
 </body>
 </html>

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -340,6 +340,17 @@ var FamilyWall = (function() {
         '<div class="fw-card-empty">Add a profile to start tracking routines.</div>' +
       '</div>';
     }
+    // Hide profiles that opted out of routines (eg. parent profiles).
+    var withRoutines = profiles.filter(function(p) {
+      if (typeof Routines.isEnabledFor === 'function') return Routines.isEnabledFor(p.name);
+      return p && p.routinesEnabled !== false;
+    });
+    if (!withRoutines.length) {
+      return '<div class="fw-card fw-card-routines">' +
+        '<div class="fw-card-head"><span class="fw-card-icon">📋</span> Routines</div>' +
+        '<div class="fw-card-empty">No profiles have routines enabled.</div>' +
+      '</div>';
+    }
     // Show only the routine that matches the current time of day:
     //  - before 14:00  → morning
     //  - 14:00 onwards → evening
@@ -347,7 +358,7 @@ var FamilyWall = (function() {
     var which = hour < 14 ? 'morning' : 'evening';
     var sectionLabel = which === 'morning' ? '🌅 Morning' : '🌙 Night';
 
-    var rows = profiles.map(function(p) {
+    var rows = withRoutines.map(function(p) {
       var status = Routines.getStatusFor(p.name);
       if (!status) return '';
       var bucket = status[which];
@@ -692,6 +703,9 @@ var FamilyWall = (function() {
       try { localStorage.removeItem(WEATHER_KEY); } catch (e) {}
       _paint();
     });
+    // syncProfiles fires zs:synced when the merged profile list changed.
+    // Repaint so things like routinesEnabled toggles reflect immediately.
+    window.addEventListener('zs:synced', function() { _paint(); });
   }
 
   return {

--- a/js/index.js
+++ b/js/index.js
@@ -105,6 +105,7 @@
   window.redeemForTime = function() { redeemForTime(); };
   window.updateKidChess = function(idx, val) { updateKidChess(idx, val); };
   window.updateKidFaith = function(idx, val) { updateKidFaith(idx, val); };
+  window.updateKidRoutinesEnabled = function(idx, val) { updateKidRoutinesEnabled(idx, val); };
   window.addRoutineItem = function(idx, which) { addRoutineItem(idx, which); };
   window.updateRoutineItem = function(idx, which, j, val) { updateRoutineItem(idx, which, j, val); };
   window.removeRoutineItem = function(idx, which, j) { removeRoutineItem(idx, which, j); };
@@ -1319,6 +1320,24 @@
     renderAppCards();
   }
 
+  function updateKidRoutinesEnabled(idx, checked) {
+    var profiles = getProfiles();
+    if (!profiles[idx]) return;
+    profiles[idx].routinesEnabled = !!checked;
+    saveProfiles(profiles);
+    // Profiles array is part of the standard profiles sync; push.
+    if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
+      try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
+    }
+    // Re-render the corner so the editor body collapses/expands.
+    renderParentsCorner();
+    // Refresh the hub widget if the active user just toggled themselves.
+    var active = getActiveUser();
+    if (active && active.name === profiles[idx].name && typeof Routines !== 'undefined') {
+      try { Routines.renderHubWidget('routines-widget'); } catch (e) {}
+    }
+  }
+
   function _renderRoutinesEditor(profile, idx) {
     var tpls = Routines.getTemplates(profile.name);
     function block(which, icon, label) {
@@ -1344,10 +1363,16 @@
         '</div>' +
       '</div>';
     }
+    var enabled = profile.routinesEnabled !== false;
     return '<div class="pk-setting" style="margin-top:16px; padding-top:12px; border-top:1px solid rgba(255,255,255,0.06);">' +
       '<label style="font-size:0.9rem; font-weight:700; color:var(--text); display:block; margin-bottom:10px;">📋 Routines</label>' +
-      block('morning', '🌅', 'Morning') +
-      block('evening', '🌙', 'Night') +
+      '<label class="pk-toggle" style="font-size:0.88rem; margin-bottom:10px;">' +
+        '<input type="checkbox" ' + (enabled ? 'checked' : '') + ' onchange="updateKidRoutinesEnabled(' + idx + ', this.checked)">' +
+        ' Show routines for ' + escHtml(profile.name) +
+      '</label>' +
+      (enabled
+        ? block('morning', '🌅', 'Morning') + block('evening', '🌙', 'Night')
+        : '<div class="pk-hint" style="font-size:0.82rem; color:var(--text-muted); font-weight:600;">Routines hidden from the hub and Family Wall for ' + escHtml(profile.name) + '.</div>') +
     '</div>';
   }
 

--- a/js/routines.js
+++ b/js/routines.js
@@ -225,9 +225,27 @@ var Routines = (function() {
   }
 
   // ── Hub widget ──
+  // A profile can opt out of routines entirely (eg. parent profiles
+  // who don't want a "Good morning, brush teeth" widget on their hub).
+  // The flag lives on the profile itself, not in zs_routines, so it
+  // syncs as part of the standard profiles bucket. Default true.
+  function isEnabledFor(userName) {
+    if (typeof getProfiles !== 'function') return true;
+    var profiles = getProfiles();
+    if (!Array.isArray(profiles)) return true;
+    var match = profiles.filter(function(p) { return p && p.name === userName; })[0];
+    if (!match) return true;
+    return match.routinesEnabled !== false;
+  }
+
   function renderHubWidget(containerId) {
     var el = typeof containerId === 'string' ? document.getElementById(containerId) : containerId;
     if (!el) return;
+    var active = (typeof getActiveUser === 'function') ? getActiveUser() : null;
+    if (active && !isEnabledFor(active.name)) {
+      el.innerHTML = '';
+      return;
+    }
     var status = getStatus();
     if (!status) { el.innerHTML = ''; return; }
 
@@ -426,6 +444,7 @@ var Routines = (function() {
     getTemplates: getTemplates,
     setTemplate: setTemplate,
     resetTemplate: resetTemplate,
+    isEnabledFor: isEnabledFor,
     DEFAULTS: DEFAULTS,
     _open: _open,
     _close: _close,

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v5';
+const CACHE_VERSION = 'zs-suite-v6';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Summary
Per-profile setting to disable routines entirely (so a parent profile doesn't see the morning/night widget on their hub or as a row on the Family Wall).

A new `routinesEnabled` flag lives on the profile (default `true`). When `false`:

- **Hub**: `Routines.renderHubWidget` exits early — no "🌅 Good morning, brush teeth" card.
- **Family Wall**: profiles with the flag off are filtered out of the routines card. If everyone has it off, the card shows an empty state instead of disappearing.
- **Parents Corner**: each profile gets a "Show routines for `<name>`" checkbox. Unchecking collapses that profile's morning/night editor and shows a hint explaining the rest of the suite hides routines for them.

The flag rides on the profile object itself, so it syncs as part of the standard profiles bucket. `updateKidRoutinesEnabled` also calls `CloudSync.overwriteProfiles` immediately, and the Family Wall now listens to `zs:synced` (in addition to `zs:household-synced`) so the toggle reflects on other devices without a manual reload.

Cache busted: `sw.js` → `v6`, `index.js?v=4`, `routines.js?v=3`, `family-wall.js?v=4` across the affected pages.

## Test plan
- [ ] Create / open a parent profile → Parents Corner → uncheck "Show routines for <Parent>".
- [ ] Log in as that parent on the hub → no routines widget. Other kids' hubs unchanged.
- [ ] Family Wall: parent's row disappears from the routines card; kids' rows still visible.
- [ ] Re-check the box → morning/night editors come back.
- [ ] On a second device, after sync ping, the change reflects without manual reload.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_