### PR TITLE
little-maestro: fix MIDI init crash on WebMIDIBrowser (unstable connection)

### DIFF
--- a/little-maestro.html
+++ b/little-maestro.html
@@ -9498,7 +9498,15 @@ const MIDIManager = (() => {
       return Promise.resolve(false);
     }
 
-    return _accessPromise
+    // Some iOS MIDI shims (WebMIDIBrowser 1.0.6) return a thenable whose
+    // .then() does NOT return a chainable promise — so `_accessPromise
+    // .then(...).catch(...)` evaluates `.catch` on undefined and throws
+    // "undefined is not an object", crashing init() on every retry and
+    // making the connection look very unstable. Promise.resolve() adopts
+    // the thenable into a genuine native Promise, so the .then().catch()
+    // chain below is always valid and any shim misbehaviour surfaces as a
+    // rejection through our .catch instead of an uncaught throw.
+    return Promise.resolve(_accessPromise)
       .then(access => {
         try {
           if (typeof Debug !== 'undefined') Debug.log('[MIDI] Access granted');


### PR DESCRIPTION
## What the diag showed (and what you reported)

```
little-maestro | TypeError: undefined is not an object (near '...})...') | line 9549 | ×12
  stack: init@little-maestro.html:9549:9  →  @9773:19
  UA:    WebMIDIBrowser/1.0.6 (iPad iOS 16.7)
```

You reported the piano MIDI connection as **"very unstable"** — this is the cause.

## Root cause

WebMIDIBrowser's `navigator.requestMIDIAccess()` returns a **thenable** (so PR #274's `typeof _accessPromise.then === 'function'` guard passes), but its `.then()` does **not** return a chainable promise. So:

```js
_accessPromise.then(access => {…}).catch(err => {…})
//                                 ^^^^^ .catch on undefined → throws
```

`init()` threw on the very first call **and** on every `_scheduleRetry()` tick, so the connection flickered between half-initialised states — the instability you saw. The `})` on line 9549 is immediately followed by `.catch`, which is why Safari attributed the throw there.

## Fix

Wrap the shim's return in `Promise.resolve()`, which adopts the thenable into a genuine native Promise. The `.then().catch()` chain then runs on a real Promise (so `.catch` always exists), and any shim misbehaviour surfaces as a **rejection through the existing `.catch`** (→ disconnected state + retry) instead of an uncaught crash.

Reproduced in node:

```
shim.then(()=>{}).catch(()=>{})        → throws (reading 'catch')
Promise.resolve(shim).then().catch()   → safe, returns a Promise
```

## Test plan

- [ ] On the iPad in WebMIDIBrowser, open Little Maestro → no console crash at init; status pill settles on a stable state
- [ ] Plug in the MIDI keyboard → connects and **stays** connected (no flicker)
- [ ] Unplug/replug → reconnects cleanly without crashing
- [ ] Chrome desktop with a real MIDI device → still connects normally (regression — `Promise.resolve` on a native promise is a no-op passthrough)
- [ ] Chrome desktop with no device → disconnected + retry loop as before


---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_