### PR TITLE
Sports Arena: full match history + Manage Players; MIDI input enumeration fix

### DIFF
--- a/js/sports-arena.js
+++ b/js/sports-arena.js
@@ -443,6 +443,21 @@ const SportsArena = (() => {
 
   // ── Players list (from profiles + any extras logged) ──
 
+  // Remove a player entirely: delete every shared match they played in.
+  // Standings and the known-players list both derive from matches, so
+  // purging the matches drops the player from both. Does NOT touch the
+  // auth profile (that's managed in Parents Corner). Returns the number
+  // of matches removed.
+  function deletePlayer(name) {
+    if (!name) return 0;
+    const target = String(name);
+    const matches = _getSharedMatches();
+    const filtered = matches.filter(m => m.player1 !== target && m.player2 !== target);
+    const removed = matches.length - filtered.length;
+    if (removed > 0) _saveSharedMatches(filtered);
+    return removed;
+  }
+
   function getKnownPlayers() {
     const profiles = typeof getProfiles === 'function' ? getProfiles() : [];
     const profileNames = profiles.map(p => p.name);
@@ -489,6 +504,7 @@ const SportsArena = (() => {
     logMatch,
     editMatch,
     deleteMatch,
+    deletePlayer,
     getMatches,
     getRecentMatches,
     createTournament,

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -9298,11 +9298,28 @@ const MIDIManager = (() => {
   // ── internal: choose best input from MIDI access ──
   function _findBestInput(inputs) {
     const inputArr = [];
-    // Use forEach instead of .values().next() for wider browser compat.
-    // Some 3rd-party iOS MIDI hosts (eg. WebMIDIBrowser) expose a
-    // non-iterable inputs object — guard so init doesn't blow up.
-    if (inputs && typeof inputs.forEach === 'function') {
-      inputs.forEach(input => { if (input) inputArr.push(input); });
+    // Collect inputs across the several shapes MIDI hosts use:
+    //   • spec MIDIInputMap → has forEach
+    //   • iterable map → has values()
+    //   • plain object keyed by id → some iOS shims (WebMIDIBrowser)
+    // expose inputs this way, with no forEach, so the old guard found
+    // zero devices and the piano never connected even though access
+    // was granted.
+    if (inputs) {
+      if (typeof inputs.forEach === 'function') {
+        inputs.forEach(input => { if (input) inputArr.push(input); });
+      } else if (typeof inputs.values === 'function') {
+        try { for (const input of inputs.values()) { if (input) inputArr.push(input); } } catch (e) {}
+      } else if (typeof inputs === 'object') {
+        Object.keys(inputs).forEach(k => {
+          const input = inputs[k];
+          if (input && typeof input === 'object') inputArr.push(input);
+        });
+      }
+    }
+    if (typeof Debug !== 'undefined') {
+      Debug.log('[MIDI] inputs found: ' + inputArr.length +
+        (inputArr.length ? ' (' + inputArr.map(i => (i && i.name) || '?').join(', ') + ')' : ''));
     }
     if (inputArr.length === 0) return null;
 

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -69,6 +69,13 @@
           <div class="m-desc">Add custom sports or outdoor activities.</div>
         </div>
       </div>
+      <div class="mode-card" onclick="showScreen('manage-players')">
+        <span class="m-icon">👥</span>
+        <div>
+          <div class="m-title">Manage Players</div>
+          <div class="m-desc">Remove a player and clear their match history.</div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -203,8 +210,8 @@
 
     <div id="standings-content"></div>
     <div style="margin-top:24px;">
-      <div style="font-family:var(--font-display); font-weight:800; font-size:1.1rem; margin-bottom:12px;">Recent Matches</div>
-      <div id="history-list"></div>
+      <div style="font-family:var(--font-display); font-weight:800; font-size:1.1rem; margin-bottom:12px;">Match History</div>
+      <div id="history-list" style="max-height:60vh; overflow-y:auto; -webkit-overflow-scrolling:touch;"></div>
     </div>
   </div>
 
@@ -225,6 +232,18 @@
       </div>
       <button class="btn-primary" onclick="addNewCustomSport()">+ Add Sport</button>
     </div>
+  </div>
+
+  <!-- ============ MANAGE PLAYERS ============ -->
+  <div class="screen" id="screen-manage-players">
+    <div class="section-header">
+      <button class="back-btn" aria-label="Go back" onclick="goMenu()">←</button>
+      <div class="section-title">👥 Manage Players</div>
+    </div>
+    <p style="color:var(--text-muted); font-size:0.85rem; font-weight:600; margin-bottom:16px;">
+      Removing a player deletes every match they played. Their profile (if they have one) is not affected.
+    </p>
+    <div id="players-list"></div>
   </div>
 
   <!-- ============ TOURNAMENT SCORE MODAL ============ -->
@@ -263,6 +282,10 @@
   let tourneySport = null;
   let tourneyPlayers = [];
   let scoreModalCb = null;
+  // Show the full family match history (scrollable), not just a recent
+  // slice — otherwise older matches can't be edited or deleted. Large
+  // enough to cover any realistic family history.
+  const HISTORY_LIMIT = 5000;
 
   // ── Screen navigation ──
   function showScreen(id) {
@@ -275,6 +298,7 @@
     if (id === 'log-activity') initLogActivity();
     if (id === 'standings') initStandings();
     if (id === 'manage-sports') renderSportsList();
+    if (id === 'manage-players') renderPlayersList();
     if (id === 'new-tournament') initNewTournament();
   }
 
@@ -698,7 +722,7 @@
 
     // Recent matches
     const historyEl = document.getElementById('history-list');
-    const recent = SportsArena.getRecentMatches(15);
+    const recent = SportsArena.getRecentMatches(HISTORY_LIMIT);
     if (recent.length === 0) {
       historyEl.innerHTML = '<div style="color:var(--text-muted); font-weight:600; font-size:0.9rem;">No matches recorded yet.</div>';
     } else {
@@ -734,7 +758,7 @@
   }
 
   function editMatchInline(matchId) {
-    const all = SportsArena.getRecentMatches(500);
+    const all = SportsArena.getRecentMatches(HISTORY_LIMIT);
     const m = all.find(x => x.id === matchId);
     if (!m) return;
     const newScore1 = prompt(`Score for ${m.player1}:`, m.score1);
@@ -752,7 +776,7 @@
   }
 
   function deleteMatchInline(matchId) {
-    const all = SportsArena.getRecentMatches(500);
+    const all = SportsArena.getRecentMatches(HISTORY_LIMIT);
     const m = all.find(x => x.id === matchId);
     if (!m) return;
     if (!confirm(`Delete this match?\n${m.player1} ${m.score1} – ${m.score2} ${m.player2}`)) return;
@@ -797,6 +821,47 @@
       SportsArena.removeCustomSport(id);
       renderSportsList();
     }
+  }
+
+  // ════════════════════════════════════════
+  // MANAGE PLAYERS
+  // ════════════════════════════════════════
+
+  function _playerMatchCounts() {
+    const counts = {};
+    SportsArena.getRecentMatches(HISTORY_LIMIT).forEach(m => {
+      if (m.player1) counts[m.player1] = (counts[m.player1] || 0) + 1;
+      if (m.player2) counts[m.player2] = (counts[m.player2] || 0) + 1;
+    });
+    return counts;
+  }
+
+  function renderPlayersList() {
+    const el = document.getElementById('players-list');
+    const players = SportsArena.getKnownPlayers();
+    if (!players.length) {
+      el.innerHTML = '<div style="color:var(--text-muted); font-weight:600;">No players yet. Log a match to add one.</div>';
+      return;
+    }
+    const counts = _playerMatchCounts();
+    el.innerHTML = '<div style="font-weight:800; font-family:var(--font-display); margin-bottom:12px;">Known Players</div>' +
+      players.map(name => {
+        const n = counts[name] || 0;
+        return `
+          <div style="display:flex; align-items:center; gap:12px; padding:12px; background:var(--bg-card); border-radius:var(--radius-sm); margin-bottom:8px; border:1px solid var(--border-subtle);">
+            <span style="flex:1; font-weight:700;">${escHtml(name)}</span>
+            <span style="font-size:0.75rem; color:var(--text-muted); font-weight:600;">${n} match${n === 1 ? '' : 'es'}</span>
+            <button onclick="deletePlayerByName('${escAttr(name)}')" aria-label="Remove player" style="background:none; border:none; color:var(--red); cursor:pointer; font-size:1.1rem;">🗑</button>
+          </div>`;
+      }).join('');
+  }
+
+  function deletePlayerByName(name) {
+    const counts = _playerMatchCounts();
+    const n = counts[name] || 0;
+    if (!confirm('Remove ' + name + ' from Sports Arena?\nThis deletes ' + n + ' match' + (n === 1 ? '' : 'es') + ' they played. Their profile is not affected.')) return;
+    SportsArena.deletePlayer(name);
+    renderPlayersList();
   }
 
   // ── Helpers ──


### PR DESCRIPTION
## Summary

Three fixes drawn from the family's reports and the captured device logs.

### Sports Arena
- **Edit/delete any match.** The history list only rendered the 15 most recent matches, and edit/delete buttons only exist on rendered rows — so older matches couldn't be touched. Now renders the **full family history in a scrollable container**, so every match is reachable.
- **Manage Players screen (new).** Players whose only matches were old lingered in standings and the picker with no way to remove them. Added a menu card + screen listing every known player with their match count and a delete button. `SportsArena.deletePlayer(name)` purges all of that player's matches from the shared store (standings and the known-players list both derive from matches, so they drop off). Does **not** touch the auth profile.

### Little Maestro (MIDI)
- The #317 fix stopped MIDI init from crashing on WebMIDIBrowser — the device logs now show `[MIDI] Access granted` with no error. But after access is granted, `_findBestInput` only enumerated devices when `_access.inputs` exposed `forEach`. Some iOS shims (WebMIDIBrowser) present inputs as a plain id-keyed object, so **zero devices were found and the piano never connected** despite access being granted.
- Now collects inputs across all three shapes — spec `MIDIInputMap` (`forEach`), iterable maps (`values()`), and plain objects (`Object.keys`) — and logs `[MIDI] inputs found: N (names...)` so the next captured log pins down whether the keyboard is being enumerated.

## Test plan
- [ ] Sports Arena → Standings & History: confirm the list scrolls and old matches can be edited/deleted.
- [ ] Sports Arena → Manage Players: confirm players list with counts; delete removes a player's matches and drops them from standings/picker; profile is unaffected.
- [ ] Little Maestro on WebMIDIBrowser with keyboard plugged in: capture logs, confirm `[MIDI] inputs found:` reports the device and the piano connects.

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_