### PR TITLE
hub: cache-bust index.js so the chess slider actually ships

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,6 +423,6 @@
   <script src="js/routines.js?v=3"></script>
   <script src="js/family-calendar.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
-  <script src="js/index.js?v=4"></script>
+  <script src="js/index.js?v=5"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Follow-up to #241. The chess slider was added to `js/index.js` but the cache-bust on the `<script>` tag wasn't bumped, so iPads using the service worker (stale-while-revalidate) keep loading the pre-slider `index.js?v=4` and Parents Corner still renders without the new control. Any profile carrying a legacy `chessPlaysPerWeek=0` therefore stays stuck on "Chess is currently disabled."

Bump `js/index.js?v=4` → `?v=5` so the new build reaches every device on the next page load.

## Test plan

- [ ] Hard-reload `index.html` (or wait for the SW to revalidate) → Network tab shows `js/index.js?v=5`.
- [ ] Open Parents Corner → each kid card now shows the "♟ Chess Plays/Week" slider.
- [ ] Drag from "Off" to 2x → tap chess → "Play vs Computer" no longer alerts "Chess is currently disabled."

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1jCkY9HEjBhdHKbkiFtfU)_