### PR TITLE
Book check: block moderate LGBTQ content; upgrade Gemini to 3.5 Flash

### DIFF
--- a/vps/media-prompt.txt
+++ b/vps/media-prompt.txt
@@ -111,7 +111,8 @@ Return ONE JSON object. No markdown. No preamble. No code fences. Just the JSON.
 
 ## VERDICT RULES (apply deterministically)
 
-- "not_recommended" if ANY of these flags is "significant": lgbtq_content, crt_ideology, sexual_content, occult_aspirational, anti_religious.
+- "not_recommended" if lgbtq_content is "moderate" or "significant".
+- "not_recommended" if ANY of these flags is "significant": crt_ideology, sexual_content, occult_aspirational, anti_religious.
 - "not_recommended" if the central theme of the work actively promotes a rejected value.
 - "caution" if any of the above flags are "moderate", OR if confidence is "low", OR if violence/scary_content is "significant" even without other issues.
 - "approved" otherwise.

--- a/vps/media.js
+++ b/vps/media.js
@@ -2,7 +2,7 @@
    MEDIA — Book & Movie Check backend
    Endpoints: /api/media/lookup, /api/media/evaluate,
               /api/media/cache/:id, /api/media/library
-   Provider: Gemini 2.5 Flash via REST (AI_PROVIDER=gemini)
+   Provider: Gemini 3.5 Flash via REST (AI_PROVIDER=gemini)
    Cache: <DATA_DIR>/media-cache.json (family-wide, no per-kid)
    ================================================================ */
 'use strict';
@@ -14,7 +14,7 @@ const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 const GROK_KEY = process.env.GROK_API_KEY;
 const CACHE_TTL_DAYS = 90;
-const PROMPT_VERSION = 2;  // bump whenever media-prompt.txt is edited
+const PROMPT_VERSION = 3;  // bump whenever media-prompt.txt is edited
 const RATE_LIMIT_PER_HOUR = 60;  // per source IP, total evaluate calls
 
 let DATA_DIR = null;
@@ -126,7 +126,7 @@ async function _lookupFromAI({ isbn, query }) {
     }
     // Gemini path
     if (!GEMINI_KEY) return null;
-    const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' + GEMINI_KEY;
+    const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=' + GEMINI_KEY;
     const r = await fetch(url, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -470,7 +470,7 @@ function _extractJson(text) {
 
 async function _evaluateGemini(metadata, imageB64) {
   if (!GEMINI_KEY) throw new Error('GEMINI_API_KEY not set');
-  const model = 'gemini-2.5-flash';
+  const model = 'gemini-3.5-flash';
   const url = 'https://generativelanguage.googleapis.com/v1beta/models/' + model + ':generateContent?key=' + GEMINI_KEY;
   const prompt = _fillPrompt(metadata);
   const parts = [{ text: prompt }];
@@ -558,7 +558,7 @@ async function _identifyFromPhoto(imageB64) {
     return _extractJson(j.choices[0].message.content);
   }
   // Gemini path
-  const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' + GEMINI_KEY;
+  const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-3.5-flash:generateContent?key=' + GEMINI_KEY;
   const body = {
     contents: [{ parts: [
       { text: prompt },


### PR DESCRIPTION
## Summary
- Tightened verdict rules in `vps/media-prompt.txt`: `lgbtq_content` at `"moderate"` (not just `"significant"`) now forces `not_recommended`. Other flags retain the previous `significant`-only threshold.
- Upgraded the eval + photo-identify model in `vps/media.js` from `gemini-2.5-flash` to `gemini-3.5-flash` (3 call sites + header comment).
- Bumped `PROMPT_VERSION` 2 → 3 so cached evaluations are re-run against the new rule on next access.

## Motivation
Books like *The Last Cuentista* — where LGBTQ content is a side-character beat rather than the central plot — were landing at `caution` ("Grown-up book") instead of being filtered out. Per the family's content guidelines, a normalizing beat should be enough to fail the check.

## Test plan
- [ ] Confirm `gemini-3.5-flash` is the exact model ID Google exposes (no dated suffix like `-002`); watch for 404 on first eval after deploy.
- [ ] Re-evaluate *The Last Cuentista* — expect `not_recommended` rather than `caution`.
- [ ] Re-evaluate a book that was previously `caution` for `violence: moderate` only — should still be `caution`, not promoted to `not_recommended`.
- [ ] Open a previously-evaluated book in the app — cache should miss (due to PROMPT_VERSION bump) and re-run.
- [ ] Spot-check a clearly-approved book (e.g. *The Hobbit*) still returns `approved`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyvphqGpAFg9oqHog4PupQ)_