### PR TITLE
diag: stop churning empty commits, preserve client event time

### DIFF
--- a/vps/diag-push.js
+++ b/vps/diag-push.js
@@ -182,7 +182,10 @@ function buildDigest() {
     if (bucket.has(fp)) {
       const b = bucket.get(fp);
       b.count++;
-      b.lastTs = Math.max(b.lastTs, s.ts);
+      if (typeof s.ts === 'number') {
+        b.firstTs = typeof b.firstTs === 'number' ? Math.min(b.firstTs, s.ts) : s.ts;
+        b.lastTs = typeof b.lastTs === 'number' ? Math.max(b.lastTs, s.ts) : s.ts;
+      }
       if (b.users.indexOf(s.user) === -1 && s.user) b.users.push(s.user);
     } else {
       bucket.set(fp, {
@@ -205,14 +208,49 @@ function buildDigest() {
     }))
   };
 
-  // Also a latest.json for easy reading
+  // Flatten groups across days, ranked by recency × frequency, so
+  // latest.json carries enough signal to act on without opening
+  // window.json. Each entry keeps just the high-signal scrubbed fields.
+  const flat = [];
+  digest.days.forEach(d => d.groups.forEach(g => flat.push(g)));
+  flat.sort((a, b) => (b.lastTs || 0) - (a.lastTs || 0) || b.count - a.count);
+  const TOP_N = 10;
+  const topGroups = flat.slice(0, TOP_N).map(g => ({
+    app: g.entry.app,
+    kind: g.entry.kind,
+    page: g.entry.page,
+    message: g.entry.message,
+    filename: g.entry.filename,
+    lineno: g.entry.lineno,
+    colno: g.entry.colno,
+    count: g.count,
+    firstTs: g.firstTs,
+    lastTs: g.lastTs,
+    users: g.users.length
+  }));
+
   const latest = {
     generatedAt: digest.generatedAt,
+    windowHours: WINDOW_HOURS,
     totalGroups: digest.days.reduce((acc, d) => acc + d.groups.length, 0),
-    totalEvents: digest.days.reduce((acc, d) => acc + d.groups.reduce((a, g) => a + g.count, 0), 0)
+    totalEvents: digest.days.reduce((acc, d) => acc + d.groups.reduce((a, g) => a + g.count, 0), 0),
+    topGroups
   };
 
   return { digest, latest };
+}
+
+// Strip generatedAt so two digests with different timestamps but
+// identical content compare equal. Prevents an empty refresh every
+// 15 minutes from filling the branch with no-op commits.
+function withoutTimestamp(obj) {
+  const clone = JSON.parse(JSON.stringify(obj));
+  delete clone.generatedAt;
+  return clone;
+}
+
+function readJsonIfExists(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
 }
 
 // ── Main ──
@@ -225,8 +263,22 @@ function buildDigest() {
   const diagDir = path.join(REPO_PATH, 'diag');
   if (!fs.existsSync(diagDir)) fs.mkdirSync(diagDir, { recursive: true });
 
-  fs.writeFileSync(path.join(diagDir, 'latest.json'), JSON.stringify(latest, null, 2));
-  fs.writeFileSync(path.join(diagDir, 'window.json'), JSON.stringify(digest, null, 2));
+  const latestPath = path.join(diagDir, 'latest.json');
+  const windowPath = path.join(diagDir, 'window.json');
+
+  // Decide whether the meaningful digest changed before writing. If
+  // not, leave the working tree alone — no diff, no commit, no churn.
+  const prevLatest = readJsonIfExists(latestPath);
+  const prevWindow = readJsonIfExists(windowPath);
+  const sameLatest = prevLatest && JSON.stringify(withoutTimestamp(prevLatest)) === JSON.stringify(withoutTimestamp(latest));
+  const sameWindow = prevWindow && JSON.stringify(withoutTimestamp(prevWindow)) === JSON.stringify(withoutTimestamp(digest));
+  if (sameLatest && sameWindow) {
+    log('Digest unchanged since last push; skipping.');
+    return;
+  }
+
+  fs.writeFileSync(latestPath, JSON.stringify(latest, null, 2));
+  fs.writeFileSync(windowPath, JSON.stringify(digest, null, 2));
 
   // Drop day files that fell out of the window so the branch doesn't
   // accumulate stale daily archives forever.

--- a/vps/diag.js
+++ b/vps/diag.js
@@ -68,11 +68,26 @@ function init(app, dataDir) {
     const ip = (req.headers['x-forwarded-for'] || req.socket.remoteAddress || 'unknown').toString().split(',')[0].trim();
     const ua = (req.headers['user-agent'] || '').toString();
 
+    // Accept the client-supplied ts when it's a sane number — within
+    // 30 days past or 5 minutes future of now. Falling back to `now`
+    // for missing or out-of-range values means a batch that was
+    // buffered offline for hours still groups under the day the bug
+    // actually occurred, instead of all events sharing one server
+    // timestamp and aging out of the digest window in lockstep.
+    const TS_PAST_LIMIT = now - 30 * 24 * 3600 * 1000;
+    const TS_FUTURE_LIMIT = now + 5 * 60 * 1000;
+    function _canonicalTs(e) {
+      if (e && typeof e.ts === 'number' && e.ts >= TS_PAST_LIMIT && e.ts <= TS_FUTURE_LIMIT) {
+        return e.ts;
+      }
+      return now;
+    }
+
     return body.entries.slice(0, MAX_ENTRIES_PER_BATCH).map(e => ({
       id: e && e.id ? String(e.id).slice(0, 40) : undefined,
       clientTs: e && typeof e.ts === 'number' ? e.ts : now,
       serverTs: now,
-      ts: now, // canonical timestamp
+      ts: _canonicalTs(e),
       kind: e && e.kind ? String(e.kind).slice(0, 40) : 'unknown',
       app: e && e.app ? String(e.app).slice(0, 60) : null,
       page: e && e.page ? String(e.page).slice(0, 120) : null,
@@ -132,10 +147,15 @@ function init(app, dataDir) {
   app.get('/api/diag/health', (req, res) => {
     let size = 0;
     try { size = fs.statSync(JSONL_PATH).size; } catch (e) {}
+    const windowH = Math.max(parseInt(process.env.DIAG_WINDOW_HOURS || '24', 10) || 24, 1);
+    const inWindow = _readSince(windowH * 60 * 60 * 1000).length;
     res.json({
       status: 'ok',
       jsonl_bytes: size,
-      entries_last_24h: _readSince(24 * 60 * 60 * 1000).length
+      window_hours: windowH,
+      entries_in_window: inWindow,
+      // Kept for back-compat with any external monitor wired to the old key.
+      entries_last_24h: windowH === 24 ? inWindow : _readSince(24 * 60 * 60 * 1000).length
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes several issues with the `diag` branch pipeline that were causing noise and lost signal:

- **Empty refresh churn**: `diag-push.js` now skips the commit entirely when the meaningful digest is identical to the previous push (only `generatedAt` differs). Stops the `diag` branch filling up with `(0 groups, 0 events)` refreshes every 15 minutes.
- **Client event time preserved**: `diag.js` keeps the client-supplied `ts` when it's within a sane range (30 days past, 5 minutes future), instead of unconditionally stamping receive time. A batch buffered offline for hours now groups under the day the bug actually happened and ages out one event at a time, instead of the whole batch dropping at once when it crosses the 24h cutoff.
- **Honest `firstTs`**: dedupe now uses `Math.min` for `firstTs`, so a long-running recurring error reports a real first-seen time instead of `firstTs === lastTs`.
- **Useful `latest.json`**: includes a `topGroups` summary (top 10 by recency × frequency) so a glance at the file actually shows what's hot, matching what the README promises.
- **Health endpoint honors `DIAG_WINDOW_HOURS`**: `/api/diag/health` now reports `entries_in_window` plus the configured window. `entries_last_24h` is kept for back-compat.

## Test plan

- [ ] Deploy to VPS, confirm next `zs-diag-push.timer` run does not produce a commit when there are no new events
- [ ] Post a synthetic entry with `ts` set to 6h ago, confirm it groups under that day instead of today
- [ ] Repro a duplicated error across two batches, confirm the resulting group's `firstTs < lastTs`
- [ ] Open `diag/latest.json` on the diag branch and confirm `topGroups` is populated
- [ ] `curl /api/diag/health` returns `entries_in_window` and `window_hours`


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_