### PR TITLE
docs: update unified explorer rank names and table

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A core feature of the Zavala Serra Apps suite is helping kids develop healthy di
 ## 🛠️ Características Principales (Key Features)
 
 - **Perfiles Personalizados (Personalized Profiles)**: Los niños pueden crear sus propios exploradores con avatares y colores personalizados. (Kids can create their own explorers with custom avatars and colors).
-- **Rango de Explorador Unificado (Unified Explorer Rank)**: Gana rangos en toda la suite (Cadete → Leyenda) al dominar diferentes materias. (Earn ranks across the entire app suite (Cadet → Legend) by mastering different subjects).
+- **Rango de Explorador Unificado (Unified Explorer Rank)**: Gana rangos en toda la suite (Cadete → Grand Master) al dominar diferentes materias. (Earn ranks across the entire app suite (Cadet → Grand Master) by mastering different subjects).
 - **Dificultad Adaptativa (Age-Adaptive Difficulty)**: El contenido se ajusta automáticamente a la edad de cada niño para un desafío adecuado. (Content automatically adjusts to each child's age for an appropriate challenge level).
 - **Seguimiento de Progreso (Progress Tracking)**: Todas las estrellas, niveles y puntuaciones se guardan localmente usando `localStorage`. (All stars, levels, and scores are saved locally using `localStorage`).
 - **Panel de Padres (Parent Dashboard)**: Un área segura para monitorear el progreso y balance con insights para cada niño. (A secure area to monitor progress and balance with insights for each child).
@@ -93,7 +93,18 @@ All content in this repository adheres to the [Content Guidelines](content-guide
   |____|
   /    \
 ```
-¡Bienvenidos, exploradores! Tu misión es aprender nuevas habilidades, descubrir hechos asombrosos y completar desafíos para subir de rango, de Cadete a Leyenda. ¡Aprende jugando! (Welcome, explorers! Your mission is to learn new skills, discover amazing facts, and complete challenges to rank up from Cadet to Legend. Learn by playing!)
+¡Bienvenidos, exploradores! Tu misión es aprender nuevas habilidades, descubrir hechos asombrosos y completar desafíos para subir de rango, de Cadete a Grand Master. ¡Aprende jugando! (Welcome, explorers! Your mission is to learn new skills, discover amazing facts, and complete challenges to rank up from Cadet to Grand Master. Learn by playing!)
+
+| Rango (Rank) | Estrellas (Stars) | Ícono (Icon) |
+| --- | --- | --- |
+| Cadet | 0 | 🛸 |
+| Apprentice | 15 | 🌟 |
+| Veteran | 30 | 🛡️ |
+| Explorer | 60 | 🌍 |
+| Pilot | 100 | 🚀 |
+| Astronaut | 150 | 🌌 |
+| Elite | 250 | 💎 |
+| Grand Master | 500 | 👑 |
 
 ## 🚀 Instalación y Uso (Getting Started)
 

--- a/content-guidelines.md
+++ b/content-guidelines.md
@@ -20,7 +20,7 @@ Build fun, factual, skill-based learning apps for our kids. Every app should fee
 - **Language**: Vocabulary, reading, spelling — neutral educational content.
 - **Catholic Faith**: Common prayers (Padre Nuestro, Ave María, Gloria), factual saint biographies (dates, locations, historical facts), Chilean Catholic heritage (churches, patron saints, religious festivals as cultural-historical facts), interactive rosary (mystery names and bead counting). All content must be factual and historical.
 - **Art History**: References to famous artists and styles (e.g., Seurat pointillism, Mondrian De Stijl, pixel art) must be factual and educational. No modern art commentary or political art.
-- **Values**: Hard work, curiosity, exploration, family, perseverance, sportsmanship. Progression through effort — ranks earned by demonstrating skill across multiple subjects. Rank names (Cadet, Explorer, Pilot, Commander, Legend) are skill-based and not tied to identity markers.
+- **Values**: Hard work, curiosity, exploration, family, perseverance, sportsmanship. Progression through effort — ranks earned by demonstrating skill across multiple subjects. Rank names (Cadet, Apprentice, Veteran, Explorer, Pilot, Astronaut, Elite, Grand Master) are skill-based and not tied to identity markers.
 
 ## Strictly Excluded Content
 


### PR DESCRIPTION
This PR updates the documentation to correctly reflect the Unified Explorer ranks progression as defined in `js/auth.js`.

Changes:
- Replaced mentions of "Cadete -> Leyenda" with "Cadete -> Grand Master" in `README.md`.
- Added a bilingual markdown table illustrating the rank progression, required stars, and icons to the `README.md` "For Explorers" section.
- Updated the comma-separated ranks list in the `content-guidelines.md` "Values" bullet to exactly match the 8 official skill-based rank names (Cadet, Apprentice, Veteran, Explorer, Pilot, Astronaut, Elite, Grand Master).

All changes follow the strict vanilla Markdown and content guideline rules. Compliance verifications passed.

---
*PR created automatically by Jules for task [1120260735503792807](https://jules.google.com/task/1120260735503792807) started by @rozavala*