### PR TITLE
World Cup: fix QuotaExceededError storm reported in diag

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2225,23 +2225,121 @@
     picks: {}, // memberId -> { champion, runnerUp, goldenBoot, ko: { R32: {matchId: code}, R16:..., QF:..., SF:..., Final:... }, groupWinners: { A: code, B: code, ... }, groupRunnersUp: { A: code, ... } }
   };
 
+  // Fields that can be mutated per match (vs the canonical OpenFootball
+  // baseline). Anything else stays read-only at the OFFICIAL_SCHEDULE level.
+  const MATCH_OVERRIDE_FIELDS = ['home', 'away', 'date', 'time', 'venue', 'result'];
+
+  function _scheduleBaseline(id) {
+    return OFFICIAL_SCHEDULE.find(x => x.id === id);
+  }
+  function _diffGroups() {
+    for (const g of GROUP_LETTERS) {
+      const a = (state.groups[g] || []).slice().sort().join(',');
+      const b = (defaultGroups[g] || []).slice().sort().join(',');
+      if (a !== b) return state.groups;
+    }
+    return null;
+  }
+  function _diffMatches() {
+    const overrides = {};
+    for (const m of state.matches) {
+      const base = _scheduleBaseline(m.id);
+      if (!base) continue;
+      const diff = {};
+      for (const k of MATCH_OVERRIDE_FIELDS) {
+        const mv = m[k] === undefined ? null : m[k];
+        const bv = base[k] === undefined ? null : base[k];
+        if (JSON.stringify(mv) !== JSON.stringify(bv)) diff[k] = m[k];
+      }
+      if (Object.keys(diff).length > 0) overrides[m.id] = diff;
+    }
+    return Object.keys(overrides).length > 0 ? overrides : null;
+  }
+
   function load() {
+    // Always re-seed matches from the canonical schedule so we don't carry
+    // 30KB of redundant fixture data through every save cycle.
+    state.matches = JSON.parse(JSON.stringify(OFFICIAL_SCHEDULE));
+    state.groups = JSON.parse(JSON.stringify(defaultGroups));
+
     try {
       const raw = localStorage.getItem(STORE_KEY);
-      if (raw) {
-        const saved = JSON.parse(raw);
-        // shallow merge — keep canonical groups/matches if saved missing
-        state = Object.assign(state, saved);
-        if (!state.groups || Object.keys(state.groups).length === 0) state.groups = defaultGroups;
-        if (!state.matches || state.matches.length === 0) state.matches = defaultMatches;
+      if (!raw) return;
+      const saved = JSON.parse(raw);
+
+      if (saved.groups && Object.keys(saved.groups).length > 0) {
+        state.groups = saved.groups;
       }
+
+      // New slim shape — matchOverrides keyed by match id
+      if (saved.matchOverrides && typeof saved.matchOverrides === 'object') {
+        for (const id of Object.keys(saved.matchOverrides)) {
+          const m = state.matches.find(x => x.id === id);
+          if (!m) continue;
+          const diff = saved.matchOverrides[id] || {};
+          for (const k of MATCH_OVERRIDE_FIELDS) {
+            if (k in diff) m[k] = diff[k];
+          }
+        }
+      }
+
+      // Back-compat: old payloads stored the whole matches array inline.
+      if (Array.isArray(saved.matches)) {
+        for (const sm of saved.matches) {
+          if (!sm || !sm.id) continue;
+          const m = state.matches.find(x => x.id === sm.id);
+          if (!m) continue;
+          const base = _scheduleBaseline(sm.id);
+          for (const k of MATCH_OVERRIDE_FIELDS) {
+            if (k in sm) {
+              const sv = sm[k] === undefined ? null : sm[k];
+              const bv = base && base[k] !== undefined ? base[k] : null;
+              if (JSON.stringify(sv) !== JSON.stringify(bv)) m[k] = sm[k];
+            }
+          }
+        }
+      }
+
+      state.members = Array.isArray(saved.members) ? saved.members : [];
+      state.picks = (saved.picks && typeof saved.picks === 'object') ? saved.picks : {};
+      state.uiSelectedMember = saved.uiSelectedMember || null;
     } catch (e) { console.warn('wc load failed', e); }
   }
+
+  // Throttle save() so a flurry of edits doesn't write 20 times in a row,
+  // and persist only diffs to keep the payload tiny.
+  let _saveTimer = null;
+  let _lastQuotaWarn = 0;
   function save() {
-    try { localStorage.setItem(STORE_KEY, JSON.stringify(state)); }
-    catch (e) { console.warn('wc save failed', e); }
-    // Best-effort cross-device sync (no-op if CloudSync not loaded/online)
-    try { if (window.CloudSync && CloudSync.online && CloudSync.push) CloudSync.push(STORE_KEY); } catch (e) {}
+    if (_saveTimer) return;
+    _saveTimer = setTimeout(() => {
+      _saveTimer = null;
+      const slim = {
+        members: state.members,
+        picks: state.picks,
+        uiSelectedMember: state.uiSelectedMember || null,
+      };
+      const gd = _diffGroups();
+      if (gd) slim.groups = gd;
+      const md = _diffMatches();
+      if (md) slim.matchOverrides = md;
+
+      try {
+        localStorage.setItem(STORE_KEY, JSON.stringify(slim));
+      } catch (e) {
+        // Quota exceeded — surface once per minute instead of spamming.
+        const now = Date.now();
+        if (now - _lastQuotaWarn > 60000) {
+          _lastQuotaWarn = now;
+          console.warn('wc save failed', e);
+          if (typeof toast === 'function') {
+            toast('⚠️ Storage full — clear another app\'s data to keep saving picks.');
+          }
+        }
+      }
+      // Best-effort cross-device sync (no-op if CloudSync not loaded/online)
+      try { if (window.CloudSync && CloudSync.online && CloudSync.push) CloudSync.push(STORE_KEY); } catch (e) {}
+    }, 200);
   }
 
   /* ----------------------------------------------------------------

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=8">
+  <link rel="stylesheet" href="css/world-cup.css?v=10">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -64,6 +64,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=8"></script>
+  <script src="js/world-cup.js?v=10"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Diag report on `origin/diag` (latest refresh 2026-05-17T15:40 UTC):
> **`world-cup.html` console.warn (131x): "wc save failed: The quota has been exceeded."** — 2 users affected, 72-hour window

**Cause:** `save()` serialized the entire `state` object on every write — including the full 104-match schedule duplicated from `OFFICIAL_SCHEDULE` (~30KB). With other apps in the suite using their share of the 5MB localStorage budget, the WC payload was tipping users over the limit, and every subsequent edit retriggered the warning.

## Fix — three changes
1. **Persist diffs only.** `matches[]` is re-seeded from `OFFICIAL_SCHEDULE` on every load; the stored payload is now `{ members, picks, uiSelectedMember, matchOverrides?, groups? }`. After one score edit: **144 bytes** (vs ~30KB before).
2. **Throttle `save()`** so a flurry of pick changes coalesces into a single write 200ms later.
3. **Friendly quota notice.** When quota is exceeded, a user-visible toast appears ("⚠️ Storage full — clear another app's data to keep saving picks.") and subsequent warnings within 60s are suppressed instead of spamming `console.warn`.

## Back-compat
Old inline-matches payloads still load — the back-compat path picks up any non-baseline fields, and the next `save()` automatically rewrites storage in the slim format. No data migration needed; the storage key stays `wc2026.v2`.

## Verified locally via puppeteer
```
Stored payload: {"members":[],"picks":{},"uiSelectedMember":null,"matchOverrides":{"m001":{"result":{"home":2,"away":1,"pkWinner":null}}}}
Matches tab shows 2-1 after reload: true
Old inline-matches payload migrates cleanly: true
Old m002 result 0-3 carried over: true
Errors: 0
```

Cache bumped to `?v=10`.

## Test plan
- [ ] Open World Cup, edit a few results → localStorage entry should be a few hundred bytes, not tens of KB
- [ ] Reload → results survive
- [ ] If quota is exhausted by other apps, the warning shows as a single toast (not 100+ console.warns)
- [ ] Existing users with v1 inline-matches payloads still see their data after upgrade

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_