### PR TITLE
little-maestro: guard against WebMIDIBrowser-style non-Promise returns

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -7980,7 +7980,35 @@ const MIDIManager = (() => {
 
     _logEvent('Requesting MIDI access...');
 
-    return navigator.requestMIDIAccess({ sysex: false })
+    // Some iOS MIDI shim apps (e.g. WebMIDIBrowser 1.0.6) define
+    // navigator.requestMIDIAccess but either return undefined or throw
+    // synchronously instead of returning a Promise. In both cases the
+    // subsequent .then() would throw "undefined is not an object" and
+    // Safari would attribute the error to the .then() close brace,
+    // bypassing every try/catch inside the callback. Guard explicitly
+    // here so we degrade to the unsupported state instead of crashing.
+    let _accessPromise;
+    try {
+      _accessPromise = navigator.requestMIDIAccess({ sysex: false });
+    } catch (syncErr) {
+      const m = syncErr && syncErr.message ? syncErr.message : String(syncErr);
+      if (typeof Debug !== 'undefined') Debug.error('[MIDI] requestMIDIAccess threw synchronously: ' + m);
+      _status = 'unsupported';
+      _updateStatusUI();
+      _notifyStatusChange();
+      _updateMidiBanner();
+      return Promise.resolve(false);
+    }
+    if (!_accessPromise || typeof _accessPromise.then !== 'function') {
+      if (typeof Debug !== 'undefined') Debug.error('[MIDI] requestMIDIAccess did not return a Promise (shim?)');
+      _status = 'unsupported';
+      _updateStatusUI();
+      _notifyStatusChange();
+      _updateMidiBanner();
+      return Promise.resolve(false);
+    }
+
+    return _accessPromise
       .then(access => {
         try {
           if (typeof Debug !== 'undefined') Debug.log('[MIDI] Access granted');


### PR DESCRIPTION
## Root cause finally pinned

Pulled the full day-archive entry from the `diag` branch and got the stack + UA:

```
init@little-maestro.html:8031:9
@little-maestro.html:8255:19
ua: Mozilla/5.0 (iPad; CPU OS 16_7_15 ...) WebMIDIBrowser/1.0.6
```

**WebMIDIBrowser** is a third-party iOS shim app that ships its own Web MIDI polyfill. Its `navigator.requestMIDIAccess({ sysex: false })` does **not** return a Promise — it returns `undefined` (or throws synchronously). The very next call, `.then(...)`, then throws `"undefined is not an object"`. Safari attributes the throw to the closing brace of the `.then()` callback, which is why PR #265 and PR #269's try/catch inside the callback could never catch it.

## Fix

Wrap the `requestMIDIAccess()` call itself in try/catch, then check that the return value is thenable before calling `.then()`. In either failure mode:

- Log to `Debug.error` with the actual reason ("threw synchronously" vs. "did not return a Promise")
- Set `_status = 'unsupported'` and update the UI, mirroring the existing `!navigator.requestMIDIAccess` branch
- Return `Promise.resolve(false)` so the DOMContentLoaded handler still gets its expected `.then(granted => …)`

Result: kids on WebMIDIBrowser land in the "Use Chrome for MIDI" pill instead of an uncaught crash.

## Files

- `little-maestro.html` — one block of guard logic added before the existing `.then().catch()` chain

## Test plan

- [ ] Normal Chrome with no MIDI device → still hits the disconnected/retry path (regression check)
- [ ] Normal Chrome with a MIDI keyboard plugged in → still connects (regression check)
- [ ] Manually inject `navigator.requestMIDIAccess = () => undefined` in DevTools and reload → status shows "Use Chrome for MIDI" pill, console shows `[MIDI] requestMIDIAccess did not return a Promise (shim?)`, no uncaught error
- [ ] Manually inject `navigator.requestMIDIAccess = () => { throw new Error('shim'); }` → same result, console shows `[MIDI] requestMIDIAccess threw synchronously: shim`


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_