### PR TITLE
BMC + Debug: clearer "off the tailnet" message, add missing Debug.warn

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -113,6 +113,24 @@ var BMC = (function() {
       });
   }
 
+  // Classify a fetch failure into a kid-friendly message. Distinguishes
+  // "the device can't reach the VPS at all" (the iPad isn't on Tailscale,
+  // or the VPS is asleep) from a timeout or HTTP error so the parent
+  // knows where to look.
+  function _userMsgForFetchErr(err, context) {
+    if (err && err.name === 'AbortError') {
+      return 'The ' + context + ' timed out. Check your connection and try again.';
+    }
+    var msg = err && err.message ? String(err.message) : '';
+    // Safari (iOS) → "Load failed". Chrome/Firefox → "Failed to fetch".
+    var unreachable = err && err.name === 'TypeError' &&
+      (msg === 'Load failed' || msg === 'Failed to fetch' || /NetworkError/i.test(msg));
+    if (unreachable) {
+      return 'Can\'t reach the book server. Open the Tailscale app on this device, then try again.';
+    }
+    return 'Could not reach the book server. Please try again.';
+  }
+
   // ── Status display ─────────────────────────────────────────────
   function _setStatus(msg, kind) {
     var el = document.getElementById('bmc-status');
@@ -391,10 +409,7 @@ var BMC = (function() {
       })
       .catch(function(err) {
         console.warn('[BMC] Lookup failed:', err);
-        var msg = (err && err.name === 'AbortError')
-          ? 'The search timed out. Check your connection and try again.'
-          : 'Could not reach the book server. Please try again.';
-        _setStatus(msg, 'error');
+        _setStatus(_userMsgForFetchErr(err, 'search'), 'error');
       });
   }
 
@@ -516,7 +531,7 @@ var BMC = (function() {
       })
       .catch(function(err) {
         console.warn('[BMC] ISBN lookup failed:', err);
-        _setStatus('Could not look up that ISBN right now.', 'error');
+        _setStatus(_userMsgForFetchErr(err, 'ISBN lookup'), 'error');
       });
   }
 
@@ -547,7 +562,7 @@ var BMC = (function() {
           })
           .catch(function(err) {
             console.warn('[BMC] Photo lookup failed:', err);
-            _setStatus('Could not identify the photo right now.', 'error');
+            _setStatus(_userMsgForFetchErr(err, 'photo lookup'), 'error');
           });
       };
       reader.readAsDataURL(file);
@@ -608,7 +623,9 @@ var BMC = (function() {
       })
       .catch(function(err) {
         console.warn('[BMC] Evaluate failed:', err);
-        if (wrap) wrap.innerHTML = '<div class="bmc-empty">Could not finish the check right now. Please try again.</div>';
+        if (wrap) {
+          wrap.innerHTML = '<div class="bmc-empty">' + _userMsgForFetchErr(err, 'review') + '</div>';
+        }
         _setStatus('');
       });
   }
@@ -931,14 +948,17 @@ var BMC = (function() {
 
   // ── VPS family library hydration ───────────────────────────────
   function _hydrateFamilyLibrary() {
-    // Pulls the full server-side cache of evaluated titles
+    // Pulls the full server-side cache of evaluated titles. This is
+    // an optimisation, not a requirement — every other BMC feature
+    // works without it. When the device is off the tailnet (kid hasn't
+    // opened Tailscale, or the VPS is asleep) this fetch fails with
+    // "Load failed". That's expected, not a bug; don't pollute the
+    // diag log with a warn for it.
     return _fetchJson(VPS + '/api/media/library')
       .then(function(library) {
         _familyLibrary = library || {};
       })
-      .catch(function(err) {
-        console.warn('[BMC] Library hydrate failed:', err);
-      });
+      .catch(function() { /* silent — see comment above */ });
   }
 
   // ── Re-review / stale-count (parent tools) ─────────────────────

--- a/js/debug.js
+++ b/js/debug.js
@@ -258,6 +258,7 @@ var Debug = (function() {
 
   return {
     log: function(msg, meta) { _add('info', msg, meta); },
+    warn: function(msg, meta) { _add('warn', msg, meta); },
     error: function(msg, meta) { _add('error', msg, meta); },
     show: show,
     hide: hide,


### PR DESCRIPTION
## Summary

Driven by real entries surfaced on the `diag` branch (now that the pipeline is fixed and `topGroups` works):

- **`Debug.warn` was missing.** Eight call sites assumed it existed — `lm-bridge.js:21/36/69`, `pwa.js:59`, `auth.js:86`, `index.js:302`, `sync.js:294`. The `lm-bridge` ones surfaced as `TypeError: Debug.warn is not a function` and were the likely upstream cause of the `little-maestro:7997` "undefined is not an object" cascade. Adding the missing level fixes all eight without touching any callers.

- **BMC fetch failures didn't tell the parent what to do.** When the iPad falls off the tailnet (the `*.ts.net` host stops resolving), every BMC fetch fails with iOS Safari's `TypeError: Load failed`. The kid was seeing a generic "Could not reach the book server" message instead of "open Tailscale". Added a small classifier that routes `TypeError` with `Load failed` / `Failed to fetch` / `NetworkError` to a Tailscale-actionable message. Applied to title lookup, ISBN lookup, photo lookup, and evaluate. The library-hydrate path is non-fatal so its catch is now silent instead of warning every page load.

## Files

- `js/debug.js` — add `warn:` to the exported API
- `js/book-movie-check.js` — `_userMsgForFetchErr` helper + use in 4 catches; silence library hydrate

## Test plan

- [ ] Disconnect Tailscale on the iPad, open BMC, search for a title → message reads "Open the Tailscale app on this device, then try again"
- [ ] Reconnect Tailscale, retry → search succeeds
- [ ] Photo of cover with Tailscale off → same actionable message in the photo flow
- [ ] Open `little-maestro.html` in Safari → no `Debug.warn is not a function` in the console
- [ ] Trigger a sync quota error to confirm `Debug.warn` lands in the diag log instead of throwing

## Note

Won't fix the underlying connectivity issue (the user already noted Tailscale was probably disconnected on the iPad), but the next time it happens the failure mode is self-explanatory.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_