### PR TITLE
BMC: re-entry guard so double-taps don't trigger "video already playing"

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -457,6 +457,12 @@ var BMC = (function() {
   // ISBN-13 / EAN-13 directly from the rear-camera video feed.
   var _zxingReader = null;
   function _startZxingScan() {
+    // Re-entry guard. If the kid taps "Scan ISBN" while a scan is
+    // already running, the second decodeFromConstraints call ends up
+    // invoking video.play() on an already-playing element, which Safari
+    // logs as "Trying to play video that is already playing." Just bail.
+    if (_scanActive) return;
+
     var modal = document.getElementById('bmc-scan-modal');
     var video = document.getElementById('bmc-scan-video');
     var hint = document.getElementById('bmc-scan-hint');
@@ -516,6 +522,7 @@ var BMC = (function() {
   }
 
   function _startScan(formats) {
+    if (_scanActive) return;  // re-entry guard, see _startZxingScan
     var modal = document.getElementById('bmc-scan-modal');
     var video = document.getElementById('bmc-scan-video');
     var hint = document.getElementById('bmc-scan-hint');


### PR DESCRIPTION
Diag follow-up to #262.

## What the diag showed

After the iPad scanner shipped, the next 24h of diag captured **11 "Trying to play video that is already playing." warnings from 2 users** on `book-movie-check.html`. Reproduces by tapping "Scan ISBN" twice in quick succession (or after the modal is already open) — the second `decodeFromConstraints` call ends up invoking `video.play()` on an already-playing element, which Safari logs as a warning. That warning then bubbles up through `console.warn` and into the diag log.

## The fix

Bail early in `_startZxingScan` and `_startScan` when `_scanActive` is already `true`. The kid only ever sees one viewfinder, the redundant `play()` is never called, and the diag stays clean.

## What's also in the diag (not addressed here)

- **"Fetch is aborted"** on Photo lookup (×2) and ISBN lookup (×5): these are the 20 s `_fetchJson` timeouts firing. The kid already sees a "search timed out" message via `_userMsgForFetchErr` from #259. Not a code bug — VPS / network speed.
- **Old "Load failed" entries** from May 5: pre-#259, will age out of the 72 h window soon.

## Test plan

- [ ] Tap "Scan ISBN" twice in a row on iPad → only one viewfinder, no console warning
- [ ] Tap "Scan ISBN" with modal already open → no-op (safe), no warning
- [ ] Single-tap scan → still works as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_