### PR TITLE
little-maestro: wrap deferred MIDI callbacks so the diag captures real context

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -7852,20 +7852,29 @@ const MIDIManager = (() => {
   // ── internal: scan all inputs and connect to best one ──
   function _scanInputs() {
     if (!_access) return;
-    const best = _findBestInput(_access.inputs);
-    if (best) {
-      _connectInput(best);
-    } else {
-      if (_activeInput) { try { _activeInput.onmidimessage = null; } catch(e) {} }
-      _activeInput = null;
-      _deviceName  = null;
-      _status      = 'disconnected';
-      _updateStatusUI();
-      _notifyStatusChange();
-      document.querySelectorAll('.lesson-panel--keyboard').forEach(el => el.classList.remove('midi-connected'));
-      _updateMidiBanner();
-      // Auto-retry if we had a connection and lost it
-      _scheduleRetry();
+    try {
+      const best = _findBestInput(_access.inputs);
+      if (best) {
+        _connectInput(best);
+      } else {
+        if (_activeInput) { try { _activeInput.onmidimessage = null; } catch(e) {} }
+        _activeInput = null;
+        _deviceName  = null;
+        _status      = 'disconnected';
+        _updateStatusUI();
+        _notifyStatusChange();
+        document.querySelectorAll('.lesson-panel--keyboard').forEach(el => el.classList.remove('midi-connected'));
+        _updateMidiBanner();
+        // Auto-retry if we had a connection and lost it
+        _scheduleRetry();
+      }
+    } catch (e) {
+      // _scanInputs runs deferred (setTimeout from onstatechange and from
+      // the retry timer). An uncaught throw here surfaces in the diag as
+      // a window.onerror at the .then() closing brace — useless to debug.
+      // Capture the real message and surface it through Debug instead.
+      if (typeof Debug !== 'undefined') Debug.error('[MIDI] _scanInputs threw: ' + (e && e.message));
+      try { _status = 'disconnected'; _updateStatusUI(); _notifyStatusChange(); } catch (e2) {}
     }
   }
 
@@ -7881,13 +7890,17 @@ const MIDIManager = (() => {
     _logEvent(`Retry ${_retryCount}/${MAX_RETRIES} in ${delay/1000}s...`);
     clearTimeout(_retryTimer);
     _retryTimer = setTimeout(() => {
-      if (_status !== 'connected') {
-        _scanInputs();
-        // If still not connected after scan, try full re-init
-        if (_status !== 'connected' && _access) {
-          _access.onstatechange = null;
-          init();
+      try {
+        if (_status !== 'connected') {
+          _scanInputs();
+          // If still not connected after scan, try full re-init
+          if (_status !== 'connected' && _access) {
+            _access.onstatechange = null;
+            init();
+          }
         }
+      } catch (e) {
+        if (typeof Debug !== 'undefined') Debug.error('[MIDI] retry timer threw: ' + (e && e.message));
       }
     }, delay);
   }


### PR DESCRIPTION
## What the diag showed

Last 72 h surfaced one recurring entry on `little-maestro.html`:

```
TypeError: undefined is not an object (near '...})...')
  filename: little-maestro.html
  lineno: 7997, colno: 9
```

Line 7997 is the closing brace of the `requestMIDIAccess().then(access => { ... })` arrow function. The error has hit four times across a week, always with this exact same stack-less pattern. The `.then().catch(...)` chain at lines 7970–8020 should be eating it but isn't, which means the throw is happening in code that *was* scheduled inside the `.then()` body but actually runs **later** — outside the chain.

Two such call sites were unwrapped:

- `setTimeout(_scanInputs, 400)` inside `_access.onstatechange` (line 7983)
- The `setTimeout(() => { _scanInputs(); init(); }, delay)` body in `_scheduleRetry` (line 7883)

A throw inside either becomes a `window.onerror` whose `lineno` Safari maps back to the `.then()` closing brace — useless to debug.

## Fix

Wrap `_scanInputs()` and the retry-timer body in `try/catch`. On error:

- The kid lands in a graceful `'disconnected'` state instead of a bare crash
- The actual error message goes through `Debug.error('[MIDI] _scanInputs threw: …')`, which the diag pipeline now captures with **real** context — so the next occurrence will tell us which property of which object was undefined

This doesn't paper over the underlying defect. It just stops the throw from being misattributed and gives us the breadcrumbs to fix the root cause when it happens again.

## Test plan

- [ ] Open `little-maestro.html` on a desktop with no MIDI device → status pill shows "Piano Not Connected", retry loop runs, no console errors
- [ ] Plug in a MIDI keyboard during the retry loop → connects normally
- [ ] Hot-unplug the keyboard while playing → status flips to disconnected, retry loop restarts cleanly
- [ ] On a browser without MIDI support → status pill shows "Use Chrome for MIDI", no retry storms


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_