### PR TITLE
Content Guardian: Daily updates and pruning for Math, Geography, and Language apps

### DIFF
--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -331,6 +331,8 @@ const QB={
     {q:'¿En qué región se encuentra el desierto de Atacama?',a:'Norte Grande',o:['Norte Grande','Zona Central','Patagonia','Sur'], tier:'beginner'}
   ],
   antartica:[
+    {q:'¿Cuál es la temperatura media en el interior de la Antártica?',a:'Bajo cero',o:['Bajo cero','10 grados','20 grados','30 grados'], tier:'intermediate'},
+    {q:'¿Qué océano rodea la Antártica?',a:'Océano Antártico',o:['Océano Antártico','Océano Atlántico','Océano Pacífico','Océano Índico'], tier:'beginner'},
     {q:'¿Cuál es la base civil más conocida de Chile en la Antártica?',a:'Villa Las Estrellas',o:['Villa Las Estrellas','Punta Arenas','Puerto Williams','Base Prat'], tier:'advanced'},
     {q:'¿Qué tratado regula la presencia de países en la Antártica?',a:'Tratado Antártico',o:['Tratado Antártico','Acuerdo de París','Pacto de Santiago','Convención de Ginebra'], tier:'expert'},
     {q:'¿Qué animal es común encontrar en la Antártica?',a:'Pingüino',o:['Pingüino','Oso Polar','León','Mono'], tier:'beginner'},
@@ -377,6 +379,8 @@ const QB={
     {q:'¿En qué siglo se fundó la ciudad de Santiago?',a:'Siglo XVI (16)',o:['Siglo XVI (16)','Siglo XVIII (18)','Siglo XIX (19)','Siglo XV (15)'], tier:'advanced'}
   ],
   culture:[
+    {q:'¿Qué instrumento folclórico se parece a un charango o guitarrita?',a:'Guitarrón chileno',o:['Guitarrón chileno','Violín','Arpa','Flauta'], tier:'advanced'},
+    {q:'¿Qué comida chilena se hace con choclo molido?',a:'Pastel de choclo',o:['Pastel de choclo','Empanada de pino','Cazuela','Completos'], tier:'beginner'},
     {q:'¿Cuál es el baile nacional de Chile?',a:'La Cueca',o:['La Cueca','El Tango','La Salsa','El Candombe'], tier:'beginner'},
     {q:'¿Qué instrumento de cuerdas se usa frecuentemente en la música folclórica chilena?',a:'La guitarra',o:['La guitarra','El violín','El piano','La trompeta'], tier:'intermediate'},
     {q:'¿Qué lleva la empanada de pino?',a:'Carne, cebolla, huevo, aceitunas',o:['Carne, cebolla, huevo, aceitunas','Pollo con queso','Porotos con arroz','Pescado con limón'], tier:'beginner'},
@@ -404,6 +408,8 @@ const QB={
     {q:'¿Qué pájaro habita en los salares del norte?',a:'Flamenco',o:['Flamenco','Cóndor','Gaviota','Pelícano'], tier:'beginner'}
   ],
   famous:[
+    {q:'¿Quién escribió "Altazor"?',a:'Vicente Huidobro',o:['Vicente Huidobro','Pablo Neruda','Gabriela Mistral','Nicanor Parra'], tier:'expert'},
+    {q:'¿Qué famoso pianista chileno toca a nivel mundial?',a:'Claudio Arrau',o:['Claudio Arrau','Roberto Bravo','Valentín Trujillo','Tomás González'], tier:'advanced'},
     {q:'¿Poeta chileno Nobel en 1971?',a:'Pablo Neruda',o:['Pablo Neruda','Gabriela Mistral','Isabel Allende','Huidobro'], tier:'intermediate'},
     {q:'¿Primera Nobel latina de Literatura?',a:'Gabriela Mistral',o:['Gabriela Mistral','Neruda','García Márquez','Vargas Llosa'], tier:'intermediate'},
     {q:'¿Futbolista chileno del Barcelona?',a:'Alexis Sánchez',o:['Alexis Sánchez','Arturo Vidal','Marcelo Ríos','Claudio Bravo'], tier:'beginner'},

--- a/js/fe-explorador.js
+++ b/js/fe-explorador.js
@@ -234,6 +234,18 @@ const FeManager = (() => {
         { q: '¿A quién se le considera el primer Papa?', a: ['San Pablo', 'San Pedro', 'San Juan'], correct: 1 },
         { q: '¿En qué siglo vivió?', a: ['Siglo V', 'Siglo III', 'Siglo I'], correct: 2 }
       ]
+    },
+    {
+      id: 'juan_cruz',
+      name: 'San Juan de la Cruz',
+      dates: '1542–1591',
+      country: 'España 🇪🇸',
+      bio: 'Famoso místico y poeta que ayudó a Santa Teresa de Ávila a reformar la Orden del Carmelo.',
+      questions: [
+        { q: '¿A quién ayudó a reformar su orden?', a: ['Santa Teresa de Ávila', 'Santa Rosa de Lima', 'San Francisco de Asís'], correct: 0 },
+        { q: '¿Por qué es famoso?', a: ['Por ser místico y poeta', 'Por fundar Roma', 'Por inventar la imprenta'], correct: 0 },
+        { q: '¿De qué país era?', a: ['España', 'Francia', 'Italia'], correct: 0 }
+      ]
     }
   ];
 

--- a/js/guitar-jam.js
+++ b/js/guitar-jam.js
@@ -24,8 +24,8 @@ const CHORDS = [
   { name: 'D7', fullName: 'D Dominant 7', tier: 'advanced', frets: [-1, -1, 0, 2, 1, 2], fingers: [0, 0, 0, 2, 1, 3], funFact: 'It looks like a backwards D Major chord.' },
   { name: 'A7', fullName: 'A Dominant 7', tier: 'advanced', frets: [-1, 0, 2, 0, 2, 0], fingers: [0, 0, 2, 0, 3, 0], funFact: 'Like an A Major chord, but with an open G string in the middle.' },
   { name: 'E7', fullName: 'E Dominant 7', tier: 'advanced', frets: [0, 2, 0, 1, 0, 0], fingers: [0, 2, 0, 1, 0, 0], funFact: 'A very bluesy sounding chord.' },
-  { name: 'Am7', fullName: 'A Minor 7', tier: 'advanced', frets: [-1, 0, 2, 0, 1, 0], fingers: [0, 0, 2, 0, 1, 0], funFact: 'A jazzy variation of the standard A Minor chord.' },
-  { name: 'Fm', fullName: 'F Minor (Barre)', tier: 'expert', frets: [1, 3, 3, 1, 1, 1], fingers: [1, 3, 4, 1, 1, 1], funFact: 'A sad, moody barre chord.' }
+  // PRUNED [2026-05-18]: Removed 'Am7', 'Fm' to make room for 'A#m' and stay within MAX 18 limit.
+  { name: 'A#m', fullName: 'A# Minor', tier: 'expert', frets: [-1, 1, 3, 3, 2, 1], fingers: [0, 1, 3, 4, 2, 1], funFact: 'A difficult barre chord starting on the first fret.' }
 ];
 
 const SONGS = [
@@ -40,9 +40,9 @@ const SONGS = [
   { id: 'house', title: 'House of the Rising Sun', tier: 'advanced', bpm: 80, progression: [['Am', 4], ['C', 4], ['D', 4], ['F', 4], ['Am', 4], ['C', 4], ['E', 8]] },
   { id: 'scarborough', title: 'Scarborough Fair', tier: 'advanced', bpm: 90, progression: [['Am', 8], ['Am', 4], ['G', 4], ['Am', 4], ['G', 4], ['C', 4], ['D', 4], ['F', 4], ['Am', 8]] },
   { id: 'amazing', title: 'Amazing Grace', tier: 'intermediate', bpm: 100, progression: [['G', 6], ['G', 6], ['C', 6], ['G', 6], ['G', 6], ['G', 6], ['D', 12]] },
-  { id: 'valerie', title: 'Valerie', tier: 'intermediate', bpm: 105, progression: [['C', 4], ['Dm', 4], ['C', 4], ['Dm', 4]] },
-  { id: 'letitbe', title: 'Let It Be', tier: 'intermediate', bpm: 70, progression: [['C', 4], ['G', 4], ['Am', 4], ['F', 4], ['C', 4], ['G', 4], ['F', 2], ['C', 6]] },
-  { id: 'hallelujah', title: 'Hallelujah', tier: 'intermediate', bpm: 60, progression: [['C', 6], ['Am', 6], ['C', 6], ['Am', 6], ['F', 6], ['G', 6], ['C', 6], ['G', 6]] }
+  // PRUNED [2026-05-18]: Removed 'valerie', 'letitbe' to make room for 'twinkle2' and stay within MAX 12 limit.
+  { id: 'hallelujah', title: 'Hallelujah', tier: 'intermediate', bpm: 60, progression: [['C', 6], ['Am', 6], ['C', 6], ['Am', 6], ['F', 6], ['G', 6], ['C', 6], ['G', 6]] },
+  { id: 'twinkle2', title: 'Twinkle in G', tier: 'beginner', bpm: 90, progression: [['G', 4], ['D', 4], ['Em', 4], ['C', 4], ['G', 4], ['D', 4], ['G', 8]] }
 ];
 
 const GuitarJam = (() => {

--- a/js/learning-checks.js
+++ b/js/learning-checks.js
@@ -85,6 +85,14 @@ var LearningCheck = (function() {
       { q: 'What force keeps us on the ground?', options: ['Magnetism', 'Friction', 'Gravity', 'Electricity'], answer: 2 },
       { q: 'What is the largest ocean?', options: ['Atlantic', 'Indian', 'Arctic', 'Pacific'], answer: 3 },
       { q: 'How many planets in the solar system?', options: ['7', '8', '9', '10'], answer: 1 }
+    ],
+    science: [
+      { q: 'What gas do plants absorb from the air?', options: ['Oxygen', 'Carbon Dioxide', 'Nitrogen', 'Hydrogen'], answer: 1 },
+      { q: 'What is the hardest natural substance on Earth?', options: ['Gold', 'Iron', 'Diamond', 'Quartz'], answer: 2 },
+      { q: 'What part of the plant conducts photosynthesis?', options: ['Root', 'Stem', 'Flower', 'Leaf'], answer: 3 },
+      { q: 'What type of animal is a frog?', options: ['Reptile', 'Amphibian', 'Mammal', 'Fish'], answer: 1 },
+      { q: 'At what temperature does water boil?', options: ['50°C', '90°C', '100°C', '120°C'], answer: 2 },
+      { q: 'Which planet is closest to the Sun?', options: ['Venus', 'Earth', 'Mercury', 'Mars'], answer: 2 }
     ]
   };
 

--- a/js/math-galaxy.js
+++ b/js/math-galaxy.js
@@ -144,7 +144,8 @@ function generateDistractors(correct, count, min, max) {
 function genCadet() {
   // PRUNED [2026-04-14]: Removed 'shape', 'bigger' to make room for 'moon_count', 'star_sub' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'alien_shape', 'moon_shape' to make room for 'satellite_count', 'planet_sub'
-  const types = ['count', 'add', 'moon_count', 'star_sub', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'galaxy_count', 'alien_count', 'satellite_add', 'meteor_add', 'robot_add', 'meteor_count', 'ufo_count', 'telescope_add', 'star_shape', 'sun_count', 'alien_sub', 'sun_add', 'rocket_count', 'satellite_count', 'asteroid_add', 'planet_sub'];
+  // PRUNED [2026-05-18]: Removed 'robot_add', 'alien_sub' to make room for 'sun_sub', 'meteor_pattern' and stay within MAX 25 limit.
+  const types = ['count', 'add', 'moon_count', 'star_sub', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'galaxy_count', 'alien_count', 'satellite_add', 'meteor_add', 'meteor_count', 'ufo_count', 'telescope_add', 'star_shape', 'sun_count', 'sun_add', 'rocket_count', 'satellite_count', 'asteroid_add', 'planet_sub', 'sun_sub', 'meteor_pattern'];
   const type = types[rand(0, types.length - 1)];
   if (type === 'galaxy_count') { return { label: 'Counting', text: '🌌🌌🌌', hint: 'Count the galaxies!', answer: 3, options: generateDistractors(3, 3, 1, 10), mode: 'choice' }; }
   if (type === 'satellite_count') { return { label: 'Counting', text: '🛰️🛰️', hint: 'Count the satellites!', answer: 2, options: generateDistractors(2, 3, 1, 10), mode: 'choice' }; }
@@ -169,9 +170,8 @@ function genCadet() {
     const n = rand(1, 10);
     return { label: 'Suns', text: '☀️'.repeat(n), hint: 'How many suns?', answer: n, options: generateDistractors(n, 3, 1, 10), mode: 'choice' };
   }
-  if (type === 'alien_sub') {
-    const a = rand(2, 5), b = rand(1, a - 1);
-    return { label: 'Alien Subtraction', text: `${a} 👽 - ${b} 👽 = ?`, hint: 'How many aliens left?', answer: a - b, options: generateDistractors(a - b, 3, 1, 10), mode: 'choice' };
+  if (type === 'meteor_pattern') {
+    return { label: 'Pattern', text: '☄️ 🌠 ☄️ 🌠 ?', hint: 'What is next?', answer: '☄️', options: shuffle(['☄️', '🌠', '🚀', '⭐']), mode: 'choice' };
   }
   if (type === 'sun_add') {
     const a = rand(1, 5), b = rand(1, 4);
@@ -192,9 +192,9 @@ function genCadet() {
   if (type === 'star_shape') {
     return { label: 'Star Shapes', text: '⭐', hint: 'What shape is this star?', answer: 'Star', options: shuffle(['Star', 'Circle', 'Triangle', 'Square']), mode: 'choice' };
   }
-  if (type === 'robot_add') {
-    const a = rand(1, 4), b = rand(1, 5);
-    return { label: 'Robot Assembly', text: `${a} 🤖 + ${b} 🤖 = ?`, hint: 'Add the robots!', answer: a + b, options: generateDistractors(a + b, 3, 1, 10), mode: 'choice' };
+  if (type === 'sun_sub') {
+    const a = rand(3, 8), b = rand(1, 2);
+    return { label: 'Subtraction', text: `${a} ☀️ - ${b} ☀️ = ?`, hint: '', answer: a - b, options: generateDistractors(a - b, 3, 1, 10), mode: 'choice' };
   }
   if (type === 'meteor_count') {
     const n = rand(2, 9);
@@ -260,7 +260,8 @@ function genExplorer() {
   // PRUNED [2026-04-12]: Removed 'comet_compare' to make room for 'telescope_sub' and stay within MAX 25 limit.
   // PRUNED [2026-04-14]: Removed 'missing', 'compare' to make room for 'planet_add', 'comet_compare2' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'satellite_mult', 'comet_diff' to make room for 'asteroid_sub', 'meteor_add_2'
-  const types = ['add', 'sub', 'planet_add', 'comet_compare2', 'double', 'alien_add', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'meteor_sub', 'moon_pattern', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare', 'star_sub', 'rocket_add', 'planet_sub', 'comet_add', 'asteroid_sub', 'meteor_add_2'];
+  // PRUNED [2026-05-18]: Removed 'alien_add', 'rocket_add' to make room for 'spaceship_add', 'satellite_add2' and stay within MAX 25 limit.
+  const types = ['add', 'sub', 'planet_add', 'comet_compare2', 'double', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'meteor_sub', 'moon_pattern', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare', 'star_sub', 'planet_sub', 'comet_add', 'asteroid_sub', 'meteor_add_2', 'spaceship_add', 'satellite_add2'];
   const type = types[rand(0, types.length - 1)];
   if (type === 'asteroid_sub') { const a = rand(10,20), b = rand(1,9); return { label: 'Subtraction', text: `${a} ☄️ - ${b} ☄️ = ?`, hint: '', answer: a-b, options: generateDistractors(a-b, 3, 1, 25), mode: 'choice' }; }
   if (type === 'meteor_add_2') { const a = rand(10,20), b = rand(5,15); return { label: 'Addition', text: `${a} ☄️ + ${b} ☄️ = ?`, hint: '', answer: a+b, options: generateDistractors(a+b, 3, 10, 40), mode: 'choice' }; }
@@ -286,9 +287,9 @@ function genExplorer() {
     const a = rand(6, 15), b = rand(1, a - 1);
     return { label: 'Star Subtraction', text: `${a} ⭐ - ${b} ⭐ = ?`, hint: 'Subtract the stars', answer: a - b, options: generateDistractors(a - b, 3, 1, 15), mode: 'choice' };
   }
-  if (type === 'rocket_add') {
-    const a = rand(3, 9), b = rand(3, 9);
-    return { label: 'Rocket Addition', text: `${a} 🚀 + ${b} 🚀 = ?`, hint: 'Add the rockets', answer: a + b, options: generateDistractors(a + b, 3, 5, 20), mode: 'choice' };
+  if (type === 'satellite_add2') {
+    const a = rand(10, 20), b = rand(5, 10);
+    return { label: 'Addition', text: `${a} 🛰️ + ${b} 🛰️ = ?`, hint: '', answer: a + b, options: generateDistractors(a + b, 3, 10, 40), mode: 'choice' };
   }
   if (type === 'planet_sub') {
     const a = rand(5, 10), b = rand(1, a - 1);
@@ -344,9 +345,9 @@ function genExplorer() {
   if (type === 'planet_pattern') {
     return { label: 'Space Pattern', text: '🌍 🪐 🌍 🪐 ?', hint: 'Which planet is next?', answer: '🌍', options: shuffle(['🌍', '🪐', '🌕', '☄️']), mode: 'choice' };
   }
-  if (type === 'alien_add') {
-    const a = rand(3, 9), b = rand(3, 9);
-    return { label: 'Alien Math', text: `${a} 👽 + ${b} 👽 = ?`, hint: 'How many aliens total?', answer: a + b, options: generateDistractors(a + b, 3, 5, 20), mode: 'choice' };
+  if (type === 'spaceship_add') {
+    const a = rand(10, 20), b = rand(5, 10);
+    return { label: 'Addition', text: `${a} 🛸 + ${b} 🛸 = ?`, hint: 'Add spaceships!', answer: a + b, options: generateDistractors(a + b, 3, 15, 35), mode: 'choice' };
   }
   if (type === 'space_compare') {
     const a = rand(5, 20), b = rand(5, 20);
@@ -368,7 +369,8 @@ function genPilot() {
   // PRUNED [2026-04-12]: Removed 'alien_word' to make room for 'comet_frac' and stay within MAX 25 limit.
   // PRUNED [2026-04-14]: Removed 'word', 'missing_mult' to make room for 'ufo_mult', 'satellite_frac' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'rocket_alg', 'planet_div' to make room for 'blackhole_mult', 'galaxy_div'
-  const types = ['mult', 'div', 'frac_visual', 'ufo_mult', 'satellite_frac', 'comet_mult', 'asteroid_div', 'star_word', 'alien_mult', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'rocket_word', 'robot_mult', 'meteor_div', 'astronaut_mult', 'rocket_div', 'moon_frac', 'alien_pct', 'asteroid_mult', 'alien_div', 'blackhole_mult', 'comet_frac', 'galaxy_div'];
+  // PRUNED [2026-05-18]: Removed 'alien_mult', 'rocket_word' to make room for 'nebula_frac', 'star_div' and stay within MAX 25 limit.
+  const types = ['mult', 'div', 'frac_visual', 'ufo_mult', 'satellite_frac', 'comet_mult', 'asteroid_div', 'star_word', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'robot_mult', 'meteor_div', 'astronaut_mult', 'rocket_div', 'moon_frac', 'alien_pct', 'asteroid_mult', 'alien_div', 'blackhole_mult', 'comet_frac', 'galaxy_div', 'nebula_frac', 'star_div'];
   const type = types[rand(0, types.length - 1)];
   if (type === 'blackhole_mult') { const a = rand(6,12), b = rand(6,12); return { label: 'Multiplication', text: `${a} 🕳️ × ${b} = ?`, hint: '', answer: a*b, options: generateDistractors(a*b, 3, 30, 150), mode: 'choice' }; }
   if (type === 'galaxy_div') { const b = rand(3,9), a = b * rand(3,12); return { label: 'Division', text: `${a} 🌌 ÷ ${b} = ?`, hint: '', answer: a/b, options: generateDistractors(a/b, 3, 2, 15), mode: 'choice' }; }
@@ -431,13 +433,12 @@ function genPilot() {
     const b = rand(2, 8), ans = rand(2, 8);
     return { label: 'UFO Landing', text: `${b * ans} 🛸 ÷ ${b} = ?`, hint: 'Divide the UFOs', answer: ans, options: generateDistractors(ans, 3, 1, 10), mode: 'choice' };
   }
-  if (type === 'rocket_word') {
-    const fuel = rand(6, 15), perShip = rand(2, 4);
-    return { label: 'Fleet Supply', text: `A fleet needs ${perShip} fuel units per ship. For ${fuel} ships?`, hint: 'Multiply to find total fuel.', answer: fuel * perShip, options: generateDistractors(fuel * perShip, 3, 10, 60), mode: 'choice' };
+  if (type === 'nebula_frac') {
+    return { label: 'Nebula Fractions', text: '🌌 🌌 🌌 🌑', hint: 'Fraction of nebulas?', answer: '3/4', options: shuffle(['3/4', '1/4', '1/3', '2/3']), mode: 'choice' };
   }
-  if (type === 'alien_mult') {
-    const a = rand(4, 9), b = rand(2, 6);
-    return { label: 'Alien Multiply', text: `${a} 👾 × ${b} = ?`, hint: 'Total aliens?', answer: a * b, options: generateDistractors(a * b, 3, 5, 60), mode: 'choice' };
+  if (type === 'star_div') {
+    const b = rand(2, 5), ans = rand(3, 8);
+    return { label: 'Star Division', text: `${b * ans} ⭐ ÷ ${b} = ?`, hint: 'Divide the stars', answer: ans, options: generateDistractors(ans, 3, 1, 15), mode: 'choice' };
   }
   if (type === 'satellite_div') {
     const b = rand(2, 7), ans = rand(2, 7);
@@ -471,7 +472,8 @@ function genCommander() {
   // PRUNED [2026-04-12]: Removed duplicates of 'sci_not' and 'dec_add' to make room for 'speed_ops' and 'planet_pct' and stay within MAX 25 limit.
   // PRUNED [2026-04-14]: Removed 'fraction_add', 'decimal' to make room for 'blackhole_div', 'galaxy_frac' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'speed_ops', 'planet_pct' to make room for 'quasar_ops', 'pulsar_dec'
-  const types = ['big_add', 'big_mult', 'blackhole_div', 'galaxy_frac', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'robot_ops', 'ufo_decimal', 'rocket_pct', 'blackhole_add', 'asteroid_decimal', 'supernova_pct', 'gravity_ops', 'orbit_dec', 'quasar_ops', 'pulsar_dec'];
+  // PRUNED [2026-05-18]: Removed 'rocket_pct', 'asteroid_decimal' to make room for 'pulsar_add', 'galaxy_pct' and stay within MAX 25 limit.
+  const types = ['big_add', 'big_mult', 'blackhole_div', 'galaxy_frac', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'robot_ops', 'ufo_decimal', 'blackhole_add', 'supernova_pct', 'gravity_ops', 'orbit_dec', 'quasar_ops', 'pulsar_dec', 'pulsar_add', 'galaxy_pct'];
   const type = types[rand(0, types.length - 1)];
   if (type === 'gravity_ops') { const a=rand(5,10), b=rand(2,5); const ans=a+(b*b); return { label: 'Gravity Math', text: `${a} + ${b}² = ?`, hint: 'Square first!', answer: ans, options: generateDistractors(ans, 3, 5, 50), mode: 'choice' }; }
   if (type === 'orbit_dec') { const a=(rand(10,50)/10).toFixed(1); const b=(rand(10,50)/10).toFixed(1); const ans=(parseFloat(a)-parseFloat(b)).toFixed(1); return { label: 'Decimals', text: `${a} - ${b} = ?`, hint: '', answer: ans, options: generateDistractors(ans, 3, -5, 5).map(x=>x.toFixed(1)), mode: 'choice' }; }
@@ -522,16 +524,9 @@ function genCommander() {
     const a = rand(100, 999), b = rand(100, 999);
     return { label: 'Mass Addition', text: `${a} + ${b} = ?`, hint: 'Add the large numbers.', answer: a + b, options: generateDistractors(a + b, 3, 200, 2000), mode: 'choice' };
   }
-  if (type === 'asteroid_decimal') {
-    const a = (rand(10, 99) / 10).toFixed(1);
-    const b = (rand(10, 99) / 10).toFixed(1);
-    const ans = (parseFloat(a) + parseFloat(b)).toFixed(1);
-    const opts = [ans];
-    while (opts.length < 4) {
-      const fake = (parseFloat(ans) + (rand(-20, 20) / 10)).toFixed(1);
-      if (!opts.includes(fake) && parseFloat(fake) > 0 && fake !== ans) opts.push(fake);
-    }
-    return { label: 'Asteroid Decimals', text: `${a} + ${b} = ?`, hint: 'Add the decimals.', answer: ans, options: shuffle(opts), mode: 'choice' };
+  if (type === 'pulsar_add') {
+    const a = rand(150, 450), b = rand(150, 450);
+    return { label: 'Pulsar Math', text: `${a} 💫 + ${b} 💫 = ?`, hint: 'Add the large numbers.', answer: a + b, options: generateDistractors(a + b, 3, 300, 900), mode: 'choice' };
   }
   if (type === 'supernova_pct') {
     const pcts = [10, 20, 25, 50, 75];
@@ -562,12 +557,12 @@ function genCommander() {
     }
     return { label: 'UFO Speed', text: `${a} Mach + ${b} Mach = ?`, hint: 'Add the speeds.', answer: ans, options: shuffle(opts), mode: 'choice' };
   }
-  if (type === 'rocket_pct') {
+  if (type === 'galaxy_pct') {
     const pcts = [20, 25, 50, 75];
     const p = pcts[rand(0, pcts.length - 1)];
-    const fuel = rand(20, 80) * 10;
-    const ans = fuel * (p / 100);
-    return { label: 'Rocket Fuel', text: `${p}% of ${fuel} gallons`, hint: 'Find the percentage.', answer: ans, options: generateDistractors(ans, 3, 10, fuel), mode: 'choice' };
+    const stars = rand(10, 50) * 100;
+    const ans = stars * (p / 100);
+    return { label: 'Galaxy Stars', text: `${p}% of ${stars} 🌌`, hint: 'Find the percentage.', answer: ans, options: generateDistractors(ans, 3, 100, stars), mode: 'choice' };
   }
   if (type === 'comet_ops') {
     const a = rand(20, 50), b = rand(4, 9), c = rand(2, 6);

--- a/js/story-explorer.js
+++ b/js/story-explorer.js
@@ -318,6 +318,35 @@ const StoryExplorer = (() => {
         { q: 'Where did the explorer find the map?', qEs: '¿Dónde encontró el explorador el mapa?', options: ['In a house', 'In a cave', 'In a tree', 'In the river'], optionsEs: ['En una casa', 'En una cueva', 'En un árbol', 'En el río'], answer: 1 },
         { q: 'What did the map show the way to?', qEs: '¿Hacia dónde mostraba el camino el mapa?', options: ['A castle', 'A hidden waterfall', 'A city', 'A treasure chest'], optionsEs: ['A un castillo', 'A una cascada oculta', 'A una ciudad', 'A un cofre del tesoro'], answer: 1 }
       ]
+    },
+    {
+      id: 'atacama_desert',
+      title: 'The Atacama Desert',
+      titleEs: 'El Desierto de Atacama',
+      tier: 'explorer', ageMin: 6, region: 'north', icon: '🏜️',
+      pages: [
+        {
+          en: 'The desert is very dry. It has not rained in years.',
+          es: 'El desierto es muy seco. No ha llovido en años.',
+          vocab: [
+            { word: 'desert', wordEs: 'desierto', def: 'A very dry place with little water.', defEs: 'Un lugar muy seco con poca agua.' },
+            { word: 'dry', wordEs: 'seco', def: 'Having no water or rain.', defEs: 'Que no tiene agua ni lluvia.' }
+          ]
+        },
+        {
+          en: 'At night, the sky is full of stars and the moon shines bright.',
+          es: 'Por la noche, el cielo está lleno de estrellas y la luna brilla.',
+          vocab: [
+            { word: 'night', wordEs: 'noche', def: 'The time when the sun is down.', defEs: 'El momento en que el sol se oculta.' },
+            { word: 'sky', wordEs: 'cielo', def: 'The space over the earth where we see clouds and stars.', defEs: 'El espacio sobre la tierra donde vemos nubes y estrellas.' },
+            { word: 'stars', wordEs: 'estrellas', def: 'Bright lights in the night sky.', defEs: 'Luces brillantes en el cielo nocturno.' }
+          ]
+        }
+      ],
+      quiz: [
+        { q: 'What is the desert like?', qEs: '¿Cómo es el desierto?', options: ['Wet', 'Cold', 'Dry', 'Green'], optionsEs: ['Húmedo', 'Frío', 'Seco', 'Verde'], answer: 2 },
+        { q: 'What can you see at night?', qEs: '¿Qué puedes ver de noche?', options: ['Birds', 'Stars', 'Clouds', 'Sun'], optionsEs: ['Pájaros', 'Estrellas', 'Nubes', 'Sol'], answer: 1 }
+      ]
     }
   ];
 

--- a/js/world-explorer.js
+++ b/js/world-explorer.js
@@ -273,6 +273,23 @@ const WorldExplorer = (() => {
     ] },
     { id: 'europe', name: 'Europe', nameEs: 'Europa', icon: '🌍', color: '#3B82F6', countries: [
       {
+        id: 'spain', name: 'Spain', nameEs: 'España', flag: '🇪🇸',
+        capital: 'Madrid', capitalEs: 'Madrid',
+        facts: [
+          { en: 'Spain is located on the Iberian Peninsula.', es: 'España se encuentra en la península ibérica.' },
+          { en: 'The famous Sagrada Familia is in Barcelona.', es: 'La famosa Sagrada Familia está en Barcelona.' },
+          { en: 'Spanish is the second most spoken native language in the world.', es: 'El español es el segundo idioma nativo más hablado en el mundo.' },
+          { en: 'Flamenco is a famous Spanish art form of music and dance.', es: 'El flamenco es una famosa forma de arte español de música y baile.' }
+        ],
+        landmark: { name: 'Sagrada Familia', nameEs: 'Sagrada Familia', emoji: '⛪' },
+        animal: { name: 'Iberian Lynx', nameEs: 'Lince ibérico', emoji: '🐱' },
+        quiz: [
+          { q: 'What is the capital of Spain?', qEs: '¿Cuál es la capital de España?', options: ['Barcelona', 'Seville', 'Madrid', 'Valencia'], optionsEs: ['Barcelona', 'Sevilla', 'Madrid', 'Valencia'], answer: 2 },
+          { q: 'What famous church is in Barcelona?', qEs: '¿Qué famosa iglesia está en Barcelona?', options: ['Notre Dame', 'Sagrada Familia', 'St. Peter\'s', 'Westminster'], optionsEs: ['Notre Dame', 'Sagrada Familia', 'San Pedro', 'Westminster'], answer: 1 },
+          { q: 'Which dance is a famous Spanish art form?', qEs: '¿Qué baile es un famoso arte español?', options: ['Salsa', 'Tango', 'Flamenco', 'Ballet'], optionsEs: ['Salsa', 'Tango', 'Flamenco', 'Ballet'], answer: 2 }
+        ]
+      },
+      {
         id: 'france', name: 'France', nameEs: 'Francia', flag: '🇫🇷',
         capital: 'Paris', capitalEs: 'París',
         facts: [
@@ -291,6 +308,23 @@ const WorldExplorer = (() => {
       }
     ] },
     { id: 'africa', name: 'Africa', nameEs: 'África', icon: '🌍', color: '#EF4444', countries: [
+      {
+        id: 'kenya', name: 'Kenya', nameEs: 'Kenia', flag: '🇰🇪',
+        capital: 'Nairobi', capitalEs: 'Nairobi',
+        facts: [
+          { en: 'Kenya is famous for its wildlife savannas.', es: 'Kenia es famosa por sus sabanas de vida silvestre.' },
+          { en: 'Mount Kenya is the second highest mountain in Africa.', es: 'El monte Kenia es la segunda montaña más alta de África.' },
+          { en: 'Swahili and English are its official languages.', es: 'El suajili y el inglés son sus idiomas oficiales.' },
+          { en: 'The Great Rift Valley runs through Kenya.', es: 'El Gran Valle del Rift atraviesa Kenia.' }
+        ],
+        landmark: { name: 'Mount Kenya', nameEs: 'Monte Kenia', emoji: '⛰️' },
+        animal: { name: 'Lion', nameEs: 'León', emoji: '🦁' },
+        quiz: [
+          { q: 'What is the capital of Kenya?', qEs: '¿Cuál es la capital de Kenia?', options: ['Cairo', 'Nairobi', 'Lagos', 'Pretoria'], optionsEs: ['El Cairo', 'Nairobi', 'Lagos', 'Pretoria'], answer: 1 },
+          { q: 'What landscape is Kenya famous for?', qEs: '¿Por qué paisaje es famosa Kenia?', options: ['Deserts', 'Rainforests', 'Tundras', 'Savannas'], optionsEs: ['Desiertos', 'Selvas', 'Tundras', 'Sabanas'], answer: 3 },
+          { q: 'What is the second highest mountain in Africa?', qEs: '¿Cuál es la segunda montaña más alta de África?', options: ['Kilimanjaro', 'Mount Kenya', 'Atlas', 'Ruwenzori'], optionsEs: ['Kilimanjaro', 'Monte Kenia', 'Atlas', 'Ruwenzori'], answer: 1 }
+        ]
+      },
       {
         id: 'egypt', name: 'Egypt', nameEs: 'Egipto', flag: '🇪🇬',
         capital: 'Cairo', capitalEs: 'El Cairo',


### PR DESCRIPTION
Updated educational content banks across the Zavala Serra apps suite to provide fresh learning material while aggressively enforcing capacity limits through pruning.

- **Math Galaxy:** Generated 8 new question types across all tiers (`sun_sub`, `meteor_pattern`, `spaceship_add`, `satellite_add2`, `nebula_frac`, `star_div`, `pulsar_add`, `galaxy_pct`) and pruned 8 older types (`robot_add`, `alien_sub`, `alien_add`, `rocket_add`, `alien_mult`, `rocket_word`, `asteroid_decimal`, `rocket_pct`) to maintain the strict MAX 25 limit.
- **Descubre Chile:** Expanded quiz banks for `antartica` (+2), `culture` (+2), and `famous` (+2).
- **Fe Explorador:** Added a new saint biography for San Juan de la Cruz to the `SAINTS` array.
- **World Explorer:** Introduced two new countries: Spain (Europe) and Kenya (Africa) with full facts, landmarks, and bilingual quizzes.
- **Guitar Jam:** Added chord `A#m` and song `twinkle2`. Pruned chords `Am7`, `Fm` and songs `valerie`, `letitbe` to respect strict memory limits.
- **Learning Checks:** Restored the missing `science` subject bank with 6 foundational questions.
- **Story Explorer:** Appended a new bilingual adventure story "The Atacama Desert" focusing on geography and nocturnal navigation.

All generated content has been strictly verified against `content-guidelines.md` for factual neutrality and the absence of any restricted terms. Syntax and unit tests have been successfully executed to confirm file integrity.

---
*PR created automatically by Jules for task [13845167955152791237](https://jules.google.com/task/13845167955152791237) started by @rozavala*