### PR TITLE
learning-checks: rebuild 6 subjects whose first question was malformed (closes #260)

### DIFF
--- a/js/learning-checks.js
+++ b/js/learning-checks.js
@@ -11,9 +11,8 @@ var LearningCheck = (function() {
 
   var QUESTIONS = {
     math: [
-      { q: 'What is 12 + 15?', options: ['25', '27', '29', '30',
-      { q: 'What is 30 / 5?', options: ['5', '6', '7', '8'], answer: 1 }
-    ], answer: 1 },
+      { q: 'What is 12 + 15?', options: ['25', '27', '29', '30'], answer: 1 },
+      { q: 'What is 30 / 5?', options: ['5', '6', '7', '8'], answer: 1 },
       { q: 'What is 8 x 4?', options: ['32', '36', '40', '28'], answer: 0 },
       { q: 'What is 100 - 45?', options: ['45', '55', '65', '75'], answer: 1 },
       { q: 'What is 20 / 4?', options: ['4', '5', '6', '10'], answer: 1 },
@@ -22,10 +21,9 @@ var LearningCheck = (function() {
       { q: 'What is 6 x 6?', options: ['36', '30', '42', '48'], answer: 0 }
     ],
     music: [
-      { q: 'Which note is higher?', options: ['C4', 'G4', 'E4', 'D4',
+      { q: 'Which note is higher?', options: ['C4', 'G4', 'E4', 'D4'], answer: 1 },
       { q: 'Which note comes after C?', options: ['A', 'B', 'D', 'E'], answer: 2 },
-      { q: 'What instrument is a flute?', options: ['Brass', 'Woodwind', 'String', 'Percussion'], answer: 1 }
-    ], answer: 1 },
+      { q: 'What instrument is a flute?', options: ['Brass', 'Woodwind', 'String', 'Percussion'], answer: 1 },
       { q: 'How many beats is a whole note?', options: ['1', '2', '3', '4'], answer: 3 },
       { q: 'What is a sharp symbol (#)?', options: ['Lowers note', 'Raises note', 'Silences note', 'Lengthens note'], answer: 1 },
       { q: 'How many strings on a standard guitar?', options: ['4', '5', '6', '7'], answer: 2 },
@@ -33,10 +31,9 @@ var LearningCheck = (function() {
       { q: 'What instrument has black and white keys?', options: ['Guitar', 'Violin', 'Piano', 'Drums'], answer: 2 }
     ],
     chess: [
-      { q: 'Which piece moves in an L-shape?', options: ['Bishop', 'Rook', 'Knight', 'Pawn',
+      { q: 'Which piece moves in an L-shape?', options: ['Bishop', 'Rook', 'Knight', 'Pawn'], answer: 2 },
       { q: 'How many squares on a chessboard?', options: ['60', '64', '68', '72'], answer: 1 },
-      { q: 'Which piece moves horizontally and vertically?', options: ['Rook', 'Knight', 'Bishop', 'Pawn'], answer: 0 }
-    ], answer: 2 },
+      { q: 'Which piece moves horizontally and vertically?', options: ['Rook', 'Knight', 'Bishop', 'Pawn'], answer: 0 },
       { q: 'Can a King move two squares?', options: ['No', 'Only when castling', 'Yes', 'Only on first move'], answer: 1 },
       { q: 'Which piece can move diagonally?', options: ['Rook', 'Knight', 'Bishop', 'Pawn'], answer: 2 },
       { q: 'What is it called when a pawn reaches the other side?', options: ['Castling', 'Check', 'Promotion', 'En passant'], answer: 2 },
@@ -44,10 +41,9 @@ var LearningCheck = (function() {
       { q: 'How many pawns does each player start with?', options: ['6', '8', '10', '12'], answer: 1 }
     ],
     history: [
-      { q: 'What are the colors of the Chilean flag?', options: ['Red, White, Blue', 'Green, Yellow', 'Blue, White', 'Red, Yellow',
+      { q: 'What are the colors of the Chilean flag?', options: ['Red, White, Blue', 'Green, Yellow', 'Blue, White', 'Red, Yellow'], answer: 0 },
       { q: 'Who discovered America?', options: ['Christopher Columbus', 'Ferdinand Magellan', 'Marco Polo', 'Vasco da Gama'], answer: 0 },
-      { q: 'In what year did World War II end?', options: ['1945', '1939', '1918', '1950'], answer: 0 }
-    ], answer: 0 },
+      { q: 'In what year did World War II end?', options: ['1945', '1939', '1918', '1950'], answer: 0 },
       { q: 'Who founded Santiago in 1541?', options: ['Pedro de Valdivia', 'Bernardo O\'Higgins', 'Arturo Prat', 'Manuel Blanco'], answer: 0 },
       { q: 'In what year did Chile declare independence?', options: ['1818', '1810', '1850', '1900'], answer: 0 },
       { q: 'What ancient civilization built Machu Picchu?', options: ['Aztecs', 'Maya', 'Inca', 'Olmec'], answer: 2 },
@@ -55,10 +51,9 @@ var LearningCheck = (function() {
       { q: 'Who was the first person to walk on the moon?', options: ['Neil Armstrong', 'Yuri Gagarin', 'Buzz Aldrin', 'John Glenn'], answer: 0 }
     ],
     art: [
-      { q: 'What are the primary colors?', options: ['Red, Blue, Yellow', 'Green, Orange, Purple', 'Black, White, Gray', 'Red, Green, Blue',
+      { q: 'What are the primary colors?', options: ['Red, Blue, Yellow', 'Green, Orange, Purple', 'Black, White, Gray', 'Red, Green, Blue'], answer: 0 },
       { q: 'What are secondary colors?', options: ['Red, Blue, Yellow', 'Green, Orange, Purple', 'Black, White', 'Pink, Brown'], answer: 1 },
-      { q: 'What do you use to draw?', options: ['Hammer', 'Screwdriver', 'Pencil', 'Wrench'], answer: 2 }
-    ], answer: 0 },
+      { q: 'What do you use to draw?', options: ['Hammer', 'Screwdriver', 'Pencil', 'Wrench'], answer: 2 },
       { q: 'What tool is used to paint on a canvas?', options: ['Hammer', 'Brush', 'Wrench', 'Spoon'], answer: 1 },
       { q: 'Who painted the Mona Lisa?', options: ['Van Gogh', 'Picasso', 'Leonardo da Vinci', 'Monet'], answer: 2 },
       { q: 'Mixing red and yellow makes what color?', options: ['Green', 'Orange', 'Purple', 'Brown'], answer: 1 },
@@ -66,10 +61,9 @@ var LearningCheck = (function() {
       { q: 'What material is used to make pottery?', options: ['Wood', 'Clay', 'Metal', 'Glass'], answer: 1 }
     ],
     faith: [
-      { q: 'Who is the foster father of Jesus?', options: ['Peter', 'Paul', 'Joseph', 'John',
+      { q: 'Who is the foster father of Jesus?', options: ['Peter', 'Paul', 'Joseph', 'John'], answer: 2 },
       { q: 'Who was the first Pope?', options: ['Paul', 'John', 'Peter', 'James'], answer: 2 },
-      { q: 'Where did Jesus grow up?', options: ['Nazareth', 'Bethlehem', 'Jerusalem', 'Rome'], answer: 0 }
-    ], answer: 2 },
+      { q: 'Where did Jesus grow up?', options: ['Nazareth', 'Bethlehem', 'Jerusalem', 'Rome'], answer: 0 },
       { q: 'What prayer begins with "Our Father"?', options: ['Hail Mary', 'Gloria', 'Lord\'s Prayer', 'Creed'], answer: 2 },
       { q: 'How many apostles did Jesus have?', options: ['10', '12', '14', '7'], answer: 1 },
       { q: 'Who was the mother of Jesus?', options: ['Elizabeth', 'Mary', 'Martha', 'Ruth'], answer: 1 },


### PR DESCRIPTION
Closes #260.

## Summary

Rebuilds the first question in six of seven `QUESTIONS.<subject>` blocks that were silently corrupted: `math`, `music`, `chess`, `history`, `art`, `faith`. In each, the first question's `options:` array was missing its closing `]` and `}`, so the next 1–2 question objects were parsed as nested array elements of that broken `options`. The file passed `node -c` because mixing strings and objects in an array is legal JS — but at runtime the first question rendered 6 options (4 strings + 2 `[object Object]`) with the answer index pointing at the wrong slot.

Each first question is restored to the obvious intended shape (4-string `options`, integer `answer` in `0..3`). Answers spot-checked against the prompt:

| Subject | Question | Correct | Index |
|---|---|---|---|
| math | 12 + 15 = ? | 27 | 1 |
| music | Highest of C4/G4/E4/D4 | G4 | 1 |
| chess | L-shape mover | Knight | 2 |
| history | Chilean flag colors | Red, White, Blue | 0 |
| art | Primary colors | Red, Blue, Yellow | 0 |
| faith | Foster father of Jesus | Joseph | 2 |

## Test plan

A scripted shape check (re-evaluating the literal in `vm`) confirms all 56 questions across 7 subjects now satisfy:
- `options` is an array of exactly 4 strings
- `answer` is a number in `0..3`

```
OK  math (8 questions)
OK  music (8 questions)
OK  chess (8 questions)
OK  history (8 questions)
OK  art (8 questions)
OK  faith (8 questions)
OK  general (8 questions)

All good.
```

## Note

Worth filing a follow-up to add this shape check as a CI step so a regression of this kind would fail the build instead of silently shipping. Out of scope for this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_