### PR TITLE
book-movie-check: raise client fetch timeout to 60s for grounded eval

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -10,7 +10,7 @@ var BMC = (function() {
 
   var VPS = 'https://real-options-dev.tail57521e.ts.net';
   var STORAGE_PREFIX = 'zs_bmcheck_';
-  var FETCH_TIMEOUT = 20000;  // 20s — AI evaluations can take 5-10s
+  var FETCH_TIMEOUT = 60000;  // 60s — Gemini calls with google_search grounding routinely take 15-30s, plus Wikipedia enrichment adds ~1s
 
   // In-memory caches
   var _familyLibrary = {};   // canonical_id -> full evaluation (synced across family via VPS cache)

--- a/vps/media.js
+++ b/vps/media.js
@@ -452,9 +452,10 @@ async function _trailerForTmdbId(tmdbId) {
 // English Wikipedia article and appending it to the metadata gives the
 // LLM long-form plot context to evaluate against.
 async function _fetchWikipediaPlot(metadata) {
+  const debug = { fetched: false };
   try {
     const title = metadata.title;
-    if (!title) return null;
+    if (!title) { debug.reason = 'no title'; return { extract: null, debug: debug }; }
     const author = metadata.author_or_director || '';
     const ua = { 'User-Agent': 'ZavalaFamilyApps/1.0 (rozavala@gmail.com)' };
 
@@ -463,21 +464,22 @@ async function _fetchWikipediaPlot(metadata) {
       + '&limit=3&namespace=0&format=json'
       + '&search=' + encodeURIComponent(searchTerms);
     const sr = await fetch(searchUrl, { headers: ua });
-    if (!sr.ok) return null;
+    if (!sr.ok) { debug.reason = 'opensearch http ' + sr.status; return { extract: null, debug: debug }; }
     const sj = await sr.json();
     const pageTitles = sj[1] || [];
-    if (!pageTitles.length) return null;
+    if (!pageTitles.length) { debug.reason = 'no search match'; return { extract: null, debug: debug }; }
     const pageTitle = pageTitles[0];
+    debug.page_title = pageTitle;
 
     const extractUrl = 'https://en.wikipedia.org/w/api.php?action=query'
       + '&format=json&prop=extracts&explaintext=1&redirects=1'
       + '&titles=' + encodeURIComponent(pageTitle);
     const er = await fetch(extractUrl, { headers: ua });
-    if (!er.ok) return null;
+    if (!er.ok) { debug.reason = 'extracts http ' + er.status; return { extract: null, debug: debug }; }
     const ej = await er.json();
     const pages = (ej.query && ej.query.pages) || {};
     const firstPage = Object.values(pages)[0];
-    if (!firstPage || !firstPage.extract) return null;
+    if (!firstPage || !firstPage.extract) { debug.reason = 'no extract on page'; return { extract: null, debug: debug }; }
 
     let extract = firstPage.extract;
 
@@ -488,16 +490,22 @@ async function _fetchWikipediaPlot(metadata) {
     if (author) {
       const haystack = extract.toLowerCase();
       const tokens = author.split(/[\s,]+/).filter(t => t.length >= 3).map(t => t.toLowerCase());
-      if (tokens.length && !tokens.some(t => haystack.includes(t))) return null;
+      if (tokens.length && !tokens.some(t => haystack.includes(t))) {
+        debug.reason = 'author token mismatch (' + tokens.join('/') + ' not in extract)';
+        return { extract: null, debug: debug };
+      }
     }
 
     // Cap length — keep the lede + early plot section, drop release
     // history / awards lists at the tail.
     if (extract.length > 4000) extract = extract.slice(0, 4000) + '...';
-    return extract;
+    debug.fetched = true;
+    debug.length = extract.length;
+    return { extract: extract, debug: debug };
   } catch (e) {
     console.warn('[media] Wikipedia plot lookup failed:', e.message);
-    return null;
+    debug.reason = 'exception: ' + e.message;
+    return { extract: null, debug: debug };
   }
 }
 
@@ -552,10 +560,22 @@ async function _evaluateGemini(metadata, imageB64) {
     throw new Error('Gemini ' + r.status + ': ' + errText.slice(0, 200));
   }
   const j = await r.json();
-  const text = j.candidates && j.candidates[0] && j.candidates[0].content && j.candidates[0].content.parts &&
-               j.candidates[0].content.parts[0] && j.candidates[0].content.parts[0].text;
+  const candidate = j.candidates && j.candidates[0];
+  const text = candidate && candidate.content && candidate.content.parts &&
+               candidate.content.parts[0] && candidate.content.parts[0].text;
   if (!text) throw new Error('Gemini returned empty response');
-  return _extractJson(text);
+  const evaluation = _extractJson(text);
+  const gm = candidate.groundingMetadata;
+  const grounding = gm ? {
+    queries: gm.webSearchQueries || [],
+    sources: (gm.groundingChunks || [])
+      .map(c => ({
+        title: (c.web && c.web.title) || '',
+        uri: (c.web && c.web.uri) || ''
+      }))
+      .filter(s => s.uri)
+  } : null;
+  return { evaluation: evaluation, grounding: grounding, model: model };
 }
 
 async function _evaluateGrok(metadata, imageB64) {
@@ -586,23 +606,39 @@ async function _evaluateGrok(metadata, imageB64) {
   const j = await r.json();
   const text = j.choices && j.choices[0] && j.choices[0].message && j.choices[0].message.content;
   if (!text) throw new Error('Grok returned empty response');
-  return _extractJson(text);
+  return { evaluation: _extractJson(text), grounding: null, model: model };
 }
 
 async function _evaluate(metadata, imageB64) {
   let augmented = metadata;
-  const wikiPlot = await _fetchWikipediaPlot(metadata);
-  if (wikiPlot) {
+  const wiki = await _fetchWikipediaPlot(metadata);
+  if (wiki.extract) {
     augmented = Object.assign({}, metadata, {
       synopsis: (metadata.synopsis || '').trim()
         + (metadata.synopsis ? '\n\n' : '')
         + '--- Wikipedia article (excerpt) ---\n'
-        + wikiPlot
+        + wiki.extract
     });
-    console.log('[media] Augmented synopsis for "' + metadata.title + '" with Wikipedia extract (' + wikiPlot.length + ' chars)');
+    console.log('[media] Augmented synopsis for "' + metadata.title + '" with Wikipedia extract (' + wiki.extract.length + ' chars, page: ' + wiki.debug.page_title + ')');
+  } else {
+    console.log('[media] No Wikipedia augmentation for "' + metadata.title + '": ' + wiki.debug.reason);
   }
-  if (PROVIDER === 'grok') return _evaluateGrok(augmented, imageB64);
-  return _evaluateGemini(augmented, imageB64);
+  const result = (PROVIDER === 'grok')
+    ? await _evaluateGrok(augmented, imageB64)
+    : await _evaluateGemini(augmented, imageB64);
+  // Attach diagnostic trail so each cache entry is self-explanatory:
+  // GET /api/media/cache/:id will reveal exactly what the LLM saw and
+  // which sources it pulled. Kept under _debug to make it easy to strip
+  // from any client-facing payload later if desired.
+  result.evaluation._debug = {
+    model: result.model,
+    provider: PROVIDER,
+    prompt_version: PROMPT_VERSION,
+    synopsis_used: (augmented.synopsis || '').slice(0, 4000),
+    wikipedia: wiki.debug,
+    grounding: result.grounding
+  };
+  return result.evaluation;
 }
 
 // ── Photo identification (vision call) ───────────────────────────

--- a/vps/media.js
+++ b/vps/media.js
@@ -14,7 +14,7 @@ const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 const GROK_KEY = process.env.GROK_API_KEY;
 const CACHE_TTL_DAYS = 90;
-const PROMPT_VERSION = 3;  // bump whenever media-prompt.txt is edited
+const PROMPT_VERSION = 4;  // bump whenever media-prompt.txt is edited or eval inputs change
 const RATE_LIMIT_PER_HOUR = 60;  // per source IP, total evaluate calls
 
 let DATA_DIR = null;
@@ -444,6 +444,63 @@ async function _trailerForTmdbId(tmdbId) {
   } catch (e) { return null; }
 }
 
+// ── Wikipedia plot enrichment ────────────────────────────────────
+// Publisher blurbs from Google Books / OpenLibrary are marketing copy
+// and routinely omit content that matters for this family's evaluation
+// (e.g. The Last Cuentista's same-sex side couple is absent from every
+// jacket synopsis but discussed in detail on Wikipedia). Fetching the
+// English Wikipedia article and appending it to the metadata gives the
+// LLM long-form plot context to evaluate against.
+async function _fetchWikipediaPlot(metadata) {
+  try {
+    const title = metadata.title;
+    if (!title) return null;
+    const author = metadata.author_or_director || '';
+    const ua = { 'User-Agent': 'ZavalaFamilyApps/1.0 (rozavala@gmail.com)' };
+
+    const searchTerms = author ? (title + ' ' + author) : title;
+    const searchUrl = 'https://en.wikipedia.org/w/api.php?action=opensearch'
+      + '&limit=3&namespace=0&format=json'
+      + '&search=' + encodeURIComponent(searchTerms);
+    const sr = await fetch(searchUrl, { headers: ua });
+    if (!sr.ok) return null;
+    const sj = await sr.json();
+    const pageTitles = sj[1] || [];
+    if (!pageTitles.length) return null;
+    const pageTitle = pageTitles[0];
+
+    const extractUrl = 'https://en.wikipedia.org/w/api.php?action=query'
+      + '&format=json&prop=extracts&explaintext=1&redirects=1'
+      + '&titles=' + encodeURIComponent(pageTitle);
+    const er = await fetch(extractUrl, { headers: ua });
+    if (!er.ok) return null;
+    const ej = await er.json();
+    const pages = (ej.query && ej.query.pages) || {};
+    const firstPage = Object.values(pages)[0];
+    if (!firstPage || !firstPage.extract) return null;
+
+    let extract = firstPage.extract;
+
+    // Sanity check: confirm this article is about the same work. If the
+    // author was provided, at least one significant author token must
+    // appear in the extract; otherwise we may have grabbed a different
+    // work with the same title.
+    if (author) {
+      const haystack = extract.toLowerCase();
+      const tokens = author.split(/[\s,]+/).filter(t => t.length >= 3).map(t => t.toLowerCase());
+      if (tokens.length && !tokens.some(t => haystack.includes(t))) return null;
+    }
+
+    // Cap length — keep the lede + early plot section, drop release
+    // history / awards lists at the tail.
+    if (extract.length > 4000) extract = extract.slice(0, 4000) + '...';
+    return extract;
+  } catch (e) {
+    console.warn('[media] Wikipedia plot lookup failed:', e.message);
+    return null;
+  }
+}
+
 // ── AI providers ─────────────────────────────────────────────────
 
 function _fillPrompt(metadata) {
@@ -475,12 +532,15 @@ async function _evaluateGemini(metadata, imageB64) {
   const prompt = _fillPrompt(metadata);
   const parts = [{ text: prompt }];
   if (imageB64) parts.push({ inlineData: { mimeType: 'image/jpeg', data: imageB64 } });
+  // Google Search grounding lets the model pull parent reviews, Common
+  // Sense Media notes, Wikipedia plot details etc. during evaluation
+  // rather than relying solely on the publisher synopsis. Incompatible
+  // with responseMimeType: 'application/json' — _extractJson handles any
+  // markdown fences or preamble the model emits.
   const body = {
     contents: [{ parts: parts }],
-    generationConfig: {
-      temperature: 0.2,
-      responseMimeType: 'application/json'
-    }
+    tools: [{ google_search: {} }],
+    generationConfig: { temperature: 0.2 }
   };
   const r = await fetch(url, {
     method: 'POST',
@@ -530,8 +590,19 @@ async function _evaluateGrok(metadata, imageB64) {
 }
 
 async function _evaluate(metadata, imageB64) {
-  if (PROVIDER === 'grok') return _evaluateGrok(metadata, imageB64);
-  return _evaluateGemini(metadata, imageB64);
+  let augmented = metadata;
+  const wikiPlot = await _fetchWikipediaPlot(metadata);
+  if (wikiPlot) {
+    augmented = Object.assign({}, metadata, {
+      synopsis: (metadata.synopsis || '').trim()
+        + (metadata.synopsis ? '\n\n' : '')
+        + '--- Wikipedia article (excerpt) ---\n'
+        + wikiPlot
+    });
+    console.log('[media] Augmented synopsis for "' + metadata.title + '" with Wikipedia extract (' + wikiPlot.length + ' chars)');
+  }
+  if (PROVIDER === 'grok') return _evaluateGrok(augmented, imageB64);
+  return _evaluateGemini(augmented, imageB64);
 }
 
 // ── Photo identification (vision call) ───────────────────────────


### PR DESCRIPTION
## Summary

Fixes "Re-review failed: signal is aborted without reason" surfaced after #306.

Gemini calls with `google_search` grounding routinely take 15–30s (the model issues live web searches before responding), plus ~1s for the Wikipedia enrichment fetch. The previous 20s client-side `AbortController` fired before the server responded.

Bumps the single `FETCH_TIMEOUT` knob in `js/book-movie-check.js` from 20s to 60s.

## Test plan

- [ ] Trigger a re-review on a previously-failing book and confirm the spinner stays up until the response arrives (no more abort).
- [ ] Confirm a normal cache-hit lookup still feels instant (timeout is a ceiling, not a floor).
- [ ] Spot-check `_debug.grounding.sources` is populated on the resulting cache entry.

https://claude.ai/code/session_01MyvphqGpAFg9oqHog4PupQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyvphqGpAFg9oqHog4PupQ)_