### PR TITLE
little-maestro: remove </script> inside keepsake template literal (fixes leaked code on screen)

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -15476,7 +15476,7 @@ document.addEventListener('DOMContentLoaded', () => {
       Exported ${new Date().toLocaleDateString()}
     </div>
   </div>
-  <script src="js/pwa.js"></script>
+  <!-- pwa.js intentionally omitted — keepsake is a standalone export -->
 
 </body>
 </html>`;


### PR DESCRIPTION
## What the screenshot showed

The kid's iPad displayed raw JavaScript source on every Little Maestro page, starting with:

```
; const blob = new Blob([html], { type: 'text/html' }); const url = URL.createObjectURL(blob); ...
function importUser(file) { return new Promise((resolve, reject) => { ...
```

…visible at the bottom of the lesson screen, the next-song-unlocked overlay, the piano keyboard view — everywhere.

## Root cause

Line 15479 had a literal `<script src="js/pwa.js"></script>` **inside a JavaScript template literal** that builds the kid's keepsake HTML export. The HTML parser doesn't see JS string boundaries — when it scans the inline `<script>` block and hits `</script>`, it closes the tag at that exact byte offset and renders every subsequent byte as body text. Everything after the keepsake's pwa.js reference (the rest of `exportKeepsake`, `importUser`, `_doImport`, etc.) was being dumped onto the page.

## Fix

Removed the offending `<script>` line from the keepsake template. The keepsake is a one-shot exported HTML file the kid downloads — pwa.js registration would fail from `file://` anyway, so dropping it loses nothing. Replaced with an explanatory comment so a future reader understands why it's missing.

After this change, the file has **zero** mid-inline-script `</script>` sequences. All 25 remaining `</script>` tags are legitimate script-tag boundaries.

## Test plan

- [ ] Open `little-maestro.html` on iPad/Safari and Chrome — no leaked code at the bottom of any view
- [ ] Finish a song → star screen, parent review, next-song reveal all render normally
- [ ] Trigger the keepsake export from Parents Corner → downloaded HTML file opens correctly without the missing pwa.js script
- [ ] `grep '</script>' little-maestro.html` returns only legitimate tag closures


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_