### PR TITLE
family calendar: anchor recurring events to source-zone wall clock so DST doesn't drift them

### DIFF
--- a/family.html
+++ b/family.html
@@ -53,7 +53,7 @@
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/chilean-calendar.js?v=2"></script>
   <script src="js/routines.js?v=3"></script>
-  <script src="js/family-calendar.js?v=5"></script>
+  <script src="js/family-calendar.js?v=6"></script>
   <script src="js/family-wall.js?v=4"></script>
   <script src="js/pwa.js?v=2"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -421,7 +421,7 @@
   <script src="js/chilean-calendar.js?v=1"></script>
   <script src="js/tts.js?v=1"></script>
   <script src="js/routines.js?v=3"></script>
-  <script src="js/family-calendar.js?v=2"></script>
+  <script src="js/family-calendar.js?v=3"></script>
   <script src="js/pwa.js?v=1"></script>
   <script src="js/index.js?v=6"></script>
 </body>

--- a/js/family-calendar.js
+++ b/js/family-calendar.js
@@ -200,7 +200,7 @@ var FamilyCalendar = (function() {
         case 'UID':       cur.uid = value; break;
         case 'SUMMARY':   cur.summary = _unescapeText(value); break;
         case 'LOCATION':  cur.location = _unescapeText(value); break;
-        case 'DTSTART':   var sParams = _parseParams(lhs); var s = _parseIcsDate(value, sParams.TZID); if (s) { cur.start = s.date; cur.allDay = s.allDay; } break;
+        case 'DTSTART':   var sParams = _parseParams(lhs); var s = _parseIcsDate(value, sParams.TZID); if (s) { cur.start = s.date; cur.allDay = s.allDay; if (sParams.TZID) cur.tzid = sParams.TZID; } break;
         case 'DTEND':     var eParams = _parseParams(lhs); var e = _parseIcsDate(value, eParams.TZID); if (e) cur.end = e.date; break;
         case 'RRULE':     cur.rrule = _parseRrule(value); break;
         default: /* ignore */ break;
@@ -235,13 +235,53 @@ var FamilyCalendar = (function() {
     };
   }
 
+  // Read wall-clock parts of `date` in `tzid` (or local if no tzid).
+  // Used to anchor recurrences in the source calendar's zone so they
+  // don't drift when the device crosses a DST boundary.
+  function _wallPartsOf(date, tzid) {
+    if (tzid) {
+      try {
+        var dtf = new Intl.DateTimeFormat('en-US', {
+          timeZone: tzid, hourCycle: 'h23',
+          year: 'numeric', month: '2-digit', day: '2-digit',
+          hour: '2-digit', minute: '2-digit', second: '2-digit'
+        });
+        var parts = dtf.formatToParts(date);
+        var p = {};
+        parts.forEach(function(x) { p[x.type] = x.value; });
+        return { y: +p.year, m: +p.month - 1, d: +p.day, hh: +p.hour, mn: +p.minute, ss: +p.second };
+      } catch (e) {}
+    }
+    return {
+      y: date.getFullYear(), m: date.getMonth(), d: date.getDate(),
+      hh: date.getHours(), mn: date.getMinutes(), ss: date.getSeconds()
+    };
+  }
+
+  // Add a calendar offset to wall-clock parts using a UTC scratch Date
+  // (UTC has no DST, so date arithmetic is exact). Returns new parts.
+  function _addToParts(parts, deltaDays, deltaMonths, deltaYears) {
+    var d = new Date(Date.UTC(parts.y, parts.m, parts.d, parts.hh, parts.mn, parts.ss));
+    if (deltaDays)   d.setUTCDate(d.getUTCDate() + deltaDays);
+    if (deltaMonths) d.setUTCMonth(d.getUTCMonth() + deltaMonths);
+    if (deltaYears)  d.setUTCFullYear(d.getUTCFullYear() + deltaYears);
+    return {
+      y: d.getUTCFullYear(), m: d.getUTCMonth(), d: d.getUTCDate(),
+      hh: d.getUTCHours(), mn: d.getUTCMinutes(), ss: d.getUTCSeconds()
+    };
+  }
+
+  function _partsToDate(parts, tzid) {
+    if (tzid) return _wallTimeInTzToDate(parts.y, parts.m, parts.d, parts.hh, parts.mn, parts.ss, tzid);
+    return new Date(parts.y, parts.m, parts.d, parts.hh, parts.mn, parts.ss);
+  }
+
   // Expand a single VEVENT into instances within [from, to].
   function _expand(event, from, to) {
     var instances = [];
     if (!event || !event.start) return instances;
 
-    function pushIfInRange(start) {
-      if (start < from || start > to) return;
+    function pushInstance(start) {
       var duration = (event.end && event.start) ? (event.end - event.start) : 0;
       instances.push({
         uid: event.uid || (start.getTime() + '_' + (event.summary || '')),
@@ -254,35 +294,33 @@ var FamilyCalendar = (function() {
     }
 
     if (!event.rrule) {
-      pushIfInRange(event.start);
+      if (event.start >= from && event.start <= to) pushInstance(event.start);
       return instances;
     }
 
     var rr = event.rrule;
-    var step = { DAILY: 1, WEEKLY: 7, MONTHLY: 0, YEARLY: 0 }[rr.freq] || 0;
-    var cur = new Date(event.start.getTime());
+    // Anchor recurrences on the wall-clock parts in the source zone so
+    // a 14:00 LA weekly event stays at 14:00 LA across DST boundaries
+    // (instead of drifting by the offset every time we cross spring-
+    // forward / fall-back). All-day events have no zone — use local.
+    var tzid = event.allDay ? null : event.tzid;
+    var basis = _wallPartsOf(event.start, tzid);
     var n = 0;
     var maxIter = 366 * 2;
     while (n < maxIter) {
+      var nextParts;
+      if (rr.freq === 'DAILY')        nextParts = _addToParts(basis, n * rr.interval, 0, 0);
+      else if (rr.freq === 'WEEKLY')  nextParts = _addToParts(basis, n * rr.interval * 7, 0, 0);
+      else if (rr.freq === 'MONTHLY') nextParts = _addToParts(basis, 0, n * rr.interval, 0);
+      else if (rr.freq === 'YEARLY')  nextParts = _addToParts(basis, 0, 0, n * rr.interval);
+      else break;
+
+      var cur = _partsToDate(nextParts, tzid);
       if (rr.until && cur > rr.until) break;
       if (rr.count && n >= rr.count) break;
       if (cur > to) break;
-      pushIfInRange(cur);
+      if (cur >= from) pushInstance(cur);
       n++;
-      // Advance by interval according to freq
-      if (rr.freq === 'DAILY' || rr.freq === 'WEEKLY') {
-        cur = new Date(cur.getTime() + step * rr.interval * 86400000);
-      } else if (rr.freq === 'MONTHLY') {
-        var next = new Date(cur);
-        next.setMonth(next.getMonth() + rr.interval);
-        cur = next;
-      } else if (rr.freq === 'YEARLY') {
-        var nextY = new Date(cur);
-        nextY.setFullYear(nextY.getFullYear() + rr.interval);
-        cur = nextY;
-      } else {
-        break;
-      }
     }
     return instances;
   }


### PR DESCRIPTION
## Summary

Follow-up to #244. The TZID fix from #244 corrects single-occurrence events, but recurring events still drift by exactly the DST offset whenever the rendering window crosses a spring-forward / fall-back boundary. Symptom: a weekly meeting created at 14:00 PST in February shows at 15:00 on iPad/phone after DST starts in mid-March — one hour off, every week, until DST ends.

**Root cause:** `_expand` advanced the recurrence cursor by raw milliseconds (`step * interval * 86400000` for daily/weekly). That's an exact elapsed-time delta, but iCal RRULE semantics are calendar-based: "weekly" means *same wall-clock hour next week in the source zone*. Adding `7 × 24h` across spring-forward lands one hour late in the source zone's wall clock. `MONTHLY` / `YEARLY` had the analogous flaw via `setMonth` / `setFullYear`, which operate on *device-local* time, not the event's source zone.

**Fix:** store `TZID` on the event during `parseIcs` (in addition to the per-occurrence UTC instant from #244). In `_expand`, read the start's wall-clock parts in the source zone (or local for floating-time / all-day events), advance those parts by calendar days/weeks/months/years using a UTC scratch `Date` for the arithmetic, and re-resolve each occurrence to a UTC instant via the existing `_wallTimeInTzToDate`. Every recurrence is anchored to the source calendar's wall clock, so a 14:00 LA event stays at 14:00 LA whether the rendering happens before or after DST.

**Verified** with a Node Intl harness: a `Feb 1 2026 14:00 America/Los_Angeles` weekly event resolves to `14:00 LA` at weeks +0/+4/+8/+12/+16, spanning the Mar 8 DST start.

Bumped `js/family-calendar.js?v=` on `family.html` (5→6) and `index.html` (2→3) so the new expander reaches every device on next load. The 10-min event cache will self-heal — or re-add a calendar to force.

## Test plan

- [ ] Reload `family.html` / `index.html` → Network shows `family-calendar.js?v=6` / `?v=3`.
- [ ] Subscribe a weekly Google Calendar event scheduled before the most recent DST transition → on the iPad, it shows the same wall-clock time *every* week, including weeks past the DST boundary.
- [ ] Same for a monthly event spanning DST → same wall-clock time each month.
- [ ] Single (non-recurring) events still resolve correctly (#244 path unchanged).
- [ ] All-day events still render as all-day.

---
_Generated by [Claude Code](https://claude.ai/code/session_01F1jCkY9HEjBhdHKbkiFtfU)_