### PR TITLE
diag sweep + chess parental control: fix story quiz crash, restore chess slider

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -178,7 +178,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -197,7 +197,7 @@
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
   <script src="js/sync.js?v=5"></script>
-  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/book-movie-check.js?v=2"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -130,7 +130,7 @@
 
 <script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
-<script src="js/zs-diag.js"></script>
+<script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>
 <script src="js/timer.js"></script>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -75,7 +75,7 @@
 <script src="js/auth.js"></script>
 <script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
-<script src="js/zs-diag.js"></script>
+<script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>
 <script src="js/timer.js"></script>

--- a/family.html
+++ b/family.html
@@ -48,7 +48,7 @@
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
   <script src="js/sync.js?v=5"></script>
-  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/chilean-calendar.js?v=2"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -121,7 +121,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -98,7 +98,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -152,7 +152,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -28,7 +28,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/home-timer.js"></script>

--- a/index.html
+++ b/index.html
@@ -411,7 +411,7 @@
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
   <script src="js/sync.js?v=5"></script>
-  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>
   <script src="js/schedule.js?v=3"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -1214,6 +1214,10 @@
                 '<label>Daily Time Limit: <span id="val-' + i + '">' + escHtml(p.maxMinutes || 45) + '</span> min</label>' +
                 '<input type="range" min="15" max="120" step="15" value="' + escHtml(p.maxMinutes || 45) + '" oninput="updateKidLimit(' + i + ', this.value)">' +
               '</div>' +
+              '<div class="pk-setting" style="margin-top:12px;">' +
+                '<label>♟ Chess Plays/Week: <span id="chess-val-' + i + '">' + escHtml(_chessLabel(p.chessPlaysPerWeek)) + '</span></label>' +
+                '<input type="range" min="0" max="7" step="1" value="' + (p.chessPlaysPerWeek === undefined ? 2 : p.chessPlaysPerWeek) + '" oninput="updateKidChess(' + i + ', this.value)">' +
+              '</div>' +
               '<div class="pk-setting" style="display:flex; gap:8px; flex-wrap:wrap; margin-top:12px;">' +
                 '<button class="hub-action-btn secondary" style="padding:6px 12px; font-size:0.75rem; flex:1;" onclick="addKidBonus(getProfiles()[' + i + '].name, 15)">+15 min</button>' +
                 '<button class="hub-action-btn secondary" style="padding:6px 12px; font-size:0.75rem; flex:1;" onclick="addKidBonus(getProfiles()[' + i + '].name, 30)">+30 min</button>' +
@@ -1302,15 +1306,18 @@
     }
   }
 
+  function _chessLabel(v) {
+    if (v === undefined || v === null || isNaN(v)) v = 2;
+    v = parseInt(v);
+    return v >= 7 ? 'Daily' : v <= 0 ? 'Off' : v + 'x';
+  }
+
   function updateKidChess(idx, val) {
     var profiles = getProfiles();
     profiles[idx].chessPlaysPerWeek = parseInt(val);
     saveProfiles(profiles);
     var label = document.getElementById('chess-val-' + idx);
-    if (label) {
-      var v = parseInt(val);
-      label.textContent = (v === 7 ? 'Daily' : v === 0 ? 'Off' : v + 'x');
-    }
+    if (label) label.textContent = _chessLabel(val);
   }
 
   function updateKidFaith(idx, checked) {

--- a/js/story-explorer.js
+++ b/js/story-explorer.js
@@ -516,9 +516,15 @@ const StoryExplorer = (() => {
   }
 
   function _startQuiz() {
+    // Some stories ship without a quiz block — finish straight to the
+    // results screen instead of crashing on `quiz[0]` (#diag).
+    if (!currentStory || !Array.isArray(currentStory.quiz) || !currentStory.quiz.length) {
+      _showResults(2);
+      return;
+    }
     const wrap = document.getElementById('quiz-wrap');
     const q = currentStory.quiz[0]; // Simple: one question for now or loop through all
-    
+
     wrap.innerHTML = `
       <div class="quiz-q">${lang === 'es' ? q.qEs : q.q}</div>
       <div class="quiz-options">

--- a/js/zs-diag.js
+++ b/js/zs-diag.js
@@ -115,17 +115,31 @@
   //   _callback_addSource, _callback_addDestination. When the
   //   polyfill misses, every page load throws a ReferenceError for
   //   them — thousands of identical entries that drown out signal.
-  function _shouldIgnoreError(message) {
+  function _shouldIgnoreError(message, filename) {
     if (!message) return false;
     var s = String(message);
     if (/_callback_receiveMIDIMessage|_callback_addSource|_callback_addDestination/.test(s)) return true;
     return false;
   }
 
+  // Generic cross-origin "Script error." with no filename/lineno/stack
+  // carries zero signal — drop it. Real same-origin errors always
+  // include at least filename + lineno.
+  function _isGenericScriptError(ev) {
+    if (!ev) return false;
+    var msg = ev.message ? String(ev.message) : '';
+    if (msg !== 'Script error.' && msg !== 'Script error') return false;
+    var hasFile = ev.filename && String(ev.filename).length > 0;
+    var hasLine = typeof ev.lineno === 'number' && ev.lineno > 0;
+    var hasStack = ev.error && ev.error.stack;
+    return !hasFile && !hasLine && !hasStack;
+  }
+
   window.addEventListener('error', function(ev) {
     try {
       var msg = ev && ev.message ? String(ev.message) : 'unknown error';
       if (_shouldIgnoreError(msg)) return;
+      if (_isGenericScriptError(ev)) return;
       _enqueue({
         id: _uid(),
         ts: Date.now(),

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -68,7 +68,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -7808,19 +7808,23 @@ const MIDIManager = (() => {
   // ── internal: choose best input from MIDI access ──
   function _findBestInput(inputs) {
     const inputArr = [];
-    // Use forEach instead of .values().next() for wider browser compat
-    inputs.forEach(input => inputArr.push(input));
+    // Use forEach instead of .values().next() for wider browser compat.
+    // Some 3rd-party iOS MIDI hosts (eg. WebMIDIBrowser) expose a
+    // non-iterable inputs object — guard so init doesn't blow up.
+    if (inputs && typeof inputs.forEach === 'function') {
+      inputs.forEach(input => { if (input) inputArr.push(input); });
+    }
     if (inputArr.length === 0) return null;
 
     // 1. Prefer any device with common piano keywords
     const pianoKeywords = ['yamaha', 'roland', 'casio', 'kawai', 'korg', 'akai', 'alesis', 'arturia', 'native instruments', 'novation', 'piano', 'keyboard', 'midi'];
     for (const input of inputArr) {
-      const name = input.name.toLowerCase();
-      if (pianoKeywords.some(kw => name.includes(kw))) return input;
+      const name = (input && typeof input.name === 'string') ? input.name.toLowerCase() : '';
+      if (name && pianoKeywords.some(kw => name.includes(kw))) return input;
     }
     // 2. Prefer any device that is in "connected" state
     for (const input of inputArr) {
-      if (input.state === 'connected') return input;
+      if (input && input.state === 'connected') return input;
     }
     // 3. Fall back to first available
     return inputArr[0] || null;
@@ -14195,7 +14199,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 <script src="js/a11y.js?v=2"></script>
 <script src="js/sync.js?v=2"></script>
-<script src="js/zs-diag.js?v=2"></script>
+<script src="js/zs-diag.js?v=3"></script>
 <script src="js/timer.js?v=2"></script>
 <script src="js/learning-checks.js?v=2"></script>
 <script src="js/activity-log.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -143,7 +143,7 @@
 
   <script src="js/a11y.js?v=2"></script>
   <script src="js/sync.js?v=5"></script>
-  <script src="js/zs-diag.js?v=2"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/timer.js?v=2"></script>

--- a/menu.html
+++ b/menu.html
@@ -28,7 +28,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/menu.js"></script>
   <script src="js/pwa.js"></script>

--- a/money-master.html
+++ b/money-master.html
@@ -29,7 +29,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -44,7 +44,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -74,7 +74,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>
   <script src="js/pwa.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -246,7 +246,7 @@
 
 <script src="js/a11y.js"></script>
 <script src="js/sync.js"></script>
-<script src="js/zs-diag.js"></script>
+<script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>
 <script src="js/timer.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -87,14 +87,14 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/learning-checks.js"></script>
   <script src="js/tts.js"></script>
-  <script src="js/story-explorer.js"></script>
+  <script src="js/story-explorer.js?v=2"></script>
   <script src="js/pwa.js"></script>
 
 </body>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -28,7 +28,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/routines.js"></script>
   <script src="js/sunday-report.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -47,7 +47,7 @@
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>
   <script src="js/pwa.js"></script>

--- a/vacation.html
+++ b/vacation.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/vacation.js"></script>
   <script src="js/pwa.js"></script>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -76,7 +76,7 @@
 
   <script src="js/a11y.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/zs-diag.js"></script>
+  <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>
   <script src="js/timer.js"></script>


### PR DESCRIPTION
## Summary

Triaged the latest `diag` branch logs and one user-reported chess issue.

**Already fixed in earlier commits** (verified, no action needed):
- `family-calendar.js:179` `start.getTime is not a function` (100eacc)
- `FamilyWall.runLocationSearch is not a function` (f404458)
- `BMC.setSearchType is not a function` (e3de04c — cache bust)
- `[Descubre Chile] No quiz bank for id: folk` (e3de04c)
- `[Debug] Cloud push failed` (e3de04c — added error detail)

**New fixes in this PR:**

### `diag sweep: story quiz crash, midi shell hardening, log noise filter` (8c6d41d)
- **story-explorer**: 13 events of `currentStory.quiz[0]` TypeError. 3 of 9 stories (`andes_rescue`, `lost_compass`, `inca_trail`) ship without a `quiz` block, so finishing the last page crashed `_startQuiz`. Now skips straight to the results screen with 2 stars when no quiz is defined. Cache-bust on `js/story-explorer.js`.
- **little-maestro**: 1 event "undefined is not an object" at `init`'s `.then` handler on iOS WebMIDIBrowser. `_findBestInput` assumed every MIDI input had a string `.name` and an iterable inputs collection. Guarded `inputs.forEach` and `input.name` lookups so init no longer aborts when a non-standard MIDI host returns malformed entries.
- **zs-diag**: drop generic cross-origin `"Script error."` events with no filename/lineno/stack — 54 events of pure noise across index/lab-explorer/math-galaxy/family that drown out real bugs. Same pattern as the existing `_callback_*` filter. Bumped `zs-diag.js` to `?v=3` across all 23 HTML files so the filter takes effect on every page.

### `parents corner: restore chess plays/week slider` (a7ad468)
The chess gate (`canPlayChess`) and `updateKidChess` handler were in the codebase, but the slider HTML was never added back to Parents Corner — so `chessPlaysPerWeek` had no way to be set, and any profile carrying a legacy `0` from an older build silently triggered "Chess is currently disabled." when kids tapped Play vs Computer. Restored the slider next to the Daily Time Limit row (0–7, where 0 = Off and 7 = Daily) so parents can adjust the cap. Extracted a shared `_chessLabel(v)` helper so the initial render and live `oninput` updates format identically and treat undefined/NaN as the default 2x.

**Not actionable in the diag log:** generic `Load failed` / `NetworkError when attempting to fetch resource.` rejections — transient connectivity blips on iPad, no code fix.

## Test plan

- [ ] Open Parents Corner — each kid card shows a "♟ Chess Plays/Week" slider under the Daily Time Limit, defaulting to 2x for new profiles.
- [ ] Drag the slider to "Off" → tapping Play vs Computer in chess-quest.html shows "Chess is currently disabled."
- [ ] Drag to 2x → can play 2 games per week; the 3rd shows the weekly-cap message.
- [ ] Drag to "Daily" → unlimited play.
- [ ] Open Story Explorer, finish a story without a quiz (e.g. "The Lost Compass") → results screen shows "Great Job! 2 stars" instead of crashing.
- [ ] Story Explorer: finish a story with a quiz (e.g. "The Condor's First Flight") → quiz still runs as before.
- [ ] iPad on WebMIDIBrowser: open Little Maestro → init no longer throws on malformed MIDI inputs.
- [ ] Reproduce a generic cross-origin script error → it no longer shows up in the next diag digest.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1jCkY9HEjBhdHKbkiFtfU)_