### PR TITLE
parents corner: push profile edits to server so they actually persist

### DIFF
--- a/index.html
+++ b/index.html
@@ -423,6 +423,6 @@
   <script src="js/routines.js?v=3"></script>
   <script src="js/family-calendar.js?v=1"></script>
   <script src="js/pwa.js?v=1"></script>
-  <script src="js/index.js?v=5"></script>
+  <script src="js/index.js?v=6"></script>
 </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -1298,6 +1298,9 @@
     var profiles = getProfiles();
     profiles[idx].maxMinutes = parseInt(val);
     saveProfiles(profiles);
+    if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
+      try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
+    }
     var label = document.getElementById('val-' + idx);
     if (label) label.textContent = val;
     var active = getActiveUser();
@@ -1316,6 +1319,9 @@
     var profiles = getProfiles();
     profiles[idx].chessPlaysPerWeek = parseInt(val);
     saveProfiles(profiles);
+    if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
+      try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
+    }
     var label = document.getElementById('chess-val-' + idx);
     if (label) label.textContent = _chessLabel(val);
   }
@@ -1324,6 +1330,9 @@
     var profiles = getProfiles();
     profiles[idx].faithVisible = checked;
     saveProfiles(profiles);
+    if (typeof CloudSync !== 'undefined' && CloudSync.overwriteProfiles) {
+      try { CloudSync.overwriteProfiles(profiles); } catch (e) {}
+    }
     renderAppCards();
   }
 


### PR DESCRIPTION
## Summary

Follow-up to #241/#242. The Chess Plays/Week slider updates Parents Corner locally but the value snaps back to the old number on the next reload of `index.html`. Same silent rollback affects the Daily Time Limit slider and the Faith visibility toggle.

**Root cause:** `updateKidChess` / `updateKidLimit` / `updateKidFaith` call `saveProfiles()` (localStorage only) and stop there. `CloudSync.syncProfiles()` runs on every `index.html` load and merges server + local profiles with "higher age wins, ties go to the first occurrence" — and the merged array puts server entries first (`[].concat(serverProfiles, localProfiles)`), so when ages tie (the normal case for an existing kid), the server's stale profile overwrites the local change. The PUT that follows then sends the server's version back to the server, so the edit never reaches the cloud at all.

**Fix:** mirror the pattern `updateKidRoutinesEnabled` already uses — after `saveProfiles`, call `CloudSync.overwriteProfiles(profiles)` so the server has the new value before the next `syncProfiles` pull/merge runs. Bumped `js/index.js?v=5` → `?v=6` so iPads pick up the fix on the next load.

## Test plan

- [ ] Hard-reload `index.html` → Network shows `js/index.js?v=6`.
- [ ] Open Parents Corner → drag Chess Plays/Week from "Off" to 2x → reload page → slider still shows 2x.
- [ ] Same for Daily Time Limit slider.
- [ ] Toggle Faith visible/hidden → reload → toggle stays.
- [ ] On a second device, pull → the change shows up.
- [ ] With chess set to 2x, Play vs Computer works (no "Chess is currently disabled.").

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1jCkY9HEjBhdHKbkiFtfU)_