### PR TITLE
sports-arena: read family matches from shared store so deletes stick

### DIFF
--- a/js/sports-arena.js
+++ b/js/sports-arena.js
@@ -230,56 +230,19 @@ const SportsArena = (() => {
       .reverse();
   }
 
-  // Iterate every profile's zs_sports_<kid> blob and merge match
-  // arrays. Deduplicates when the same match was logged twice (once
-  // by each kid) using a fingerprint of date + sport + ordered
-  // player/score pair, so "Leo vs Ana 3-1" and "Ana vs Leo 1-3"
-  // collapse into one row.
+  // Read from the single shared match bucket — the same store that
+  // logMatch/editMatch/deleteMatch mutate. Earlier this scanned each
+  // per-kid zs_sports_<kid>.matches blob, but the migration copies
+  // those into the shared bucket without clearing them, so a deleted
+  // match kept reappearing from the stale per-kid copies (on every
+  // device, since each holds its own stale blobs).
   function _getAllFamilyMatches(sportId) {
-    if (typeof getProfiles !== 'function') {
-      // Fallback to current-user behaviour if profiles API isn't loaded.
-      return getMatches(sportId);
-    }
-    const profiles = getProfiles();
-    const seen = {};
-    const merged = [];
-
-    profiles.forEach(p => {
-      const key = 'zs_sports_' + p.name.toLowerCase().replace(/\s+/g, '_');
-      let data;
-      try { data = JSON.parse(localStorage.getItem(key)) || {}; }
-      catch (e) { data = {}; }
-      const list = Array.isArray(data.matches) ? data.matches : [];
-
-      list.forEach(m => {
-        if (sportId && m.sportId !== sportId) return;
-        // Fingerprint ignores player-order and score-order.
-        const names = [String(m.player1 || ''), String(m.player2 || '')].sort();
-        const scores = [Number(m.score1) || 0, Number(m.score2) || 0];
-        // Pair names with their original scores, then sort by name so
-        // the fingerprint is order-insensitive.
-        const pairs = [
-          [String(m.player1 || ''), Number(m.score1) || 0],
-          [String(m.player2 || ''), Number(m.score2) || 0]
-        ].sort((a, b) => a[0].localeCompare(b[0]));
-        const day = (m.date || '').slice(0, 10); // YYYY-MM-DD
-        const fp = [
-          day,
-          String(m.sportId || ''),
-          pairs[0][0] + ':' + pairs[0][1],
-          pairs[1][0] + ':' + pairs[1][1]
-        ].join('|');
-
-        if (seen[fp]) return;
-        seen[fp] = true;
-        merged.push(m);
-      });
-    });
-
+    const matches = _getSharedMatches().slice();
     // Sort ascending by date so .slice(-N).reverse() still means
     // "N most recent, newest first" — matches the prior contract.
-    merged.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
-    return merged;
+    matches.sort((a, b) => String(a.date || '').localeCompare(String(b.date || '')));
+    if (!sportId) return matches;
+    return matches.filter(m => m.sportId === sportId);
   }
 
   // ── Round Robin Tournament ──


### PR DESCRIPTION
## Problem

Deleting a match in Sports Arena didn't stick — on iPad **and** phone. The earlier fix (#316) cleared a JS crash (`renderHistory` ReferenceError) but the delete still failed because of a storage split:

- Every mutation — `logMatch`, `editMatch`, `deleteMatch` — writes to one shared bucket (`zs_sports_matches_shared`).
- But the standings / recent-matches list was read by `_getAllFamilyMatches`, which scanned each kid's **separate** `zs_sports_<kid>.matches` blob.
- The one-time migration copies per-kid matches into the shared bucket but never clears the originals. So a deleted match vanished from the shared bucket yet the stale per-kid copy survived — and re-rendering pulled it right back.

Because every device carries its own stale per-kid blobs, this broke identically across devices.

## Fix

`_getAllFamilyMatches` now reads from `_getSharedMatches()` — the same store the delete/edit/log paths write to — so a delete is reflected on the next render. Date-sort is preserved so `getRecentMatches`' "N most recent, newest first" contract is unchanged.

## Test plan
- [ ] Log a match, delete it from the history list — it stays gone after re-render.
- [ ] Edit a match score — standings update.
- [ ] Standings remain family-wide (all profiles' matches visible) regardless of active kid.

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_