### PR TITLE
little-maestro: catch shim-MIDI null-access and surface real init errors

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -7982,31 +7982,52 @@ const MIDIManager = (() => {
 
     return navigator.requestMIDIAccess({ sysex: false })
       .then(access => {
-        if (typeof Debug !== 'undefined') Debug.log('[MIDI] Access granted');
-        _access = access;
-        _scanInputs();
-
-        // Hot-plug: fires when any MIDI device connects or disconnects
-        _access.onstatechange = (event) => {
-          try {
-            if (event && event.port && event.port.type === 'input') {
-              if (typeof Debug !== 'undefined') Debug.log('[MIDI] State change: ' + event.port.name + ' is ' + event.port.state);
-              _logEvent(`Device ${event.port.state}: ${event.port.name}`);
-              // Delay to let device fully initialize
-              setTimeout(_scanInputs, 400);
-            }
-          } catch(e) {
-            if (typeof Debug !== 'undefined') Debug.error('[MIDI] onstatechange failed', e.message);
+        try {
+          if (typeof Debug !== 'undefined') Debug.log('[MIDI] Access granted');
+          // Guard against shim MIDI environments (e.g. iOS WebMIDIBrowser
+          // wrappers) that resolve with null/undefined instead of rejecting.
+          // Without this, `_access.onstatechange = ...` on the next line
+          // throws "undefined is not an object" and Safari attributes the
+          // error to the .then() close, which is useless to diagnose.
+          if (!access || typeof access !== 'object') {
+            throw new Error('requestMIDIAccess resolved without a MIDIAccess object');
           }
-        };
+          _access = access;
+          _scanInputs();
 
-        // If no device found on first init, start auto-retry
-        if (_status !== 'connected') {
-          if (typeof Debug !== 'undefined') Debug.log('[MIDI] No device found, starting retry loop');
-          _scheduleRetry();
+          // Hot-plug: fires when any MIDI device connects or disconnects
+          _access.onstatechange = (event) => {
+            try {
+              if (event && event.port && event.port.type === 'input') {
+                if (typeof Debug !== 'undefined') Debug.log('[MIDI] State change: ' + event.port.name + ' is ' + event.port.state);
+                _logEvent(`Device ${event.port.state}: ${event.port.name}`);
+                // Delay to let device fully initialize
+                setTimeout(_scanInputs, 400);
+              }
+            } catch(e) {
+              if (typeof Debug !== 'undefined') Debug.error('[MIDI] onstatechange failed', e.message);
+            }
+          };
+
+          // If no device found on first init, start auto-retry
+          if (_status !== 'connected') {
+            if (typeof Debug !== 'undefined') Debug.log('[MIDI] No device found, starting retry loop');
+            _scheduleRetry();
+          }
+
+          return _status === 'connected';
+        } catch (bodyErr) {
+          // Any sync throw inside the .then() callback gets attributed to
+          // the closing brace of the arrow function by Safari, which
+          // surfaces in the diag as a useless lineno-only entry. Log the
+          // real message and fall through to the disconnected path so the
+          // kid still gets a working "Reconnect" button.
+          const m = bodyErr && bodyErr.message ? bodyErr.message : String(bodyErr);
+          if (typeof Debug !== 'undefined') Debug.error('[MIDI] init body threw: ' + m);
+          _status = 'disconnected';
+          try { _updateStatusUI(); _notifyStatusChange(); _updateMidiBanner(); } catch (e) {}
+          return false;
         }
-
-        return _status === 'connected';
       })
       .catch(err => {
         const errMsg = err ? (err.message || err.name || 'Unknown error') : 'Unknown error';


### PR DESCRIPTION
## What the diag keeps showing

Even after PR #265 wrapped `_scanInputs` and the retry timer, the diag is still capturing a recurring `TypeError: undefined is not an object` attributed to the closing brace of `requestMIDIAccess().then(access => { ... })`. The count has now hit **×3** for the same fingerprint, across multiple kid sessions.

## What's almost certainly happening

Safari attributes any sync throw inside a `.then()` arrow function to its closing brace. PR #265 covered the obvious culprits (`_scanInputs`, the retry timer) but left two paths bare:

- `_access = access` then `_access.onstatechange = ...` — if `access` is `null`/`undefined`, the assignment throws `"undefined is not an object"`. Shim MIDI environments (e.g. iOS WebMIDIBrowser-style wrappers) are known to resolve the promise without a `MIDIAccess` object.
- Any other throw inside the `.then()` body had no diagnostic context.

## Fix

1. **Detect shim/null resolution explicitly** and throw a *named* error before the `.onstatechange` assignment can blow up:
   ```
   if (!access || typeof access !== 'object') {
     throw new Error('requestMIDIAccess resolved without a MIDIAccess object');
   }
   ```
2. **Wrap the whole `.then()` body in try/catch** and route any throw to `Debug.error('[MIDI] init body threw: …')` so the diag picks up the actual message instead of just a `lineno`. The kid lands in the `'disconnected'` state with a working Reconnect button instead of an uncaught error.

This doesn't paper over the defect — the throw is still logged. It just makes the next occurrence actionable.

## Test plan

- [ ] Open `little-maestro.html` on Chrome with no MIDI device → normal disconnected state, retry loop runs
- [ ] Open on Safari (which doesn't support Web MIDI) → falls into the existing `unsupported` branch above the `.then()`; no regression
- [ ] Simulate shim resolving to `null` by temporarily injecting `Promise.resolve(null)` in place of `requestMIDIAccess()` → diag entry reads `"[MIDI] init body threw: requestMIDIAccess resolved without a MIDIAccess object"`, UI shows disconnected, Reconnect button works
- [ ] Hot-unplug a connected keyboard → status flips to disconnected cleanly (regression check for PR #265's path)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_