### PR TITLE
BMC: route Re-review errors through the same Tailscale-actionable classifier (#259 follow-up)

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -1103,7 +1103,7 @@ var BMC = (function() {
       })
       .catch(function(err) {
         console.warn('[BMC] Re-review failed:', err);
-        _setStatus('Re-review failed: ' + (err && err.message ? err.message : 'unknown'), 'error');
+        _setStatus(_userMsgForFetchErr(err, 're-review'), 'error');
       });
   }
 


### PR DESCRIPTION
## What the diag showed

Two BMC Re-review failures from the same kid in the latest 72 h window:

| Message | Count |
|---|---|
| `[BMC] Re-review failed: Failed to fetch` | ×2 |
| `[BMC] Re-review failed: signal is aborted without reason` | ×3 |

Both surfaced **verbatim** to the kid because `rereviewCurrent`'s catch handler is the one BMC site PR #259's `_userMsgForFetchErr` classifier missed.

## Fix

One-line change: route the error through the existing `_userMsgForFetchErr(err, 're-review')` so the kid sees the same actionable message every other VPS-touching path already shows:

- `TypeError: Failed to fetch` / `Load failed` → `"Can't reach the book server. Open the Tailscale app on this device, then try again."`
- `AbortError` (the 20s `_fetchJson` timeout) → `"The re-review timed out. Check your connection and try again."`

## Test plan

- [ ] With Tailscale off on iPad, tap "🔄 Re-review this book" on a result → status shows Tailscale-actionable message (not "Failed to fetch")
- [ ] Pause a deliberate 30s on the VPS to force a timeout → status shows "timed out" message
- [ ] Normal re-review still works when VPS is reachable (regression)


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_