### PR TITLE
Update content across learning modules

### DIFF
--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -331,6 +331,9 @@ const QB={
     {q:'¿En qué región se encuentra el desierto de Atacama?',a:'Norte Grande',o:['Norte Grande','Zona Central','Patagonia','Sur'], tier:'beginner'}
   ],
   antartica:[
+    {q:'¿En qué mes es más cálido en la Antártica chilena?',a:'Enero',o:['Enero','Julio','Agosto','Septiembre'], tier:'beginner'},
+    {q:'¿Cómo se llama la base militar chilena más antigua en la Antártica?',a:'Base Prat',o:['Base Prat','Base O\'Higgins','Base Frei','Base Escudero'], tier:'advanced'},
+    {q:'¿Qué continente está más cerca de la Antártica?',a:'América del Sur',o:['América del Sur','África','Oceanía','Europa'], tier:'intermediate'},
     {q:'¿Cuál es la temperatura media en el interior de la Antártica?',a:'Bajo cero',o:['Bajo cero','10 grados','20 grados','30 grados'], tier:'intermediate'},
     {q:'¿Qué océano rodea la Antártica?',a:'Océano Antártico',o:['Océano Antártico','Océano Atlántico','Océano Pacífico','Océano Índico'], tier:'beginner'},
     {q:'¿Cuál es la base civil más conocida de Chile en la Antártica?',a:'Villa Las Estrellas',o:['Villa Las Estrellas','Punta Arenas','Puerto Williams','Base Prat'], tier:'advanced'},
@@ -344,6 +347,9 @@ const QB={
     {q:'¿Qué porcentaje de agua dulce del mundo está en la Antártica?',a:'Alrededor del 70%',o:['Alrededor del 70%','El 10%','El 30%','El 90%'], tier:'expert'}
   ],
   indigenous:[
+    {q:'¿Qué idioma habla el pueblo mapuche?',a:'Mapudungun',o:['Mapudungun','Aymara','Quechua','Rapa Nui'], tier:'beginner'},
+    {q:'¿Quiénes construyeron canoas o "dalcas" en los canales del sur?',a:'Los Chonos',o:['Los Chonos','Los Diaguitas','Los Atacameños','Los Aimaras'], tier:'advanced'},
+    {q:'¿En qué zona de Chile habitaban los Selknam?',a:'Tierra del Fuego',o:['Tierra del Fuego','Desierto de Atacama','Isla de Pascua','Valles Centrales'], tier:'intermediate'},
     {q:'¿Qué pueblo originario desarrolló la cerámica con diseños geométricos?',a:'Los Diaguitas',o:['Los Diaguitas','Los Mapuches','Los Chonos','Los Selknam'], tier:'advanced'},
     {q:'¿Cuándo celebran el Año Nuevo los Aymaras?',a:'Solsticio de invierno',o:['Solsticio de invierno','En Navidad','El 18 de septiembre','El 1 de enero'], tier:'intermediate'},
     {q:'¿Dónde habitan principalmente los Aymaras?',a:'En el altiplano',o:['En el altiplano','En los canales del sur','En Isla de Pascua','En Valparaíso'], tier:'intermediate'},

--- a/js/fe-explorador.js
+++ b/js/fe-explorador.js
@@ -258,27 +258,19 @@ const FeManager = (() => {
   ];
 
   const HERITAGE = [
+    // PRUNED [2026-06-15]: Removed duplicate 'tirana' object (different structure) to respect MAX 8 limit
+    // PRUNED [2026-06-15]: Removed 'vasquez' to make room for 'fiesta_san_pedro' and stay within MAX 8 limit
     {
-      id: 'tirana',
-      name: 'Fiesta de La Tirana',
-      location: 'Región de Tarapacá',
-      desc: 'Es una fiesta religiosa popular que se celebra en julio en honor a la Virgen del Carmen.',
-      icon: '🎭',
-      q: '¿A quién se honra en la Fiesta de La Tirana?',
-      a: ['A la Virgen del Carmen', 'A San Pedro', 'A San José'],
-      correct: 0
+      id: 'fiesta_san_pedro',
+      title: 'Fiesta de San Pedro',
+      info: 'Se celebra el 29 de junio. Los pescadores de la costa chilena adornan sus botes para pedir buena pesca y protección a su patrono.',
+      q: '¿Qué grupo de trabajadores celebra a San Pedro?', a: ['Los pescadores', 'Los mineros', 'Los agricultores'], correct: 0
     },
     {
       id: 'carmen',
       title: 'Virgen del Carmen',
       info: 'Es la Patrona de Chile. Fue declarada así en 1923. Cada 16 de julio se celebra su fiesta con procesiones y bailes religiosos.',
       q: '¿Qué día es la fiesta de la Virgen del Carmen?', a: ['18 de septiembre', '16 de julio', '25 de diciembre'], correct: 1
-    },
-    {
-      id: 'vasquez',
-      title: 'Santuario de Lo Vásquez',
-      info: 'Ubicado cerca de Casablanca, es el lugar de peregrinación más grande de Chile. Cada 8 de diciembre miles de personas caminan hacia allá.',
-      q: '¿En qué fecha es la gran peregrinación?', a: ['1 de enero', '8 de diciembre', '12 de octubre'], correct: 1
     },
     {
       id: 'sanfrancisco_stgo',

--- a/js/guitar-jam.js
+++ b/js/guitar-jam.js
@@ -3,7 +3,8 @@
    ================================================================ */
 
 const CHORDS = [
-  { name: 'Dm', fullName: 'D Minor', tier: 'intermediate', frets: [-1, -1, 0, 2, 3, 1], fingers: [0, 0, 0, 2, 3, 1], funFact: 'Dm sounds slightly sad or dramatic.' },
+  // PRUNED [2026-06-15]: Removed duplicate Dm (already in intermediate section) to make room for Cmaj7.
+  { name: 'Cmaj7', fullName: 'C Major 7', tier: 'advanced', frets: [-1, 3, 2, 0, 0, 0], fingers: [0, 3, 2, 0, 0, 0], funFact: 'Cmaj7 sounds very peaceful and jazzy. It is like a regular C chord but you take off your first finger!' },
 
   // Beginner
   { name: 'Em', fullName: 'E Minor', tier: 'beginner', frets: [0, 2, 2, 0, 0, 0], fingers: [0, 2, 3, 0, 0, 0], funFact: 'Em is one of the easiest guitar chords — just two fingers!' },
@@ -29,7 +30,8 @@ const CHORDS = [
 ];
 
 const SONGS = [
-  { id: 'lalabamba', title: 'La Bamba 2', tier: 'intermediate', bpm: 120, progression: [['C', 2], ['F', 2], ['G', 4], ['C', 2], ['F', 2], ['G', 4]] },
+  // PRUNED [2026-06-15]: Removed duplicate lalabamba (already in intermediate) to make room for Clementine.
+  { id: 'clementine', title: 'Oh My Clementine', tier: 'beginner', bpm: 100, progression: [['D', 6], ['D', 6], ['A', 6], ['D', 6]] },
 
   { id: 'twinkle', title: 'Twinkle Twinkle', tier: 'beginner', bpm: 90, progression: [['C', 4], ['G', 4], ['Am', 4], ['Em', 4], ['C', 4], ['G', 4], ['C', 8]] },
   { id: 'birthday', title: 'Happy Birthday', tier: 'beginner', bpm: 100, progression: [['G', 4], ['G', 4], ['G', 4], ['C', 4], ['C', 4], ['Am', 4], ['G', 4], ['G', 4], ['C', 8]] },

--- a/js/learning-checks.js
+++ b/js/learning-checks.js
@@ -86,7 +86,9 @@ var LearningCheck = (function() {
       { q: 'What part of the plant conducts photosynthesis?', options: ['Root', 'Stem', 'Flower', 'Leaf'], answer: 3 },
       { q: 'What type of animal is a frog?', options: ['Reptile', 'Amphibian', 'Mammal', 'Fish'], answer: 1 },
       { q: 'At what temperature does water boil?', options: ['50°C', '90°C', '100°C', '120°C'], answer: 2 },
-      { q: 'Which planet is closest to the Sun?', options: ['Venus', 'Earth', 'Mercury', 'Mars'], answer: 2 }
+      { q: 'Which planet is closest to the Sun?', options: ['Venus', 'Earth', 'Mercury', 'Mars'], answer: 2 },
+      { q: 'What is the closest star to Earth?', options: ['Sirius', 'Alpha Centauri', 'The Sun', 'Polaris'], answer: 2 },
+      { q: 'What force pulls objects toward the center of the Earth?', options: ['Magnetism', 'Friction', 'Gravity', 'Electricity'], answer: 2 }
     ]
   };
 

--- a/js/math-galaxy.js
+++ b/js/math-galaxy.js
@@ -145,8 +145,11 @@ function genCadet() {
   // PRUNED [2026-04-14]: Removed 'shape', 'bigger' to make room for 'moon_count', 'star_sub' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'alien_shape', 'moon_shape' to make room for 'satellite_count', 'planet_sub'
   // PRUNED [2026-05-18]: Removed 'robot_add', 'alien_sub' to make room for 'sun_sub', 'meteor_pattern' and stay within MAX 25 limit.
-  const types = ['count', 'add', 'moon_count', 'star_sub', 'planet_count', 'rocket_sub', 'shape_pattern', 'astronaut_count', 'star_add', 'galaxy_count', 'alien_count', 'satellite_add', 'meteor_add', 'meteor_count', 'ufo_count', 'telescope_add', 'star_shape', 'sun_count', 'sun_add', 'rocket_count', 'satellite_count', 'asteroid_add', 'planet_sub', 'sun_sub', 'meteor_pattern'];
+  // PRUNED [2026-06-15]: Removed 'shape_pattern', 'star_shape' to make room for 'sun_count_2', 'planet_compare' and stay within MAX 25 limit.
+  const types = ['count', 'add', 'moon_count', 'star_sub', 'planet_count', 'rocket_sub', 'astronaut_count', 'star_add', 'galaxy_count', 'alien_count', 'satellite_add', 'meteor_add', 'meteor_count', 'ufo_count', 'telescope_add', 'sun_count', 'sun_add', 'rocket_count', 'satellite_count', 'asteroid_add', 'planet_sub', 'sun_sub', 'meteor_pattern', 'sun_count_2', 'planet_compare'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'sun_count_2') { const n = rand(1, 10); return { label: 'Suns', text: '☀️'.repeat(n), hint: 'How many suns?', answer: n, options: generateDistractors(n, 3, 1, 15), mode: 'choice' }; }
+  if (type === 'planet_compare') { const a = rand(1, 10), b = rand(1, 10); if (a === b) return genCadet(); return { label: 'Comparing', text: `${a} 🪐 or ${b} 🪐`, hint: 'Which is bigger?', answer: Math.max(a, b), options: shuffle([a, b]), mode: 'choice' }; }
   if (type === 'galaxy_count') { return { label: 'Counting', text: '🌌🌌🌌', hint: 'Count the galaxies!', answer: 3, options: generateDistractors(3, 3, 1, 10), mode: 'choice' }; }
   if (type === 'satellite_count') { return { label: 'Counting', text: '🛰️🛰️', hint: 'Count the satellites!', answer: 2, options: generateDistractors(2, 3, 1, 10), mode: 'choice' }; }
   if (type === 'planet_sub') { const a = rand(3,5), b = rand(1,2); return { label: 'Subtraction', text: `${a} 🪐 - ${b} 🪐 = ?`, hint: '', answer: a-b, options: generateDistractors(a-b, 3, 1, 10), mode: 'choice' }; }
@@ -261,8 +264,11 @@ function genExplorer() {
   // PRUNED [2026-04-14]: Removed 'missing', 'compare' to make room for 'planet_add', 'comet_compare2' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'satellite_mult', 'comet_diff' to make room for 'asteroid_sub', 'meteor_add_2'
   // PRUNED [2026-05-18]: Removed 'alien_add', 'rocket_add' to make room for 'spaceship_add', 'satellite_add2' and stay within MAX 25 limit.
-  const types = ['add', 'sub', 'planet_add', 'comet_compare2', 'double', 'space_compare', 'star_fraction', 'ufo_sub', 'planet_pattern', 'meteor_sub', 'moon_pattern', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare', 'star_sub', 'planet_sub', 'comet_add', 'asteroid_sub', 'meteor_add_2', 'spaceship_add', 'satellite_add2'];
+  // PRUNED [2026-06-15]: Removed 'planet_pattern', 'moon_pattern' to make room for 'alien_diff', 'asteroid_add_2' and stay within MAX 25 limit.
+  const types = ['add', 'sub', 'planet_add', 'comet_compare2', 'double', 'space_compare', 'star_fraction', 'ufo_sub', 'meteor_sub', 'rocket_compare', 'astronaut_sub', 'robot_pattern', 'satellite_compare', 'comet_sub', 'alien_pattern', 'planet_compare', 'star_sub', 'planet_sub', 'comet_add', 'asteroid_sub', 'meteor_add_2', 'spaceship_add', 'satellite_add2', 'alien_diff', 'asteroid_add_2'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'alien_diff') { const a = rand(15,30), b = rand(5,14); return { label: 'Alien Subtraction', text: `${a} 👽 - ${b} 👽 = ?`, hint: 'Subtract the aliens', answer: a-b, options: generateDistractors(a-b, 3, 1, 30), mode: 'choice' }; }
+  if (type === 'asteroid_add_2') { const a = rand(10, 25), b = rand(10, 25); return { label: 'Asteroid Addition', text: `${a} 🪨 + ${b} 🪨 = ?`, hint: 'Add the numbers', answer: a+b, options: generateDistractors(a+b, 3, 10, 60), mode: 'choice' }; }
   if (type === 'asteroid_sub') { const a = rand(10,20), b = rand(1,9); return { label: 'Subtraction', text: `${a} ☄️ - ${b} ☄️ = ?`, hint: '', answer: a-b, options: generateDistractors(a-b, 3, 1, 25), mode: 'choice' }; }
   if (type === 'meteor_add_2') { const a = rand(10,20), b = rand(5,15); return { label: 'Addition', text: `${a} ☄️ + ${b} ☄️ = ?`, hint: '', answer: a+b, options: generateDistractors(a+b, 3, 10, 40), mode: 'choice' }; }
   if (type === 'satellite_mult') { const a = rand(2,5), b = rand(2,5); return { label: 'Multiplication', text: `${a} 🛰️ × ${b} = ?`, hint: '', answer: a*b, options: generateDistractors(a*b, 3, 4, 30), mode: 'choice' }; }
@@ -370,8 +376,11 @@ function genPilot() {
   // PRUNED [2026-04-14]: Removed 'word', 'missing_mult' to make room for 'ufo_mult', 'satellite_frac' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'rocket_alg', 'planet_div' to make room for 'blackhole_mult', 'galaxy_div'
   // PRUNED [2026-05-18]: Removed 'alien_mult', 'rocket_word' to make room for 'nebula_frac', 'star_div' and stay within MAX 25 limit.
-  const types = ['mult', 'div', 'frac_visual', 'ufo_mult', 'satellite_frac', 'comet_mult', 'asteroid_div', 'star_word', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'robot_mult', 'meteor_div', 'astronaut_mult', 'rocket_div', 'moon_frac', 'alien_pct', 'asteroid_mult', 'alien_div', 'blackhole_mult', 'comet_frac', 'galaxy_div', 'nebula_frac', 'star_div'];
+  // PRUNED [2026-06-15]: Removed 'robot_mult', 'meteor_div' to make room for 'moon_div', 'comet_mult_2' and stay within MAX 25 limit.
+  const types = ['mult', 'div', 'frac_visual', 'ufo_mult', 'satellite_frac', 'comet_mult', 'asteroid_div', 'star_word', 'satellite_div', 'telescope_frac', 'planet_mult', 'ufo_div', 'astronaut_mult', 'rocket_div', 'moon_frac', 'alien_pct', 'asteroid_mult', 'alien_div', 'blackhole_mult', 'comet_frac', 'galaxy_div', 'nebula_frac', 'star_div', 'moon_div', 'comet_mult_2'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'moon_div') { const b = rand(2, 8), ans = rand(2, 9); return { label: 'Moon Division', text: `${b * ans} 🌕 ÷ ${b} = ?`, hint: 'Divide', answer: ans, options: generateDistractors(ans, 3, 1, 10), mode: 'choice' }; }
+  if (type === 'comet_mult_2') { const a = rand(5, 12), b = rand(5, 12); return { label: 'Comet Multiplication', text: `${a} ☄️ × ${b} = ?`, hint: 'Multiply', answer: a*b, options: generateDistractors(a*b, 3, 20, 150), mode: 'choice' }; }
   if (type === 'blackhole_mult') { const a = rand(6,12), b = rand(6,12); return { label: 'Multiplication', text: `${a} 🕳️ × ${b} = ?`, hint: '', answer: a*b, options: generateDistractors(a*b, 3, 30, 150), mode: 'choice' }; }
   if (type === 'galaxy_div') { const b = rand(3,9), a = b * rand(3,12); return { label: 'Division', text: `${a} 🌌 ÷ ${b} = ?`, hint: '', answer: a/b, options: generateDistractors(a/b, 3, 2, 15), mode: 'choice' }; }
   if (type === 'alien_pct') { const val = rand(10,50)*2; return { label: 'Percentages', text: `50% of ${val} 👽 = ?`, hint: 'Half!', answer: val/2, options: generateDistractors(val/2, 3, 5, val), mode: 'choice' }; }
@@ -473,8 +482,11 @@ function genCommander() {
   // PRUNED [2026-04-14]: Removed 'fraction_add', 'decimal' to make room for 'blackhole_div', 'galaxy_frac' and stay within MAX 25 limit.
   // PRUNED [2026-04-22]: Removed 'speed_ops', 'planet_pct' to make room for 'quasar_ops', 'pulsar_dec'
   // PRUNED [2026-05-18]: Removed 'rocket_pct', 'asteroid_decimal' to make room for 'pulsar_add', 'galaxy_pct' and stay within MAX 25 limit.
-  const types = ['big_add', 'big_mult', 'blackhole_div', 'galaxy_frac', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'robot_ops', 'ufo_decimal', 'blackhole_add', 'supernova_pct', 'gravity_ops', 'orbit_dec', 'quasar_ops', 'pulsar_dec', 'pulsar_add', 'galaxy_pct'];
+  // PRUNED [2026-06-15]: Removed 'robot_ops', 'ufo_decimal' to make room for 'blackhole_sub', 'galaxy_pct_2' and stay within MAX 25 limit.
+  const types = ['big_add', 'big_mult', 'blackhole_div', 'galaxy_frac', 'percent', 'order_ops', 'galaxy_decimal', 'lightyear_percent', 'blackhole_ops', 'nebula_dec', 'blackhole_pct', 'galaxy_ops', 'comet_ops', 'star_decimal', 'asteroid_pct', 'blackhole_add', 'supernova_pct', 'gravity_ops', 'orbit_dec', 'quasar_ops', 'pulsar_dec', 'pulsar_add', 'galaxy_pct', 'blackhole_sub', 'galaxy_pct_2'];
   const type = types[rand(0, types.length - 1)];
+  if (type === 'blackhole_sub') { const a = rand(100, 500), b = rand(50, a - 1); return { label: 'Big Subtraction', text: `${a} 🕳️ - ${b} 🕳️ = ?`, hint: 'Subtract', answer: a - b, options: generateDistractors(a - b, 3, 10, 450), mode: 'choice' }; }
+  if (type === 'galaxy_pct_2') { const p = [10, 20, 25, 50][rand(0, 3)]; const base = rand(10, 50) * (100/p); const ans = base * p/100; return { label: 'Percentages', text: `${p}% of ${base} 🌌`, hint: 'Calculate', answer: ans, options: generateDistractors(ans, 3, 5, 200), mode: 'choice' }; }
   if (type === 'gravity_ops') { const a=rand(5,10), b=rand(2,5); const ans=a+(b*b); return { label: 'Gravity Math', text: `${a} + ${b}² = ?`, hint: 'Square first!', answer: ans, options: generateDistractors(ans, 3, 5, 50), mode: 'choice' }; }
   if (type === 'orbit_dec') { const a=(rand(10,50)/10).toFixed(1); const b=(rand(10,50)/10).toFixed(1); const ans=(parseFloat(a)-parseFloat(b)).toFixed(1); return { label: 'Decimals', text: `${a} - ${b} = ?`, hint: '', answer: ans, options: generateDistractors(ans, 3, -5, 5).map(x=>x.toFixed(1)), mode: 'choice' }; }
   if (type === 'blackhole_div') {

--- a/js/story-explorer.js
+++ b/js/story-explorer.js
@@ -347,6 +347,42 @@ const StoryExplorer = (() => {
         { q: 'What is the desert like?', qEs: '¿Cómo es el desierto?', options: ['Wet', 'Cold', 'Dry', 'Green'], optionsEs: ['Húmedo', 'Frío', 'Seco', 'Verde'], answer: 2 },
         { q: 'What can you see at night?', qEs: '¿Qué puedes ver de noche?', options: ['Birds', 'Stars', 'Clouds', 'Sun'], optionsEs: ['Pájaros', 'Estrellas', 'Nubes', 'Sol'], answer: 1 }
       ]
+    },
+    {
+      id: 'moon_landing',
+      title: 'The Great Moon Landing',
+      titleEs: 'El Gran Alunizaje',
+      tier: 'commander', ageMin: 10, region: 'space', icon: '🌕',
+      pages: [
+        {
+          en: 'The rocket roared as it lifted off the ground, heading toward the moon.',
+          es: 'El cohete rugió mientras despegaba del suelo, dirigiéndose hacia la luna.',
+          vocab: [
+            { word: 'rocket', wordEs: 'cohete', def: 'A vehicle used for space travel.', defEs: 'Un vehículo usado para viajar al espacio.' },
+            { word: 'roared', wordEs: 'rugió', def: 'Made a loud, deep sound.', defEs: 'Hizo un sonido fuerte y profundo.' }
+          ]
+        },
+        {
+          en: 'Astronauts looked out the small window. Earth looked like a blue marble.',
+          es: 'Los astronautas miraban por la pequeña ventana. La Tierra parecía una canica azul.',
+          vocab: [
+            { word: 'astronauts', wordEs: 'astronautas', def: 'People who travel in space.', defEs: 'Personas que viajan en el espacio.' },
+            { word: 'marble', wordEs: 'canica', def: 'A small glass ball.', defEs: 'Una pequeña bola de cristal.' }
+          ]
+        },
+        {
+          en: 'Finally, they landed. They carefully stepped out and walked on the dusty surface.',
+          es: 'Finalmente, aterrizaron. Con cuidado salieron y caminaron sobre la superficie polvorienta.',
+          vocab: [
+            { word: 'dusty', wordEs: 'polvorienta', def: 'Covered with fine dirt.', defEs: 'Cubierta con tierra fina.' },
+            { word: 'surface', wordEs: 'superficie', def: 'The outside layer.', defEs: 'La capa exterior.' }
+          ]
+        }
+      ],
+      quiz: [
+        { q: 'Where was the rocket going?', qEs: '¿A dónde iba el cohete?', options: ['The Sun', 'Mars', 'The Moon', 'Jupiter'], optionsEs: ['Al Sol', 'A Marte', 'A la Luna', 'A Júpiter'], answer: 2 },
+        { q: 'What did Earth look like from space?', qEs: '¿Cómo se veía la Tierra desde el espacio?', options: ['A red square', 'A blue marble', 'A white cloud', 'A green leaf'], optionsEs: ['Un cuadrado rojo', 'Una canica azul', 'Una nube blanca', 'Una hoja verde'], answer: 1 }
+      ]
     }
   ];
 

--- a/js/world-explorer.js
+++ b/js/world-explorer.js
@@ -395,6 +395,23 @@ const WorldExplorer = (() => {
           { q: 'Which animal is native to Australia?', qEs: '¿Qué animal es nativo de Australia?', options: ['Lion', 'Penguin', 'Kangaroo', 'Bear'], optionsEs: ['León', 'Pingüino', 'Canguro', 'Oso'], answer: 2 },
           { q: 'What famous reef is located here?', qEs: '¿Qué famoso arrecife se encuentra aquí?', options: ['Great Barrier Reef', 'Belize Barrier Reef', 'Palancar Reef', 'Ningaloo Reef'], optionsEs: ['Gran Barrera de Coral', 'Arrecife de Belice', 'Arrecife Palancar', 'Arrecife Ningaloo'], answer: 0 }
         ]
+      },
+      {
+        id: 'new_zealand', name: 'New Zealand', nameEs: 'Nueva Zelanda', flag: '🇳🇿',
+        capital: 'Wellington', capitalEs: 'Wellington',
+        facts: [
+          { en: 'New Zealand consists of two main landmasses: the North Island and South Island.', es: 'Nueva Zelanda consta de dos islas principales: la Isla Norte y la Isla Sur.' },
+          { en: 'It was the first country in the world to give women the right to vote in 1893.', es: 'Fue el primer país del mundo en dar a las mujeres el derecho al voto en 1893.' },
+          { en: 'The kiwi is a flightless bird and a national symbol of New Zealand.', es: 'El kiwi es un ave no voladora y un símbolo nacional de Nueva Zelanda.' },
+          { en: 'It is famous for its beautiful mountains and fjords.', es: 'Es famoso por sus hermosas montañas y fiordos.' }
+        ],
+        landmark: { name: 'Milford Sound', nameEs: 'Milford Sound', emoji: '🏔️' },
+        animal: { name: 'Kiwi Bird', nameEs: 'Pájaro Kiwi', emoji: '🥝' },
+        quiz: [
+          { q: 'What is the capital of New Zealand?', qEs: '¿Cuál es la capital de Nueva Zelanda?', options: ['Auckland', 'Wellington', 'Christchurch', 'Hamilton'], optionsEs: ['Auckland', 'Wellington', 'Christchurch', 'Hamilton'], answer: 1 },
+          { q: 'What is the national bird of New Zealand?', qEs: '¿Cuál es el ave nacional de Nueva Zelanda?', options: ['Eagle', 'Penguin', 'Kiwi', 'Ostrich'], optionsEs: ['Águila', 'Pingüino', 'Kiwi', 'Avestruz'], answer: 2 },
+          { q: 'How many main islands does New Zealand have?', qEs: '¿Cuántas islas principales tiene Nueva Zelanda?', options: ['One', 'Two', 'Three', 'Four'], optionsEs: ['Una', 'Dos', 'Tres', 'Cuatro'], answer: 1 }
+        ]
       }
     ] }
   ];


### PR DESCRIPTION
# DAILY DOCS UPDATE [2026-06-15] — Content Guardian Agent
# Task completed: Refreshed educational content pools

- **Math Galaxy**: Pruned 8 oldest question types across 4 tiers; added 8 new space-themed math generators.
- **Descubre Chile**: Added 3 new questions to Antártica and 3 to Pueblos Originarios quiz banks to reach targets.
- **Fe Explorador**: Pruned 2 heritage items to clear duplicate and respect MAX 8 limit; added Fiesta de San Pedro.
- **World Explorer**: Added New Zealand to Oceania to balance continents.
- **Guitar Jam**: Replaced duplicate Dm chord and La Bamba 2 song with Cmaj7 and Clementine.
- **Learning Checks**: Added 2 science questions to reach 8.
- **Story Explorer**: Added 1 bilingual story (The Great Moon Landing) with vocabulary.

All items comply strictly with `content-guidelines.md` (verifiable, neutral, skill-based). Verified limits and compliance checks passed.

---
*PR created automatically by Jules for task [10497602939940808117](https://jules.google.com/task/10497602939940808117) started by @rozavala*