### PR TITLE
World Cup: sticker album + Trophy Room + match filters + share bracket

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -179,7 +179,8 @@ function getPlayerStats(userName) {
     { id: 'world',  prefix: 'zs_world_' },
     { id: 'story',  prefix: 'zs_story_' },
     { id: 'quest',  prefix: 'zs_quest_' },
-    { id: 'bmcheck', prefix: 'zs_bmcheck_' }
+    { id: 'bmcheck', prefix: 'zs_bmcheck_' },
+    { id: 'worldcup', prefix: 'zs_worldcup_' }
   ];
 
   for (var i = 0; i < appConfigs.length; i++) {

--- a/js/sync.js
+++ b/js/sync.js
@@ -27,6 +27,7 @@ var CloudSync = (function() {
     'zs_activity_': 'activity',
     'zs_routines_': 'routines',
     'zs_money_': 'money',
+    'zs_worldcup_': 'worldcup',
     'littlemaestro_': 'littlemaestro',
   };
 

--- a/js/trophy-room.js
+++ b/js/trophy-room.js
@@ -22,7 +22,8 @@ var TrophyRoom = (function() {
     { id: 'lab',     name: 'Lab Explorer',    emoji: '🔬', color: '#6EE7B7', threshold: 1 },
     { id: 'world',   name: 'World Explorer',  emoji: '🌍', color: '#3B82F6', threshold: 1 },
     { id: 'story',   name: 'Story Explorer',  emoji: '📚', color: '#8B5CF6', threshold: 1 },
-    { id: 'guess',   name: 'Guess Quest',     emoji: '🎯', color: '#FBBF24', threshold: 1 }
+    { id: 'guess',   name: 'Guess Quest',     emoji: '🎯', color: '#FBBF24', threshold: 1 },
+    { id: 'worldcup', name: 'World Cup 2026', emoji: '🏆', color: '#16A34A', threshold: 1 }
   ];
 
   // Mirror of RANKS in auth.js so we can show the progression strip.

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2447,6 +2447,180 @@
   function escapeHTML(s){return (s||'').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));}
 
   /* ----------------------------------------------------------------
+     Per-user star bank — flows into the suite-wide Trophy Room. Each
+     achievement awards stars to a `zs_worldcup_<userKey>` storage
+     entry that trophy-room.js can read like any other app.
+     ---------------------------------------------------------------- */
+  function _userKey(name) {
+    if (!name) return null;
+    return name.toLowerCase().replace(/\s+/g, '_');
+  }
+  function _wcStarsKey(name) {
+    const k = _userKey(name);
+    return k ? 'zs_worldcup_' + k : null;
+  }
+  function _readWcStars(name) {
+    const key = _wcStarsKey(name);
+    if (!key) return { totalStars:0, awards:[] };
+    try {
+      const raw = localStorage.getItem(key);
+      if (!raw) return { totalStars:0, awards:[] };
+      const v = JSON.parse(raw);
+      return { totalStars: v.totalStars|0, awards: Array.isArray(v.awards) ? v.awards : [] };
+    } catch (e) { return { totalStars:0, awards:[] }; }
+  }
+  function awardStars(name, n, source) {
+    const key = _wcStarsKey(name);
+    if (!key || !n) return;
+    try {
+      const cur = _readWcStars(name);
+      cur.totalStars += n;
+      cur.awards.unshift({ ts: Date.now(), n, source });
+      cur.awards = cur.awards.slice(0, 50); // keep last 50 awards
+      localStorage.setItem(key, JSON.stringify(cur));
+      if (window.CloudSync && CloudSync.online && CloudSync.push) {
+        try { CloudSync.push(key); } catch (e) {}
+      }
+    } catch (e) { /* quota etc. — fail silent */ }
+  }
+
+  /* ----------------------------------------------------------------
+     Sticker album — Panini-style 48-country collection. Persisted in
+     the same wc2026.v2 bucket under state.stickers, keyed by country
+     code. status: 'locked' | 'earned' | 'starred'.
+     ---------------------------------------------------------------- */
+  function _stickerStatus(code) {
+    const s = (state.stickers || {})[code];
+    if (!s) return 'locked';
+    return s.starred ? 'starred' : 'earned';
+  }
+  function earnSticker(code, source, starred) {
+    if (!code) return;
+    state.stickers = state.stickers || {};
+    const prev = state.stickers[code];
+    const wasStarred = !!(prev && prev.starred);
+    if (prev && (starred ? wasStarred : true)) return; // already at this tier
+    state.stickers[code] = {
+      earnedAt: (prev && prev.earnedAt) || new Date().toISOString(),
+      source,
+      starred: !!(starred || wasStarred),
+    };
+    save();
+    // Award stars to the active user's bank
+    const user = currentActiveUser();
+    if (user && !prev) awardStars(user.name, 2, 'sticker:' + code);
+    if (user && starred && !wasStarred) awardStars(user.name, 3, 'sticker_starred:' + code);
+  }
+
+  /* ----------------------------------------------------------------
+     Share bracket — encode/decode a member's picks as a URL-safe
+     base64 JSON payload. Works on the public GitHub-Pages app URL so
+     extended family without VPN access can play.
+     ---------------------------------------------------------------- */
+  function _b64urlEncode(str) {
+    const utf8 = unescape(encodeURIComponent(str));
+    return btoa(utf8).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  }
+  function _b64urlDecode(s) {
+    s = s.replace(/-/g, '+').replace(/_/g, '/');
+    while (s.length % 4) s += '=';
+    return decodeURIComponent(escape(atob(s)));
+  }
+  function encodeBracket(member) {
+    const picks = state.picks[member.id] || {};
+    const payload = {
+      v: 1,
+      name: member.name || '',
+      avatar: member.avatar || '',
+      gw: picks.groupWinners || {},
+      gr: picks.groupRunnersUp || {},
+      ko: picks.ko || {},
+      ch: picks.champion || null,
+      ru: picks.runnerUp || null,
+      gb: picks.goldenBoot || '',
+    };
+    if (picks.scores && Object.keys(picks.scores).length > 0) payload.sc = picks.scores;
+    return _b64urlEncode(JSON.stringify(payload));
+  }
+  function decodeBracket(encoded) {
+    try {
+      const json = _b64urlDecode(encoded);
+      const p = JSON.parse(json);
+      if (p && p.v === 1 && typeof p.name === 'string') return p;
+    } catch (e) {}
+    return null;
+  }
+  function importSharedBracket(payload) {
+    if (!payload || !payload.name) return null;
+    // Match by lowercase name; otherwise create a new entry
+    const lower = payload.name.toLowerCase();
+    let entry = state.members.find(m => m.name && m.name.toLowerCase() === lower);
+    if (!entry) {
+      const id = 'm_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2,5);
+      entry = { id, name: payload.name, avatar: payload.avatar || null };
+      state.members.push(entry);
+    } else if (payload.avatar && !entry.avatar) {
+      entry.avatar = payload.avatar;
+    }
+    state.picks[entry.id] = {
+      groupWinners: payload.gw || {},
+      groupRunnersUp: payload.gr || {},
+      ko: payload.ko || {},
+      champion: payload.ch || null,
+      runnerUp: payload.ru || null,
+      goldenBoot: payload.gb || '',
+      goldenBootCorrect: false,
+      scores: payload.sc || {},
+    };
+    save();
+    return entry;
+  }
+  function checkUrlForImport() {
+    try {
+      const params = new URLSearchParams(window.location.search);
+      const enc = params.get('wc_share');
+      if (!enc) return;
+      const payload = decodeBracket(enc);
+      if (!payload) return;
+      // Clear the URL so a reload doesn't re-prompt
+      const url = new URL(window.location.href);
+      url.searchParams.delete('wc_share');
+      history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?'+url.searchParams.toString() : ''));
+      // Defer prompt so init() has time to mount
+      setTimeout(() => promptImportBracket(payload), 600);
+    } catch (e) {}
+  }
+  let _pendingImport = null;
+  function promptImportBracket(payload) {
+    const modal = document.getElementById('match-modal');
+    if (!modal) return;
+    _pendingImport = payload;
+    const guess = payload.gb ? `Golden Boot guess: <b>${escapeHTML(payload.gb)}</b>` : '';
+    modal.querySelector('.modal-inner').innerHTML = `
+      <h3>📨 Bracket received</h3>
+      <div class="sub">From <b>${payload.avatar ? escapeHTML(payload.avatar)+' ' : ''}${escapeHTML(payload.name)}</b></div>
+      <p style="margin:10px 0;font-size:0.9rem;">Add this bracket to the family pool? Picks will start scoring as results come in.</p>
+      ${guess ? `<p style="font-size:0.82rem;color:var(--text-muted);">${guess}</p>` : ''}
+      <div class="modal-actions">
+        <button class="btn ghost" onclick="WC.closeModal()">Not now</button>
+        <button class="btn" onclick="WC.confirmImportBracket()">✓ Add to pool</button>
+      </div>
+    `;
+    modal.classList.add('open');
+  }
+  function confirmImportBracket() {
+    const p = _pendingImport;
+    _pendingImport = null;
+    closeModal();
+    if (!p) return;
+    const entry = importSharedBracket(p);
+    if (entry) {
+      toast('Added ' + entry.name + ' to the pool');
+      activateTab('pool');
+    }
+  }
+
+  /* ----------------------------------------------------------------
      Bracket candidate resolver — given a placeholder label like
      "1A", "2B", "3A/B/C/D/F", "W73", "L101", return the set of team
      codes that could fill that slot. Cascades recursively so R16+
@@ -2674,6 +2848,7 @@
     if (name === 'standings')   renderStandings();
     if (name === 'pool')        renderPool();
     if (name === 'quiz')        renderQuiz();
+    if (name === 'stickers')    renderStickers();
     if (name === 'about')       renderAbout();
     window.scrollTo({ top:0, behavior:'instant' });
   }
@@ -3014,6 +3189,8 @@
   function openCountry(code) {
     const c = countryByCode(code);
     if (!c) return;
+    // Earn a sticker just for visiting (only the first time)
+    earnSticker(code, 'visit', false);
     const root = document.getElementById('screen-country');
     root.innerHTML = `
       <button class="btn ghost" style="margin-bottom:12px;" onclick="WC.tab('teams')">← Back to teams</button>
@@ -3077,17 +3254,56 @@
     const root = document.getElementById('screen-matches');
     const stageFilter = document.getElementById('flt-stage')?.value || 'all';
     const groupFilter = document.getElementById('flt-group')?.value || 'all';
+    const chip = state.matchChip || 'all';
 
     let list = state.matches.slice();
     if (stageFilter !== 'all') list = list.filter(m => m.stage === stageFilter);
     if (groupFilter !== 'all') list = list.filter(m => m.group === groupFilter);
+
+    // Quick chips: today / knockouts / my picks / Levi's
+    if (chip === 'today') {
+      const t = todayKey();
+      list = list.filter(m => m.date === t);
+    } else if (chip === 'ko') {
+      list = list.filter(m => m.stage !== 'group');
+    } else if (chip === 'lev') {
+      list = list.filter(m => m.venue === 'lev');
+    } else if (chip === 'mine') {
+      const user = currentActiveUser();
+      const myEntry = user ? state.members.find(m => m.name && m.name.toLowerCase() === user.name.toLowerCase()) : null;
+      const picks = myEntry ? state.picks[myEntry.id] : null;
+      const picked = new Set();
+      if (picks) {
+        for (const g of GROUP_LETTERS) {
+          if (picks.groupWinners && picks.groupWinners[g]) picked.add(picks.groupWinners[g]);
+          if (picks.groupRunnersUp && picks.groupRunnersUp[g]) picked.add(picks.groupRunnersUp[g]);
+        }
+        for (const stage of ['R32','R16','QF','SF','Final']) {
+          const s = picks.ko && picks.ko[stage] ? picks.ko[stage] : {};
+          for (const id of Object.keys(s)) if (s[id]) picked.add(s[id]);
+        }
+        if (picks.champion) picked.add(picks.champion);
+        if (picks.runnerUp) picked.add(picks.runnerUp);
+      }
+      list = list.filter(m => (m.home && picked.has(m.home)) || (m.away && picked.has(m.away)));
+    }
+
     list.sort((a,b) => (a.date+a.time).localeCompare(b.date+b.time));
 
     // group by date
     const byDate = {};
     list.forEach(m => { (byDate[m.date] = byDate[m.date] || []).push(m); });
 
+    const chipBtn = (val, label) => `<button class="tab ${chip===val?'active':''}" style="font-size:0.78rem;padding:6px 12px;" onclick="WC.setMatchChip('${val}')">${label}</button>`;
+
     const filterHTML = `
+      <div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">
+        ${chipBtn('all',   'All')}
+        ${chipBtn('today', '📅 Today')}
+        ${chipBtn('ko',    '⚔ Knockouts')}
+        ${chipBtn('mine',  '🎯 My picks')}
+        ${chipBtn('lev',   '🌉 Levi&#39;s')}
+      </div>
       <div class="match-filters">
         <select id="flt-stage" onchange="WC.renderMatches()">
           <option value="all">All stages</option>
@@ -3103,7 +3319,7 @@
           <option value="all">All groups</option>
           ${GROUP_LETTERS.map(g => `<option value="${g}" ${groupFilter===g?'selected':''}>Group ${g}</option>`).join('')}
         </select>
-        <span class="muted" style="font-size:0.8rem; align-self:center;">${list.length} matches</span>
+        <span class="muted" style="font-size:0.8rem; align-self:center;">${list.length} match${list.length===1?'':'es'}</span>
       </div>
     `;
 
@@ -3281,13 +3497,15 @@
                 <div class="pts">${m.total}</div>
                 <div class="actions">
                   <button title="Edit picks" onclick="WC.editEntry('${m.id}')">✎</button>
+                  <button title="Share bracket" onclick="WC.openShareBracket('${m.id}')">🔗</button>
                   <button title="Remove from pool" onclick="WC.removeMember('${m.id}')">✕</button>
                 </div>
               </div>`).join('')}
 
         ${selectedId ? '' : `
-          <div style="text-align:center;margin-top:14px;">
+          <div style="text-align:center;margin-top:14px;display:flex;flex-direction:column;gap:8px;align-items:center;">
             <button class="btn gold" style="font-size:1rem;padding:12px 24px;" onclick="WC.startEntry()">${ctaLabel}</button>
+            <button class="btn ghost" style="font-size:0.82rem;" onclick="WC.openInviteGuest()">📨 Invite extended family (no app/VPN needed)</button>
           </div>
         `}
 
@@ -3753,7 +3971,20 @@
     quizState.answered = true;
     const q = quizState.questions[quizState.current];
     const opt = q.options[idx];
-    if (opt && opt.correct) quizState.score++;
+    if (opt && opt.correct) {
+      quizState.score++;
+      const user = currentActiveUser();
+      if (user) awardStars(user.name, 1, 'quiz_correct');
+      // Earn a sticker for any country referenced in the question
+      const countryMention = (q.q + ' ' + (q.options || []).map(o => o.label).join(' '))
+        .toUpperCase();
+      for (const c of COUNTRIES) {
+        if (countryMention.indexOf(c.flag) !== -1) {
+          earnSticker(c.code, 'quiz', false);
+          break; // one per question
+        }
+      }
+    }
     renderQuiz();
   }
   function nextQuestion() {
@@ -3856,6 +4087,57 @@
     quizState.score = 0;
     quizState.answered = false;
     renderQuiz();
+  }
+
+  /* ---- STICKERS — Panini-style 48-country album ---- */
+  function renderStickers() {
+    const root = document.getElementById('screen-stickers');
+    state.stickers = state.stickers || {};
+    const total = COUNTRIES.length;
+    const earned = COUNTRIES.filter(c => _stickerStatus(c.code) !== 'locked').length;
+    const starred = COUNTRIES.filter(c => _stickerStatus(c.code) === 'starred').length;
+    const pct = Math.round((earned / total) * 100);
+
+    let html = `
+      <div class="card sc-hero">
+        <div class="city">Panini-style album</div>
+        <h2 style="margin:4px 0;">📒 Sticker Collection</h2>
+        <div style="display:flex;gap:8px;align-items:center;margin:8px 0;">
+          <div style="flex:1;height:10px;background:rgba(255,255,255,0.08);border-radius:99px;overflow:hidden;">
+            <div style="height:100%;width:${pct}%;background:linear-gradient(90deg,var(--wc-green),var(--wc-gold));"></div>
+          </div>
+          <b style="color:var(--wc-gold);">${earned} / ${total}</b>
+        </div>
+        <p class="muted" style="font-size:0.85rem;">⭐ ${starred} winner stickers · 🏷 ${earned - starred} earned · 🔒 ${total - earned} locked</p>
+        <p class="muted" style="font-size:0.78rem;margin-top:8px;">Earn stickers by visiting country pages, answering quiz questions about them, or entering their match results. A team's <b>⭐ winner sticker</b> unlocks when you record a match they win.</p>
+      </div>
+    `;
+
+    // Render by group
+    for (const g of GROUP_LETTERS) {
+      const codes = state.groups[g] || [];
+      html += `<div class="card" style="padding:14px;">
+        <h3 style="margin-bottom:8px;color:var(--wc-gold);">Group ${g}</h3>
+        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:8px;">
+          ${codes.map(code => {
+            const c = countryByCode(code);
+            if (!c) return '';
+            const status = _stickerStatus(code);
+            const isLocked = status === 'locked';
+            const isStarred = status === 'starred';
+            return `
+              <div onclick="WC.openCountry('${code}')" style="cursor:pointer;background:${isLocked?'rgba(255,255,255,0.03)':'var(--wc-card-strong)'};border:2px solid ${isStarred?'var(--wc-gold)':(isLocked?'var(--wc-line)':'rgba(22,163,74,0.35)')};border-radius:12px;padding:10px 8px;text-align:center;position:relative;${isLocked?'opacity:0.4;':''}">
+                <div style="font-size:2rem;line-height:1;filter:${isLocked?'grayscale(1)':'none'};">${c.flag}</div>
+                <div style="font-size:0.7rem;font-weight:800;margin-top:4px;line-height:1.15;">${escapeHTML(c.name)}</div>
+                ${isStarred ? '<div style="position:absolute;top:-6px;right:-6px;background:var(--wc-gold);color:#1a1a1a;border-radius:99px;width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:0.7rem;">⭐</div>' : ''}
+                ${isLocked ? '<div style="position:absolute;top:6px;right:6px;font-size:0.8rem;opacity:0.7;">🔒</div>' : ''}
+              </div>`;
+          }).join('')}
+        </div>
+      </div>`;
+    }
+
+    root.innerHTML = html;
   }
 
   /* ---- ABOUT ---- */
@@ -3981,6 +4263,13 @@
       const pkEl = document.getElementById('pk-winner');
       const pkWinner = pkEl ? (pkEl.value || null) : null;
       m.result = { home: hs, away: as, pkWinner };
+      // Sticker for each team that played, starred for the winner
+      const winnerCode = hs > as ? m.home : (as > hs ? m.away : pkWinner);
+      if (m.home) earnSticker(m.home, 'result', winnerCode === m.home);
+      if (m.away) earnSticker(m.away, 'result', winnerCode === m.away);
+      // Award stars to the active user (rewards engagement with results)
+      const user = currentActiveUser();
+      if (user) awardStars(user.name, 2, 'result:' + m.id);
     }
     save();
     closeModal();
@@ -4143,6 +4432,76 @@
     save();
     renderPool();
   }
+  function setMatchChip(value) {
+    state.matchChip = value;
+    renderMatches();
+  }
+
+  /* ----------------------------------------------------------------
+     Share bracket + invite extended family — uses URL parameter
+     payload so guests can play from the public app URL without VPN.
+     ---------------------------------------------------------------- */
+  function _publicAppBase() {
+    // Strip any existing query string, keep the directory + filename.
+    return window.location.origin + window.location.pathname;
+  }
+  function openShareBracket(memberId) {
+    const member = state.members.find(m => m.id === memberId);
+    if (!member) return;
+    const enc = encodeBracket(member);
+    const url = _publicAppBase() + '?wc_share=' + enc;
+    const modal = document.getElementById('match-modal');
+    modal.querySelector('.modal-inner').innerHTML = `
+      <h3>🔗 Share ${escapeHTML(member.name)}'s bracket</h3>
+      <div class="sub">Send this link to anyone in the family pool. They'll see the picks and can add the bracket.</div>
+      <textarea readonly id="share-url-area"
+                style="width:100%;background:var(--wc-card-strong);border:1px solid var(--wc-line);color:var(--text-primary);border-radius:8px;padding:10px;font-size:0.78rem;font-family:monospace;margin:10px 0;min-height:90px;word-break:break-all;"
+                onclick="this.select()">${escapeHTML(url)}</textarea>
+      <div class="modal-actions">
+        <button class="btn ghost" onclick="WC.closeModal()">Close</button>
+        <button class="btn" onclick="WC.copyShareUrl()">📋 Copy link</button>
+      </div>
+    `;
+    modal.classList.add('open');
+  }
+  function copyShareUrl() {
+    const area = document.getElementById('share-url-area');
+    if (!area) return;
+    area.select();
+    try {
+      navigator.clipboard.writeText(area.value).then(() => toast('Link copied!')).catch(() => {
+        document.execCommand && document.execCommand('copy');
+        toast('Link copied!');
+      });
+    } catch (e) {
+      try { document.execCommand('copy'); toast('Link copied!'); } catch (e2) { toast('Copy failed — long-press the link to select.'); }
+    }
+  }
+  function openInviteGuest() {
+    const link = _publicAppBase();
+    const modal = document.getElementById('match-modal');
+    modal.querySelector('.modal-inner').innerHTML = `
+      <h3>📨 Invite extended family</h3>
+      <div class="sub">No app install, no VPN needed.</div>
+      <ol style="padding-left:20px;line-height:1.6;font-size:0.88rem;margin:10px 0;">
+        <li>Send the family member this public app link:</li>
+      </ol>
+      <textarea readonly id="share-url-area"
+                style="width:100%;background:var(--wc-card-strong);border:1px solid var(--wc-line);color:var(--text-primary);border-radius:8px;padding:10px;font-size:0.78rem;font-family:monospace;margin:6px 0 10px;min-height:60px;word-break:break-all;"
+                onclick="this.select()">${escapeHTML(link)}</textarea>
+      <ol start="2" style="padding-left:20px;line-height:1.6;font-size:0.88rem;">
+        <li>They open it, fill out their bracket, and tap the <b>🔗 share</b> button next to their name.</li>
+        <li>They text/email/WhatsApp <b>that link</b> back to you.</li>
+        <li>You open <b>their link</b> here — the app prompts you to add their bracket to the pool. Done.</li>
+      </ol>
+      <p class="muted" style="font-size:0.78rem;margin-top:10px;">Their bracket then syncs to the rest of the family devices via the regular pool sync.</p>
+      <div class="modal-actions">
+        <button class="btn ghost" onclick="WC.closeModal()">Close</button>
+        <button class="btn" onclick="WC.copyShareUrl()">📋 Copy invite link</button>
+      </div>
+    `;
+    modal.classList.add('open');
+  }
   function setScorePred(memberId, matchId, side, raw) {
     const p = state.picks[memberId];
     if (!p) return;
@@ -4289,6 +4648,9 @@
       hiddenSince = null;
     });
 
+    // Honor ?wc_share=... in the URL — guest brought us a bracket to import
+    checkUrlForImport();
+
     // Initial cross-device pull so a new device picks up family picks
     if (window.CloudSync && CloudSync.pull) {
       setTimeout(() => {
@@ -4409,8 +4771,10 @@
     openGroupEditor, saveGroups,
     startEntry, editEntry, doneEntry, setEntrantName, removeMember,
     setGroupPick, setKoPick, setOutcomePick, setScorePred,
+    setMatchChip,
     quickFill,
     startQuiz, answerQuiz, nextQuestion, resetQuiz,
+    openShareBracket, copyShareUrl, openInviteGuest, confirmImportBracket,
     resetAll,
     syncScores,
   };

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2578,23 +2578,123 @@
   function checkUrlForImport() {
     try {
       const params = new URLSearchParams(window.location.search);
-      const enc = params.get('wc_share');
-      if (!enc) return;
-      const payload = decodeBracket(enc);
-      if (!payload) return;
-      // Clear the URL so a reload doesn't re-prompt
       const url = new URL(window.location.href);
-      url.searchParams.delete('wc_share');
-      history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?'+url.searchParams.toString() : ''));
-      // Defer prompt so init() has time to mount
-      setTimeout(() => promptImportBracket(payload), 600);
+
+      // Single-bracket share (?wc_share=...)
+      const shareEnc = params.get('wc_share');
+      if (shareEnc) {
+        const payload = decodeBracket(shareEnc);
+        url.searchParams.delete('wc_share');
+        history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?'+url.searchParams.toString() : ''));
+        if (payload) setTimeout(() => promptImportBracket(payload), 600);
+      }
+
+      // Full-family-pool snapshot (?wc_pool=...)
+      const poolEnc = params.get('wc_pool');
+      if (poolEnc) {
+        const payload = decodePool(poolEnc);
+        url.searchParams.delete('wc_pool');
+        history.replaceState({}, '', url.pathname + (url.searchParams.toString() ? '?'+url.searchParams.toString() : ''));
+        if (payload) setTimeout(() => promptImportPool(payload), 700);
+      }
     } catch (e) {}
+  }
+
+  /* ----------------------------------------------------------------
+     Full-family-pool snapshot — host can share a single URL bundling
+     every member's bracket plus all recorded results. Guests open
+     the URL and import to see the family leaderboard locally
+     (read-only-ish — they can still edit their own bracket).
+     ---------------------------------------------------------------- */
+  function encodePool() {
+    const members = state.members
+      .filter(m => m.name && m.name.trim())
+      .map(m => ({
+        n: m.name,
+        a: m.avatar || '',
+        p: state.picks[m.id] || null,
+      }));
+    const results = {};
+    for (const m of state.matches) if (m.result) results[m.id] = m.result;
+    const payload = { v: 1, type: 'pool', members, results };
+    return _b64urlEncode(JSON.stringify(payload));
+  }
+  function decodePool(encoded) {
+    try {
+      const json = _b64urlDecode(encoded);
+      const p = JSON.parse(json);
+      if (p && p.v === 1 && p.type === 'pool' && Array.isArray(p.members)) return p;
+    } catch (e) {}
+    return null;
+  }
+  function importPool(payload) {
+    if (!payload) return { added:0, updated:0, results:0 };
+    let added = 0, updated = 0;
+    for (const sm of payload.members || []) {
+      const lower = (sm.n || '').toLowerCase();
+      if (!lower) continue;
+      let entry = state.members.find(m => m.name && m.name.toLowerCase() === lower);
+      if (!entry) {
+        const id = 'm_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2,5);
+        entry = { id, name: sm.n, avatar: sm.a || null };
+        state.members.push(entry);
+        added++;
+      } else {
+        if (sm.a && !entry.avatar) entry.avatar = sm.a;
+        updated++;
+      }
+      if (sm.p) state.picks[entry.id] = sm.p;
+    }
+    let resultsApplied = 0;
+    for (const id of Object.keys(payload.results || {})) {
+      const m = state.matches.find(x => x.id === id);
+      if (m) { m.result = payload.results[id]; resultsApplied++; }
+    }
+    save();
+    return { added, updated, results: resultsApplied };
+  }
+  function promptImportPool(payload) {
+    const modal = document.getElementById('match-modal');
+    if (!modal) return;
+    _pendingImport = { type:'pool', payload };
+    const memberCount = (payload.members || []).filter(m => m.n).length;
+    const resultCount = Object.keys(payload.results || {}).length;
+    const memberList = (payload.members || [])
+      .filter(m => m.n)
+      .map(m => `${m.a ? escapeHTML(m.a)+' ' : ''}${escapeHTML(m.n)}`)
+      .slice(0, 8)
+      .join(', ');
+    modal.querySelector('.modal-inner').innerHTML = `
+      <h3>📨 Family pool snapshot received</h3>
+      <div class="sub">${memberCount} bracket${memberCount===1?'':'s'} · ${resultCount} match result${resultCount===1?'':'s'}</div>
+      <p style="margin:10px 0;font-size:0.9rem;line-height:1.5;">${escapeHTML(memberList)}${memberCount > 8 ? ' …' : ''}</p>
+      <p style="font-size:0.82rem;color:var(--text-muted);">Existing brackets with the same name will be updated. Your own bracket is preserved unless someone with your name is in the snapshot.</p>
+      <div class="modal-actions">
+        <button class="btn ghost" onclick="WC.closeModal()">Not now</button>
+        <button class="btn" onclick="WC.confirmImportPool()">✓ Import snapshot</button>
+      </div>
+    `;
+    modal.classList.add('open');
+  }
+  function confirmImportPool() {
+    const p = _pendingImport && _pendingImport.payload;
+    const isPool = _pendingImport && _pendingImport.type === 'pool';
+    _pendingImport = null;
+    closeModal();
+    if (!p || !isPool) return;
+    const { added, updated, results } = importPool(p);
+    const parts = [];
+    if (added) parts.push(`${added} new bracket${added===1?'':'s'}`);
+    if (updated) parts.push(`${updated} updated`);
+    if (results) parts.push(`${results} result${results===1?'':'s'}`);
+    toast('Imported — ' + (parts.join(' · ') || 'no changes'));
+    activateTab('pool');
   }
   let _pendingImport = null;
   function promptImportBracket(payload) {
     const modal = document.getElementById('match-modal');
     if (!modal) return;
-    _pendingImport = payload;
+    _pendingImport = { type: 'bracket', payload };
     const guess = payload.gb ? `Golden Boot guess: <b>${escapeHTML(payload.gb)}</b>` : '';
     modal.querySelector('.modal-inner').innerHTML = `
       <h3>📨 Bracket received</h3>
@@ -2609,11 +2709,11 @@
     modal.classList.add('open');
   }
   function confirmImportBracket() {
-    const p = _pendingImport;
+    const wrap = _pendingImport;
     _pendingImport = null;
     closeModal();
-    if (!p) return;
-    const entry = importSharedBracket(p);
+    if (!wrap || wrap.type !== 'bracket' || !wrap.payload) return;
+    const entry = importSharedBracket(wrap.payload);
     if (entry) {
       toast('Added ' + entry.name + ' to the pool');
       activateTab('pool');
@@ -3505,6 +3605,7 @@
         ${selectedId ? '' : `
           <div style="text-align:center;margin-top:14px;display:flex;flex-direction:column;gap:8px;align-items:center;">
             <button class="btn gold" style="font-size:1rem;padding:12px 24px;" onclick="WC.startEntry()">${ctaLabel}</button>
+            ${board.length > 0 ? `<button class="btn ghost" style="font-size:0.82rem;" onclick="WC.openShareFamilyPool()">📤 Share family pool (snapshot link)</button>` : ''}
             <button class="btn ghost" style="font-size:0.82rem;" onclick="WC.openInviteGuest()">📨 Invite extended family (no app/VPN needed)</button>
           </div>
         `}
@@ -4477,6 +4578,32 @@
       try { document.execCommand('copy'); toast('Link copied!'); } catch (e2) { toast('Copy failed — long-press the link to select.'); }
     }
   }
+  function openShareFamilyPool() {
+    const named = state.members.filter(m => m.name && m.name.trim());
+    if (named.length === 0) {
+      toast('No brackets to share yet — submit one first.');
+      return;
+    }
+    const enc = encodePool();
+    const url = _publicAppBase() + '?wc_pool=' + enc;
+    const resultCount = state.matches.filter(m => m.result).length;
+    const sizeKB = (url.length / 1024).toFixed(1);
+    const modal = document.getElementById('match-modal');
+    modal.querySelector('.modal-inner').innerHTML = `
+      <h3>📤 Share the family pool</h3>
+      <div class="sub">${named.length} bracket${named.length===1?'':'s'} · ${resultCount} result${resultCount===1?'':'s'} · ${sizeKB} KB URL</div>
+      <p style="margin:10px 0;font-size:0.85rem;line-height:1.5;">Send this link to extended family — opening it adds the whole pool to their device so they can see the leaderboard. Re-share after every round to keep them in sync.</p>
+      <textarea readonly id="share-url-area"
+                style="width:100%;background:var(--wc-card-strong);border:1px solid var(--wc-line);color:var(--text-primary);border-radius:8px;padding:10px;font-size:0.78rem;font-family:monospace;margin:6px 0;min-height:90px;word-break:break-all;"
+                onclick="this.select()">${escapeHTML(url)}</textarea>
+      <p class="muted" style="font-size:0.72rem;">URLs above ~4 KB may get truncated by SMS — WhatsApp / email / Slack are safe.</p>
+      <div class="modal-actions">
+        <button class="btn ghost" onclick="WC.closeModal()">Close</button>
+        <button class="btn" onclick="WC.copyShareUrl()">📋 Copy link</button>
+      </div>
+    `;
+    modal.classList.add('open');
+  }
   function openInviteGuest() {
     const link = _publicAppBase();
     const modal = document.getElementById('match-modal');
@@ -4775,6 +4902,7 @@
     quickFill,
     startQuiz, answerQuiz, nextQuestion, resetQuiz,
     openShareBracket, copyShareUrl, openInviteGuest, confirmImportBracket,
+    openShareFamilyPool, confirmImportPool,
     resetAll,
     syncScores,
   };

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -3503,39 +3503,120 @@
   }
   function _pickN(arr, n) { return _shuffle(arr).slice(0, n); }
 
-  function generateQuestion() {
-    const types = ['flag', 'capital', 'player', 'group'];
-    const t = types[Math.floor(Math.random() * types.length)];
-    if (t === 'flag') {
-      const correct = _pickN(COUNTRIES, 1)[0];
-      const distractors = _pickN(COUNTRIES.filter(c => c.code !== correct.code), 3);
-      const opts = _shuffle([correct, ...distractors]);
-      return {
-        q: `Whose flag is this? <span style="font-size:3rem;display:block;margin-top:8px;">${correct.flag}</span>`,
-        options: opts.map(o => ({ label: o.name, correct: o.code === correct.code })),
-      };
+  /* ----------------------------------------------------------------
+     Quiz generators. Each returns { q, options:[{label, correct}] }
+     or null when the data doesn't support a good question. The
+     dispatcher (startQuiz) shuffles the generator list and picks 10
+     distinct types per round so every round feels different.
+     ---------------------------------------------------------------- */
+
+  // 1. Flag → Country: name the country whose flag is shown.
+  function _qFlag() {
+    const correct = _pickN(COUNTRIES, 1)[0];
+    const distractors = _pickN(COUNTRIES.filter(c => c.code !== correct.code), 3);
+    const opts = _shuffle([correct, ...distractors]);
+    return {
+      q: `Whose flag is this? <span style="font-size:3rem;display:block;margin-top:8px;">${correct.flag}</span>`,
+      options: opts.map(o => ({ label: o.name, correct: o.code === correct.code })),
+    };
+  }
+  // 2. Country → Capital
+  function _qCapital() {
+    const correct = _pickN(COUNTRIES, 1)[0];
+    const distractors = _pickN(COUNTRIES.filter(c => c.code !== correct.code && c.capital !== correct.capital), 3);
+    const opts = _shuffle([correct, ...distractors]);
+    return {
+      q: `What is the capital of <b>${escapeHTML(correct.name)}</b> ${correct.flag}?`,
+      options: opts.map(o => ({ label: o.capital, correct: o.code === correct.code })),
+    };
+  }
+  // 3. Capital → Country (reverse direction)
+  function _qCapitalReverse() {
+    const correct = _pickN(COUNTRIES, 1)[0];
+    const distractors = _pickN(COUNTRIES.filter(c => c.code !== correct.code), 3);
+    const opts = _shuffle([correct, ...distractors]);
+    return {
+      q: `Which country's capital is <b>${escapeHTML(correct.capital.split('/')[0].split('(')[0].trim())}</b>?`,
+      options: opts.map(o => ({ label: o.flag + ' ' + o.name, correct: o.code === correct.code })),
+    };
+  }
+  // 4. Star player → Country (which national team)
+  function _qPlayer() {
+    const pool = COUNTRIES.filter(c => c.stars && c.stars.length);
+    if (pool.length < 4) return null;
+    const country = _pickN(pool, 1)[0];
+    const star = country.stars[Math.floor(Math.random() * country.stars.length)];
+    const distractors = _pickN(COUNTRIES.filter(c => c.code !== country.code), 3);
+    const opts = _shuffle([country, ...distractors]);
+    return {
+      q: `Which country does <b>${escapeHTML(star.name)}</b> play for?`,
+      options: opts.map(o => ({ label: o.flag + ' ' + o.name, correct: o.code === country.code })),
+    };
+  }
+  // 5. Country → Star player (who plays for X — pick the right player among 4 names)
+  function _qPlayerFor() {
+    const pool = COUNTRIES.filter(c => c.stars && c.stars.length);
+    if (pool.length < 4) return null;
+    const country = _pickN(pool, 1)[0];
+    const star = country.stars[Math.floor(Math.random() * country.stars.length)];
+    // Distractor stars from OTHER countries
+    const others = _shuffle(pool.filter(c => c.code !== country.code))
+      .map(c => c.stars[Math.floor(Math.random() * c.stars.length)])
+      .filter(s => s.name !== star.name)
+      .slice(0, 3);
+    if (others.length < 3) return null;
+    const all = _shuffle([star, ...others]);
+    return {
+      q: `Which of these players plays for <b>${country.flag} ${escapeHTML(country.name)}</b>?`,
+      options: all.map(s => ({ label: s.name, correct: s.name === star.name })),
+    };
+  }
+  // 6. Star player → Position
+  function _qPosition() {
+    const pool = COUNTRIES.filter(c => c.stars && c.stars.length);
+    if (pool.length === 0) return null;
+    const country = _pickN(pool, 1)[0];
+    const star = country.stars[Math.floor(Math.random() * country.stars.length)];
+    const positionMap = {
+      'GK':'Goalkeeper','CB':'Centre-back','LB':'Left-back','RB':'Right-back',
+      'CDM':'Defensive midfielder','CM':'Midfielder','AM':'Attacking midfielder',
+      'LW':'Left winger','RW':'Right winger','ST':'Striker',
+    };
+    // Find canonical position
+    const posKey = (star.pos || '').split('/')[0].trim();
+    const correctLabel = positionMap[posKey] || star.pos;
+    const allLabels = Object.values(positionMap);
+    const distractors = _shuffle(allLabels.filter(l => l !== correctLabel)).slice(0, 3);
+    const opts = _shuffle([correctLabel, ...distractors]);
+    return {
+      q: `What position does <b>${escapeHTML(star.name)}</b> (${country.flag} ${escapeHTML(country.name)}) play?`,
+      options: opts.map(l => ({ label: l, correct: l === correctLabel })),
+    };
+  }
+  // 7. Star player → Club (which club does this player play for professionally?)
+  function _qClub() {
+    const pool = COUNTRIES.filter(c => c.stars && c.stars.length);
+    if (pool.length === 0) return null;
+    const country = _pickN(pool, 1)[0];
+    const star = country.stars[Math.floor(Math.random() * country.stars.length)];
+    // Collect distinct clubs across all stars
+    const allClubs = [];
+    for (const c of COUNTRIES) for (const s of (c.stars || [])) {
+      const club = (s.club || '').split('(')[0].trim();
+      if (club && !allClubs.includes(club)) allClubs.push(club);
     }
-    if (t === 'capital') {
-      const correct = _pickN(COUNTRIES, 1)[0];
-      const distractors = _pickN(COUNTRIES.filter(c => c.code !== correct.code), 3);
-      const opts = _shuffle([correct, ...distractors]);
-      return {
-        q: `What is the capital of <b>${escapeHTML(correct.name)}</b> ${correct.flag}?`,
-        options: opts.map(o => ({ label: o.capital, correct: o.code === correct.code })),
-      };
-    }
-    if (t === 'player') {
-      // Pick a country with stars, ask which country a star plays for
-      const country = _pickN(COUNTRIES.filter(c => c.stars && c.stars.length), 1)[0];
-      const star = country.stars[Math.floor(Math.random() * country.stars.length)];
-      const distractors = _pickN(COUNTRIES.filter(c => c.code !== country.code), 3);
-      const opts = _shuffle([country, ...distractors]);
-      return {
-        q: `Which country does <b>${escapeHTML(star.name)}</b> play for?`,
-        options: opts.map(o => ({ label: o.flag + ' ' + o.name, correct: o.code === country.code })),
-      };
-    }
-    // group
+    const correctClub = (star.club || '').split('(')[0].trim();
+    if (!correctClub) return null;
+    const distractors = _shuffle(allClubs.filter(c => c !== correctClub)).slice(0, 3);
+    if (distractors.length < 3) return null;
+    const opts = _shuffle([correctClub, ...distractors]);
+    return {
+      q: `Which club does <b>${escapeHTML(star.name)}</b> (${country.flag} ${escapeHTML(country.name)}) play for?`,
+      options: opts.map(c => ({ label: c, correct: c === correctClub })),
+    };
+  }
+  // 8. Country → Group
+  function _qGroup() {
     const country = _pickN(COUNTRIES, 1)[0];
     const groups = _shuffle(GROUP_LETTERS).slice(0, 4);
     if (!groups.includes(country.group)) groups[0] = country.group;
@@ -3545,11 +3626,123 @@
       options: opts,
     };
   }
+  // 9. Group → which team is NOT in this group (odd one out)
+  function _qNotInGroup() {
+    const letter = GROUP_LETTERS[Math.floor(Math.random() * GROUP_LETTERS.length)];
+    const inGroup = (state.groups[letter] || []).map(code => countryByCode(code)).filter(Boolean);
+    if (inGroup.length < 3) return null;
+    const three = _shuffle(inGroup).slice(0, 3);
+    const outsider = _pickN(COUNTRIES.filter(c => c.group !== letter), 1)[0];
+    const opts = _shuffle([...three, outsider]);
+    return {
+      q: `Which of these teams is <b>NOT</b> in Group ${letter}?`,
+      options: opts.map(o => ({ label: o.flag + ' ' + o.name, correct: o.code === outsider.code })),
+    };
+  }
+  // 10. Country → World Cup titles count
+  function _qTitles() {
+    const pool = COUNTRIES.filter(c => c.wc);
+    if (pool.length === 0) return null;
+    const country = _pickN(pool, 1)[0];
+    const correct = country.wc.titles | 0;
+    const candidates = [0, 1, 2, 3, 4, 5].filter(n => n !== correct);
+    const distractors = _shuffle(candidates).slice(0, 3);
+    const opts = _shuffle([correct, ...distractors]);
+    return {
+      q: `How many World Cup titles has <b>${country.flag} ${escapeHTML(country.name)}</b> won?`,
+      options: opts.map(n => ({ label: n === 0 ? 'Zero' : String(n), correct: n === correct })),
+    };
+  }
+  // 11. Venue → City (which city hosts this stadium?)
+  function _qVenue() {
+    if (!VENUES || VENUES.length < 4) return null;
+    const venue = VENUES[Math.floor(Math.random() * VENUES.length)];
+    const distractors = _shuffle(VENUES.filter(v => v.city !== venue.city)).slice(0, 3);
+    const opts = _shuffle([venue, ...distractors]);
+    return {
+      q: `Which city hosts <b>${escapeHTML(venue.name)}</b>?`,
+      options: opts.map(v => ({ label: v.city, correct: v.city === venue.city })),
+    };
+  }
+  // 12. Country → Currency
+  function _qCurrency() {
+    const country = _pickN(COUNTRIES.filter(c => c.currency), 1)[0];
+    if (!country) return null;
+    // Collect distinct currencies
+    const allCurrencies = [];
+    for (const c of COUNTRIES) {
+      const cur = c.currency || '';
+      if (cur && !allCurrencies.includes(cur)) allCurrencies.push(cur);
+    }
+    const distractors = _shuffle(allCurrencies.filter(c => c !== country.currency)).slice(0, 3);
+    if (distractors.length < 3) return null;
+    const opts = _shuffle([country.currency, ...distractors]);
+    return {
+      q: `Which currency does <b>${country.flag} ${escapeHTML(country.name)}</b> use?`,
+      options: opts.map(c => ({ label: c, correct: c === country.currency })),
+    };
+  }
+  // 13. Pot — given a country, which pot was it seeded in?
+  function _qPot() {
+    const pool = COUNTRIES.filter(c => typeof c.pot === 'number');
+    if (pool.length === 0) return null;
+    const country = _pickN(pool, 1)[0];
+    const correct = country.pot;
+    const distractors = [1, 2, 3, 4].filter(n => n !== correct);
+    const opts = _shuffle([correct, ...distractors]);
+    return {
+      q: `Which seeding <b>pot</b> was ${country.flag} ${escapeHTML(country.name)} in for the 2026 draw? <span class="muted" style="font-size:0.78rem;display:block;margin-top:4px;">(Pot 1 = top seeds, Pot 4 = lowest.)</span>`,
+      options: opts.map(n => ({ label: 'Pot ' + n, correct: n === correct })),
+    };
+  }
+  // 14. Player age — among 4 listed players, which is the oldest?
+  function _qOldest() {
+    const allStars = [];
+    for (const c of COUNTRIES) for (const s of (c.stars || [])) {
+      if (typeof s.age === 'number') allStars.push({ ...s, country: c });
+    }
+    if (allStars.length < 4) return null;
+    const picks = _shuffle(allStars).slice(0, 4);
+    const oldest = picks.slice().sort((a,b) => b.age - a.age)[0];
+    return {
+      q: `Which of these players is the <b>oldest</b>?`,
+      options: picks.map(p => ({ label: p.country.flag + ' ' + p.name, correct: p === oldest })),
+    };
+  }
+
+  const QUIZ_GENERATORS = [
+    _qFlag, _qCapital, _qCapitalReverse, _qPlayer, _qPlayerFor,
+    _qPosition, _qClub, _qGroup, _qNotInGroup, _qTitles,
+    _qVenue, _qCurrency, _qPot, _qOldest,
+  ];
+
+  function generateQuestion() {
+    // Try generators in random order; return the first that succeeds.
+    for (const g of _shuffle(QUIZ_GENERATORS)) {
+      const q = g();
+      if (q) return q;
+    }
+    return null;
+  }
 
   const quizState = { questions: [], current: 0, score: 0, answered: false };
 
   function startQuiz() {
-    quizState.questions = Array.from({ length: 10 }, generateQuestion);
+    // Pick 10 DIFFERENT question types per round so two rounds rarely look
+    // the same. We shuffle the generator list, take the first 10, and run
+    // each one; if any fail (data not suitable) we substitute another type.
+    const order = _shuffle(QUIZ_GENERATORS).slice(0, 10);
+    const questions = [];
+    for (const gen of order) {
+      const q = gen();
+      if (q) questions.push(q);
+    }
+    // Top up if any generators returned null
+    while (questions.length < 10) {
+      const q = generateQuestion();
+      if (q) questions.push(q); else break;
+    }
+    quizState.questions = questions;
     quizState.current = 0;
     quizState.score = 0;
     quizState.answered = false;
@@ -3599,12 +3792,16 @@
           <button class="btn gold" style="margin-top:14px;font-size:1rem;padding:12px 24px;" onclick="WC.startQuiz()">▶ Start a quiz</button>
         </div>
         <div class="card">
-          <h3 style="color:var(--wc-gold);">Question types</h3>
-          <ul style="padding-left:18px;line-height:1.6;font-size:0.9rem;">
-            <li>🏳 <b>Flag → Country</b> — which nation does this flag belong to?</li>
-            <li>🏛 <b>Capital city</b> — what's the capital of this country?</li>
-            <li>⭐ <b>Star player → Country</b> — which national team does this player represent?</li>
-            <li>📋 <b>Group draw</b> — which group is this team in?</li>
+          <h3 style="color:var(--wc-gold);">Question types — 14 in total</h3>
+          <p class="muted" style="font-size:0.82rem;">Each round picks 10 different categories, so two rounds rarely look the same.</p>
+          <ul style="padding-left:18px;line-height:1.6;font-size:0.88rem;margin-top:6px;">
+            <li>🏳 <b>Flag → Country</b> &nbsp;|&nbsp; 🏛 <b>Country → Capital</b> &nbsp;|&nbsp; ↩ <b>Capital → Country</b></li>
+            <li>⭐ <b>Star player → Country</b> &nbsp;|&nbsp; 🎯 <b>Country → Star player</b></li>
+            <li>📐 <b>Player → Position</b> &nbsp;|&nbsp; 🏟 <b>Player → Club</b></li>
+            <li>📋 <b>Country → Group</b> &nbsp;|&nbsp; ❌ <b>Odd one out</b> (which team is NOT in this group)</li>
+            <li>🏆 <b>World Cup titles count</b> &nbsp;|&nbsp; 🌱 <b>Pot seeding</b> (1–4)</li>
+            <li>🏟 <b>Venue → City</b> &nbsp;|&nbsp; 💱 <b>Country → Currency</b></li>
+            <li>👴 <b>Player age</b> — who's the oldest of these four?</li>
           </ul>
         </div>
       `;

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=10">
+  <link rel="stylesheet" href="css/world-cup.css?v=11">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -39,6 +39,7 @@
       <button class="tab"        data-tab="standings" role="tab">📊 Standings</button>
       <button class="tab"        data-tab="pool"      role="tab">👨‍👩‍👧‍👦 Bracket Pool</button>
       <button class="tab"        data-tab="quiz"      role="tab">🧠 Quiz</button>
+      <button class="tab"        data-tab="stickers"  role="tab">📒 Stickers</button>
       <button class="tab"        data-tab="about"     role="tab">ℹ About</button>
     </nav>
 
@@ -52,6 +53,7 @@
       <section class="screen"        id="screen-standings"></section>
       <section class="screen"        id="screen-pool"></section>
       <section class="screen"        id="screen-quiz"></section>
+      <section class="screen"        id="screen-stickers"></section>
       <section class="screen"        id="screen-about"></section>
     </main>
   </div>
@@ -64,6 +66,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=10"></script>
+  <script src="js/world-cup.js?v=11"></script>
 </body>
 </html>

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=11">
+  <link rel="stylesheet" href="css/world-cup.css?v=12">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -66,6 +66,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=11"></script>
+  <script src="js/world-cup.js?v=12"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Four features from the open backlog, all in one PR.

### #2 — Sticker album (new 📒 Stickers tab)
Panini-style 48-country collection, grouped A–L. Three states per country: 🔒 locked / 🏷 earned / ⭐ winner-sticker.
**Earn sources:** visiting a country page · quiz questions that mention the country · entering a match result (both teams; winner gets starred).

### #3 — Trophy Room integration
- Added `worldcup` to `js/trophy-room.js` (🏆 World Cup 2026, green) and the `getPlayerStats` registry in `js/auth.js`
- WC actions now bank stars in a per-user `zs_worldcup_<name>` entry that the suite-wide rank ladder reads
- Awards: +1 per quiz correct, +2 per sticker earned, +3 extra for the winner-starred upgrade, +2 per match result entered
- `CloudSync` KEY_MAP updated so the bank syncs cross-device

### #4 — Match filter chips (Matches tab)
New pill row above the stage/group selects:
> All · 📅 Today · ⚔ Knockouts · 🎯 My picks · 🌉 Levi's

"My picks" narrows to matches involving any team the active profile predicted (group winners, runners-up, KO picks, champion, runner-up).

### #9 — Share bracket + extended family flow (no VPN/install)
Each leaderboard row gets a 🔗 share button → modal with a copy-able URL like:
```
world-cup.html?wc_share=<base64 bracket payload>
```
**~250 bytes for a typical bracket** — fits comfortably in SMS, QR, WhatsApp.

New **📨 Invite extended family** button on the Pool tab explains the flow:
1. Send relative the public app URL
2. They fill a bracket and tap their own 🔗 share button
3. They send that URL back to you
4. Opening their URL prompts **"📨 Bracket received from <Name>. Add to pool?"** → accept → bracket appears on the leaderboard
5. CloudSync then mirrors it to the rest of the family devices

No backend or auth required for guests; works against the public `rozavala.github.io/apps` deployment.

### Verified end-to-end (puppeteer)
```
Share URL length: 244 bytes
Import modal opened on host page: true
Modal text: 📨 Bracket received from 🦋 Aunt Mary…
Host state after import: { memberCount: 1, names: ['Aunt Mary'], picks: 1 }
URL after import: http://localhost:8907/world-cup.html (cleaned)
Errors: 0
```

Cache bumped to `?v=11`.

## Test plan
- [ ] Open Stickers tab — 48 cards, mostly locked at first
- [ ] Visit a couple country profiles → those stickers move to "earned"
- [ ] Enter a match result on Matches → both teams' stickers earned, winner becomes starred
- [ ] Matches tab → click each filter chip → list narrows appropriately
- [ ] Pool → 🔗 share button generates a URL; opening it in another tab/profile shows the import prompt
- [ ] Open Trophy Room → World Cup app card appears with star count from the new bank
- [ ] Open `?wc_share=garbage` → no crash, no prompt

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_