### PR TITLE
World Cup Home: fix ReferenceError that left the page blank

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2803,6 +2803,7 @@
       todayHTML = '<div class="empty">All 104 matches played — final whistle has blown!</div>';
     }
 
+    const preTournament = days > 0;
     const tourneyOver = !next && todays.length === 0;
 
     root.innerHTML = `

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=7">
+  <link rel="stylesheet" href="css/world-cup.css?v=8">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -63,6 +63,6 @@
 
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
-  <script src="js/world-cup.js?v=7"></script>
+  <script src="js/world-cup.js?v=8"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Hotfix for a regression from PR #288 that left the World Cup Home tab blank.

### Cause
PR #288 removed the "Next up" card and the `const preTournament = days > 0;` declaration along with it — but the template literal further down still references `preTournament` to decide whether to render the kickoff-countdown card. Touching an undeclared `let`/`const` binding inside the template throws a `ReferenceError`, so `root.innerHTML = ...` never executed and the page came up empty.

### Fix
Re-declare `preTournament` before the template. One-line fix. Cache bumped to `?v=8`.

## Test plan
- [ ] Hard refresh world-cup.html — Home renders again with countdown + next match + history + remaining cards
- [ ] No errors in console
- [ ] Other tabs unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_