### PR TITLE
sports-arena: fix match delete/edit (renderHistory is not defined)

### DIFF
--- a/sports-arena.html
+++ b/sports-arena.html
@@ -748,7 +748,7 @@
       return;
     }
     SportsArena.editMatch(matchId, { score1: s1, score2: s2 });
-    renderHistory();
+    renderStandings();
   }
 
   function deleteMatchInline(matchId) {
@@ -757,7 +757,7 @@
     if (!m) return;
     if (!confirm(`Delete this match?\n${m.player1} ${m.score1} – ${m.score2} ${m.player2}`)) return;
     SportsArena.deleteMatch(matchId);
-    renderHistory();
+    renderStandings();
   }
 
   // ════════════════════════════════════════


### PR DESCRIPTION
## What the diag showed

```
sports-arena | Uncaught ReferenceError: renderHistory is not defined | line 760 | ×2
```

That's the "records can't be deleted" bug you reported.

## Root cause

`deleteMatchInline` (line 760) and `editMatchInline` (line 751) both call `renderHistory()`, but **no such function exists**. The recent-matches list — including its 🗑 delete and ✏️ edit buttons — is rendered inside `renderStandings()` (the "Recent matches" block at the bottom of that function).

So when a kid confirmed a delete, `SportsArena.deleteMatch()` actually removed it from storage, but the very next line threw a ReferenceError that aborted the UI refresh. The list never re-rendered, so it looked like the delete did nothing.

## Fix

Point both handlers at `renderStandings()`, which re-renders the standings table **and** the recent-matches list. Two-line change.

## Test plan

- [ ] Log a match in Sports Arena → it appears in Recent matches
- [ ] Tap 🗑 → confirm → match disappears immediately, no console error
- [ ] Tap ✏️ → change a score → standings + match list update immediately
- [ ] Standings table reflects the deleted/edited match correctly


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_