### PR TITLE
media: mild LGBTQ -> not_recommended + redact topic from kid view

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -12,6 +12,13 @@ var BMC = (function() {
   var STORAGE_PREFIX = 'zs_bmcheck_';
   var FETCH_TIMEOUT = 60000;  // 60s — Gemini calls with google_search grounding routinely take 15-30s, plus Wikipedia enrichment adds ~1s
 
+  // In kid mode, the LGBTQ chip and any concerns text touching the topic
+  // are redacted entirely. Verdict is still "not_recommended" so the kid
+  // sees "Not for our family" — they just don't read about what specifically.
+  // Patterns are intentionally broad; false positives only redact non-parent
+  // text, which is acceptable.
+  var LGBTQ_KEYWORD_RE = /\b(lgbtq?\+?|gay|lesbian|queer|same[\s-]?sex|transgender|non[\s-]?binary|gender\s+identity|pride\s+flag|drag\s+queen|she\/her\/they|pronouns?)\b/i;
+
   // In-memory caches
   var _familyLibrary = {};   // canonical_id -> full evaluation (synced across family via VPS cache)
   var _currentResult = null; // last shown evaluation
@@ -870,6 +877,9 @@ var BMC = (function() {
       chipHtml = flagOrder.map(function(k) {
         var sev = (e.content_flags || {})[k];
         if (!sev || sev === 'none') return '';
+        // Kid mode: the LGBTQ chip is never shown — kids don't read the
+        // label even at "mild". Parents still see it on unlock.
+        if (!isParent && k === 'lgbtq_content') return '';
         return '<span class="bmc-chip bmc-chip-' + sev + '">' + flagLabels[k] + ' · ' + sev + '</span>';
       }).join('');
       var posLabels = {
@@ -891,9 +901,18 @@ var BMC = (function() {
 
     var concernsHtml = '';
     if (showConcerns && e.specific_concerns && e.specific_concerns.length) {
-      concernsHtml = '<div class="bmc-card"><h4>Things to know</h4><ul>' +
-        e.specific_concerns.map(function(c) { return '<li>' + _escHtmlLocal(c) + '</li>'; }).join('') +
-        '</ul></div>';
+      // Kid mode: drop any concern line that names LGBTQ topics, so the
+      // child never reads a phrase like "casual mention of a side
+      // character with same-sex parents". If nothing remains after
+      // filtering, the card is omitted entirely.
+      var concerns = !isParent
+        ? e.specific_concerns.filter(function(c) { return !LGBTQ_KEYWORD_RE.test(String(c)); })
+        : e.specific_concerns;
+      if (concerns.length) {
+        concernsHtml = '<div class="bmc-card"><h4>Things to know</h4><ul>' +
+          concerns.map(function(c) { return '<li>' + _escHtmlLocal(c) + '</li>'; }).join('') +
+          '</ul></div>';
+      }
     } else if (isCaution && !isParent && e.confidence !== 'low') {
       var nFlags = 0;
       if (e.content_flags) {

--- a/vps/media-prompt.txt
+++ b/vps/media-prompt.txt
@@ -111,7 +111,7 @@ Return ONE JSON object. No markdown. No preamble. No code fences. Just the JSON.
 
 ## VERDICT RULES (apply deterministically)
 
-- "not_recommended" if lgbtq_content is "moderate" or "significant".
+- "not_recommended" if lgbtq_content is anything other than "none" (i.e. "mild", "moderate", or "significant"). Even a one-line background mention is not acceptable for this family.
 - "not_recommended" if ANY of these flags is "significant": crt_ideology, sexual_content, occult_aspirational, anti_religious.
 - "not_recommended" if the central theme of the work actively promotes a rejected value.
 - "caution" if any of the above flags are "moderate", OR if confidence is "low", OR if violence/scary_content is "significant" even without other issues.

--- a/vps/media.js
+++ b/vps/media.js
@@ -14,7 +14,7 @@ const PROVIDER = (process.env.AI_PROVIDER || 'gemini').toLowerCase();
 const GEMINI_KEY = process.env.GEMINI_API_KEY;
 const GROK_KEY = process.env.GROK_API_KEY;
 const CACHE_TTL_DAYS = 90;
-const PROMPT_VERSION = 4;  // bump whenever media-prompt.txt is edited or eval inputs change
+const PROMPT_VERSION = 5;  // bump whenever media-prompt.txt is edited or eval inputs change
 const RATE_LIMIT_PER_HOUR = 60;  // per source IP, total evaluate calls
 
 let DATA_DIR = null;


### PR DESCRIPTION
## Summary

Two related changes following the *The Last Cuentista* re-review (which came back as `caution` with `lgbtq_content: mild` after #306 wired in Wikipedia + search grounding).

**Policy tightening (`vps/media-prompt.txt`)**
Verdict rule rewritten so any LGBTQ content rates `not_recommended`, including the one-line background mention the prompt defined as `mild`. The previous rule (mild → approved) let side-character beats slip through.

**Kid-mode UI redaction (`js/book-movie-check.js`)**
A child who scans a flagged book should not read about the topic by name. Two filters added behind a single `LGBTQ_KEYWORD_RE`:
- The `LGBTQ content` chip is suppressed in kid mode (parents still see it on PIN unlock).
- `specific_concerns` entries matching the keyword are filtered out; if nothing remains, the "Things to know" card is omitted entirely.

**Cache refresh (`vps/media.js`)**
`PROMPT_VERSION` bumped 4 → 5 so the existing `POST /api/media/reevaluate-stale` flow refreshes entries cached under the old rule.

## Test plan

- [ ] After deploy, hit `POST /api/media/reevaluate-stale` and confirm *The Last Cuentista* flips to `not_recommended`.
- [ ] In kid mode: confirm no `LGBTQ content` chip is rendered and no concern line mentions the topic.
- [ ] In parent mode (PIN unlocked): confirm chip and full `specific_concerns` are visible again.
- [ ] Approved book in kid mode (no LGBTQ content) still shows its normal chips/concerns — regex shouldn't false-positive on common words.
- [ ] Spot-check `_debug.grounding.sources` is populated on the refreshed entry to confirm grounded eval ran.

https://claude.ai/code/session_01MyvphqGpAFg9oqHog4PupQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyvphqGpAFg9oqHog4PupQ)_