### PR TITLE
diag sweep: silence sync rejections, debug push warning, cross-origin noise

### DIFF
--- a/js/debug.js
+++ b/js/debug.js
@@ -108,11 +108,14 @@ var Debug = (function() {
       _syncedAt: Date.now()
     };
 
+    // Swallow network failures silently. zs-diag.js wraps console.warn
+    // and would otherwise bounce this back into the diag pipeline as
+    // noise on every offline blip (#diag).
     return fetch(SYNC_SERVER + '/api/kids/debug/logs_' + deviceId, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
-    }).catch(function(e) { console.warn('[Debug] Cloud push failed'); });
+    }).catch(function() {});
   }
 
   // Catch global JS errors

--- a/js/sync.js
+++ b/js/sync.js
@@ -523,6 +523,9 @@ var CloudSync = (function() {
           // push any local household state that was changed while
           // CloudSync was still offline (so this device's edits before
           // the first ping resolved propagate to others).
+          // Network can drop between the ping and the follow-up calls.
+          // Swallow transient sync failures so they don't surface as
+          // unhandled promise rejections (#diag).
           state.pullHousehold().then(function() {
             try { window.dispatchEvent(new CustomEvent('zs:household-synced')); } catch (e) {}
             state.pushHousehold();
@@ -534,15 +537,16 @@ var CloudSync = (function() {
                   if (typeof renderLogin === 'function' && loginScr && loginScr.style.display !== 'none') {
                     renderLogin();
                   }
-                });
+                })
+                .catch(function() { _updatePill('offline'); });
             } else {
               var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
               if (user) {
                 var kidKey = user.name.toLowerCase().replace(/\s+/g, '_');
-                state.pullAll(kidKey);
+                state.pullAll(kidKey).catch(function() { _updatePill('offline'); });
               }
             }
-          });
+          }).catch(function() { _updatePill('offline'); });
         } else {
           state.online = false;
           _updatePill('offline');

--- a/vps/diag-push.js
+++ b/vps/diag-push.js
@@ -52,6 +52,15 @@ function pseudonym(name) {
 }
 
 // ── Read + filter raw entries ──
+// Drop generic cross-origin "Script error." reports — the browser
+// strips filename/line/stack from them so they're unactionable noise.
+function isUnactionable(e) {
+  if (!e) return true;
+  const msg = (e.message || '').trim();
+  const noStack = !e.stack && !e.filename && !e.lineno;
+  return noStack && (msg === 'Script error.' || msg === 'Script error');
+}
+
 function readWindow(hours) {
   if (!fs.existsSync(JSONL_PATH)) return [];
   const cutoff = Date.now() - hours * 3600 * 1000;
@@ -61,7 +70,7 @@ function readWindow(hours) {
     if (!line) return;
     try {
       const e = JSON.parse(line);
-      if (e && e.ts >= cutoff) out.push(e);
+      if (e && e.ts >= cutoff && !isUnactionable(e)) out.push(e);
     } catch {}
   });
   return out;
@@ -218,6 +227,16 @@ function buildDigest() {
 
   fs.writeFileSync(path.join(diagDir, 'latest.json'), JSON.stringify(latest, null, 2));
   fs.writeFileSync(path.join(diagDir, 'window.json'), JSON.stringify(digest, null, 2));
+
+  // Drop day files that fell out of the window so the branch doesn't
+  // accumulate stale daily archives forever.
+  const keepDays = new Set(digest.days.map(d => d.day));
+  fs.readdirSync(diagDir).forEach(name => {
+    const m = name.match(/^(\d{4}-\d{2}-\d{2})\.json$/);
+    if (m && !keepDays.has(m[1])) {
+      try { fs.unlinkSync(path.join(diagDir, name)); } catch {}
+    }
+  });
 
   // Per-day archive (overwrites each run with the latest grouping for that day)
   digest.days.forEach(d => {


### PR DESCRIPTION
## Summary

Cleanup of issues surfaced on the `diag` branch over the last 72 h.

- **`js/sync.js`** — `state.pullHousehold()` / `state.syncProfiles()` / `state.pullAll()` were chained inside the ping handler with no `.catch()`, so a network drop between the ping and the follow-up calls produced an unhandled `Failed to fetch` rejection. Added `.catch` handlers that just flip the pill to offline.
- **`js/debug.js`** — the legacy debug-log push warned via `console.warn` on failure. `zs-diag.js` patches `console.warn` and was bouncing every offline blip back into the diag pipeline (15 noise events today alone). Made the catch a silent no-op.
- **`vps/diag-push.js`** — opaque cross-origin `Script error.` reports (no filename / line / stack) are now filtered during ingest, and per-day archive JSONs for days outside the window are pruned so the branch stops accumulating stale files.

The Story Explorer `currentStory.quiz[0]` crash that showed up on 2026-04-29 was already fixed in `8c6d41d`; it'll age out of the 72 h window naturally.

## Test plan

- [ ] Verify hub still pings/sync on a healthy network (pill → idle, profile sync runs).
- [ ] Simulate offline mid-sync (DevTools network throttle → offline after the first ping resolves) and confirm no unhandled rejection appears in console / diag.
- [ ] Run `vps/diag-push.js` against a fixture jsonl containing a `Script error.` entry and confirm it's omitted.
- [ ] Run `vps/diag-push.js` twice with a window that skips an older day and confirm the older day file is removed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EAPHjpzxWVLApcpR1JRRUv)_