### PR TITLE
sw + world-cup: bust cached JS/CSS so users get the real schedule

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -13,7 +13,7 @@
 
 'use strict';
 
-const CACHE_VERSION = 'zs-suite-v7';
+const CACHE_VERSION = 'zs-suite-v8';
 const CORE_CACHE = CACHE_VERSION + '-core';
 const ASSETS_CACHE = CACHE_VERSION + '-assets';
 const FONTS_CACHE = CACHE_VERSION + '-fonts';

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css">
+  <link rel="stylesheet" href="css/world-cup.css?v=3">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -59,6 +59,6 @@
     <div class="modal-inner"></div>
   </div>
 
-  <script src="js/world-cup.js"></script>
+  <script src="js/world-cup.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Users who'd visited `world-cup.html` previously were still seeing the **old placeholder-fixture** build of `js/world-cup.js`, even after the OpenFootball-backed real schedule landed on main (PR #283).

**Root cause:** `sw.js` uses `_staleWhileRevalidate` for same-origin static assets — it serves the cached JS immediately and updates the cache in the background, so the new bundle doesn't run until the *next* page load. With the kid-app PWA model many users never get that next load before opening the app again.

## Fix
- `world-cup.html`: bump asset URLs to `js/world-cup.js?v=3` and `css/world-cup.css?v=3` — different URL → SW cache miss → fresh fetch on the next visit
- `sw.js`: bump `CACHE_VERSION` `v7 → v8` so the old `zs-suite-v7-*` caches are evicted on the new SW's `activate` event

## Verify
- [ ] On a previously-cached install, opening world-cup.html shows the real Levi's matches (Qatar v Switzerland on Jun 13, etc.) on first reload
- [ ] DevTools → Application → Cache Storage no longer lists `zs-suite-v7-*` after the new SW activates
- [ ] Other apps (little-maestro, etc.) still load normally

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_