### PR TITLE
little-maestro: clear end-of-song overlay before replaying a song

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -9249,6 +9249,12 @@ document.addEventListener('DOMContentLoaded', () => {
       const section = document.getElementById('screen-lesson');
       if (!hw) return;
 
+      // Idempotent: if a previous star screen is still in the DOM (e.g.
+      // an animation-loop race fired this twice), drop it before adding
+      // a fresh one so two overlays don't stack.
+      const prev = document.getElementById('fn-star-screen');
+      if (prev) prev.remove();
+
       // Expand highway to cover full lesson section so nothing clips
       if (section) hw.style.height = section.offsetHeight + 'px';
 
@@ -11577,7 +11583,13 @@ document.addEventListener('DOMContentLoaded', () => {
       // ══════════════════════════════════════════════════════════
       function _startPhase2() {
         // Hide the falling notes highway if it was visible from a previous phase 4
-        if (typeof FallingNotes !== 'undefined') FallingNotes.hide();
+        if (typeof FallingNotes !== 'undefined') {
+          FallingNotes.hide();
+          // hide() only adds a CSS class to the highway. The end-of-song
+          // overlay lives inside that highway, so it'd come back the next
+          // time .show() runs unless we drop the DOM node here.
+          FallingNotes.hideStarScreen();
+        }
         _s.phase      = 2;
         _s.listenCount = 0;
 
@@ -11602,6 +11614,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
       function _playListen() {
         _stopPlayback();
+        // Clean up any leftover end-of-song overlay so the listen-mode
+        // sheet/ball isn't drawn underneath an "AMAZING! 🌟" screen.
+        if (typeof FallingNotes !== 'undefined') FallingNotes.hideStarScreen();
         _createBall();
 
         // Ensure AudioContext is running — it's suspended until a user gesture


### PR DESCRIPTION
## What the kids reported

> "Little Piano has some bugs after you finish playing a song"

## Root cause

After a song completes, `_showStarScreen()` appends an end-of-song overlay (`#fn-star-screen` — "AMAZING! 🌟" / "Nice Work! 👍") inside the falling-notes highway. The "↺ Play Again" button opens a mode picker with three options:

| Mode | Replay function | Cleaned up the overlay? |
|---|---|---|
| 🎮 Piano Hero | `_doPlayAlong` | ✅ — calls `FallingNotes.hideStarScreen()` (line 11831) |
| 🎧 Listen to the Song | `_playListen` | ❌ — never cleaned up. **This is the visible bug.** |
| 🎼 Read Sheet Music | `_startPhase2` | Partial — `FallingNotes.hide()` only adds a CSS class to the parent highway, masking the overlay but leaving the DOM node attached. It reappears the next time the highway is shown. |

So when a kid taps Play Again → 🎧 Listen, the song restarts but the "AMAZING!" star screen is still rendered on top of the sheet music and bouncing ball.

## Fix

1. Call `FallingNotes.hideStarScreen()` at the entry of both `_playListen` and `_startPhase2` so every replay path leaves a clean slate.
2. Make `_showStarScreen()` idempotent: if a previous overlay is still attached, drop it before appending a fresh one. Defends against an animation-loop race that would otherwise stack two overlays.

Three small, focused edits in `little-maestro.html`. No new dependencies, no API changes.

## Test plan

- [ ] Finish a Piano Hero song → tap Play Again → 🎧 Listen → song plays cleanly, no star screen visible
- [ ] Finish a Piano Hero song → tap Play Again → 🎼 Read Sheet Music → sheet view shows cleanly, no star screen visible
- [ ] Finish a Piano Hero song → tap Play Again → 🎮 Piano Hero → falling notes replay (regression check — should still work as before)
- [ ] Finish two songs back-to-back without leaving the lesson → only one star overlay visible at a time


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_