### PR TITLE
schedule: fix Descubre Chile selector + add Money Master to rotation

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,7 +414,7 @@
   <script src="js/zs-diag.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>
-  <script src="js/schedule.js?v=2"></script>
+  <script src="js/schedule.js?v=3"></script>
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/learning-checks.js?v=2"></script>
   <script src="js/recital.js?v=1"></script>

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -7,27 +7,34 @@ var AppSchedule = (function() {
   'use strict';
 
   var ALL_APPS = [
-    { id: 'math',   card: '.card-math' },
-    { id: 'chile',  card: '.card-chile' },
-    { id: 'chess',  card: '.card-chess' },
-    { id: 'piano',  card: '.card-piano' },
-    { id: 'guitar', card: '.card-guitar' },
-    { id: 'art',    card: '.card-art' },
-    { id: 'lab',    card: '.card-lab' },
-    { id: 'world',  card: '.card-world' },
-    { id: 'story',  card: '.card-story' },
-    { id: 'quest',  card: '.card-quest' },
-    { id: 'guess',  card: '.card-guess' }
+    { id: 'math',    card: '.card-math' },
+    // Descubre Chile uses class `card-history` on the hub; the previous
+    // .card-chile selector returned null, so the rotation never hid this
+    // app on its off-days. Same lesson: keep this list in sync with
+    // index.html's class names.
+    { id: 'chile',   card: '.card-history' },
+    { id: 'chess',   card: '.card-chess' },
+    { id: 'piano',   card: '.card-piano' },
+    { id: 'guitar',  card: '.card-guitar' },
+    { id: 'art',     card: '.card-art' },
+    { id: 'lab',     card: '.card-lab' },
+    { id: 'world',   card: '.card-world' },
+    { id: 'story',   card: '.card-story' },
+    { id: 'quest',   card: '.card-quest' },
+    { id: 'guess',   card: '.card-guess' },
+    { id: 'money',   card: '.card-money' },
+    { id: 'bmcheck', card: '.card-bmcheck', alwaysVisible: true },
+    { id: 'trophy',  card: '.card-trophy',  alwaysVisible: true }
   ];
 
   var SMART_SCHEDULE = {
-    0: ['piano', 'math', 'art', 'world', 'guess'], // Sunday
-    1: ['piano', 'math', 'chile', 'lab', 'guess'], // Monday
-    2: ['piano', 'chess', 'guitar', 'story', 'guess'], // Tuesday
-    3: ['piano', 'math', 'art', 'world', 'guess'], // Wednesday
-    4: ['piano', 'math', 'chile', 'lab', 'guess'], // Thursday
-    5: ['piano', 'chess', 'guitar', 'story', 'guess'], // Friday
-    6: ['piano', 'math', 'art', 'world', 'guess']  // Saturday
+    0: ['piano', 'math', 'art', 'world', 'guess'],            // Sunday
+    1: ['piano', 'math', 'chile', 'lab', 'guess', 'money'],   // Monday
+    2: ['piano', 'chess', 'guitar', 'story', 'guess'],        // Tuesday
+    3: ['piano', 'math', 'art', 'world', 'guess', 'money'],   // Wednesday
+    4: ['piano', 'math', 'chile', 'lab', 'guess'],            // Thursday
+    5: ['piano', 'chess', 'guitar', 'story', 'guess', 'money'], // Friday
+    6: ['piano', 'math', 'art', 'world', 'guess']             // Saturday
   };
 
   var OVERRIDE_KEY  = 'zs_schedule_override';
@@ -71,15 +78,14 @@ var AppSchedule = (function() {
     var visibleIds = getTodayApps();
     ALL_APPS.forEach(function(app) {
       var el = document.querySelector(app.card);
-      if (el) {
-        var isVisible = visibleIds.indexOf(app.id) !== -1;
-        // Special rules
-        if (app.id === 'faith' && user && user.faithVisible === false) isVisible = false;
-        if (app.id === 'sports') isVisible = true; // Always visible
-        if (app.id === 'quest') isVisible = true;  // Always visible
-        
-        el.style.display = isVisible ? 'flex' : 'none';
-      }
+      if (!el) return;
+      var isVisible = !!app.alwaysVisible || visibleIds.indexOf(app.id) !== -1;
+      // Faith follows its own per-kid faithVisible toggle (set elsewhere).
+      if (app.id === 'faith' && user && user.faithVisible === false) isVisible = false;
+      // Quest is the always-on world map and Sports is the outdoor logger;
+      // keep them visible regardless of the rotation.
+      if (app.id === 'sports' || app.id === 'quest') isVisible = true;
+      el.style.display = isVisible ? 'flex' : 'none';
     });
   }
 

--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v6';
+const CACHE_VERSION = 'zs-suite-v7';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';


### PR DESCRIPTION
## Summary
Two real issues with the Smart Schedule that meant it was only half-working:

1. **`Descubre Chile` was always visible.** `ALL_APPS` pointed at `.card-chile`, but the hub uses class `card-history`. The selector returned null on every `applyToHub` pass, so the rotation never hid Descubre Chile on its off-days. Fixed to `.card-history` plus an inline reminder to keep the list synced with `index.html`.
2. **Money Master, Trophy Room, and Book & Movie Check** were never added to `ALL_APPS` and always showed. Added all three:
   - **Money Master** joins the rotation on **Mon / Wed / Fri** (math/discovery days).
   - **Trophy Room** and **Book & Movie Check** are tagged `alwaysVisible: true`, so they stay up every day as utilities — same effective treatment as Sports and Quest, but flag-driven instead of inline `if`s.

`applyToHub` is refactored to honor the `alwaysVisible` flag rather than growing the inline special-case chain. Sports and Quest keep the explicit override for safety until a future cleanup.

Cache busted: `sw.js` → `v7`, `schedule.js?v=3` on the hub.

## Test plan
- [ ] Open hub on a non-Mon/Thu day → Descubre Chile is hidden (banner says "5 apps today" matching rotation).
- [ ] Open hub on Monday → Descubre Chile, Math, Money Master all visible.
- [ ] Trophy Room and Book & Movie Check appear every day.
- [ ] Parents Corner schedule editor still lets you override per-day.

https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyK1ojVmbvbR7Catv3Xefd)_