### PR TITLE
docs: Clarify Chores System token value in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A core feature of the Zavala Serra Apps suite is helping kids develop healthy di
 
 - **Daily Play Timer (Temporizador Diario)**: Cada perfil tiene un límite diario (por defecto 20 minutos) para fomentar descansos. Al terminar el tiempo, la pantalla se bloquea de forma amigable. *Nota: Las aplicaciones de actividad física como "Sports Arena" no consumen tiempo de pantalla.* (Note: Physical activity apps like "Sports Arena" do not consume screen time.)
 - **Daily Limits (Límites Diarios)**: Los padres pueden configurar límites específicos por aplicación o niño desde el Panel de Padres.
-- **Chores System (Sistema de Tareas)**: Cuando se acaba el tiempo, los niños pueden ganar tiempo extra (tokens) completando tareas del mundo real (ej. "Hacer la cama", "Leer 20 minutos"). Un PIN de padres es requerido para aprobar el tiempo extra.
+- **Chores System (Sistema de Tareas)**: Cuando se acaba el tiempo, los niños pueden ganar tiempo extra (tokens) completando tareas del mundo real (ej. "Hacer la cama", "Leer 20 minutos"). Un PIN de padres es requerido para aprobar el tiempo extra (1 token = 5 minutos extra).
 - **Smart Schedule (Horario Inteligente)**: Rotación automática diaria de aplicaciones sugeridas para fomentar una dieta equilibrada de aprendizaje y evitar la fatiga de decisiones. (Automatic daily rotation of suggested apps to encourage a balanced learning diet).
 - **Privacidad Local (Local Privacy)**: Todos los datos, progresos y tiempos de uso se almacenan localmente en el dispositivo (`localStorage`). (All data and progress are stored locally on the device, ensuring maximum family privacy).
 


### PR DESCRIPTION
Updates the "Family Safety & Balance" section in `README.md` to explicitly state that 1 Adventure Token equals 5 extra minutes of play time in the Chores System, as verified from `js/chores.js`.

---
*PR created automatically by Jules for task [9239541338340988541](https://jules.google.com/task/9239541338340988541) started by @rozavala*