### PR TITLE
World Cup: drop the "More" dropdown, show all tabs again (fixes overlap bug)

### DIFF
--- a/css/world-cup.css
+++ b/css/world-cup.css
@@ -86,13 +86,12 @@ body {
 /* ---- Tabs ---- */
 .tabs {
   display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 6px;
-  overflow-x: auto;
   padding: 14px 4px 8px;
   margin-bottom: 14px;
-  scrollbar-width: none;
 }
-.tabs::-webkit-scrollbar { display: none; }
 .tab {
   flex: 0 0 auto;
   background: var(--wc-card);
@@ -112,30 +111,6 @@ body {
   background: linear-gradient(120deg, var(--wc-green), var(--wc-blue));
   color: white;
   border-color: transparent;
-}
-
-/* ---- "More" overflow menu ---- */
-.tab-more { position: relative; flex: 0 0 auto; }
-.more-menu {
-  display: none;
-  position: absolute;
-  top: 110%;
-  right: 0;
-  z-index: 60;
-  background: var(--bg-card);
-  border: 1px solid var(--wc-line);
-  border-radius: 14px;
-  padding: 8px;
-  box-shadow: 0 12px 40px rgba(0,0,0,0.4);
-  min-width: 180px;
-  flex-direction: column;
-  gap: 4px;
-}
-.tab-more.open .more-menu { display: flex; }
-.more-menu .tab {
-  width: 100%;
-  text-align: left;
-  border-radius: 10px;
 }
 
 /* ---- Global search ---- */

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -3003,15 +3003,9 @@
   /* ----------------------------------------------------------------
      RENDER — tabs
      ---------------------------------------------------------------- */
-  const PRIMARY_TABS = ['home', 'matches', 'pool', 'teams'];
   function activateTab(name) {
     document.querySelectorAll('.tab').forEach(t => t.classList.toggle('active', t.dataset.tab === name));
     document.querySelectorAll('.screen').forEach(s => s.classList.toggle('active', s.id === 'screen-'+name));
-    // Reflect active state on the "More" button when a secondary tab is open
-    const moreBtn = document.getElementById('more-btn');
-    if (moreBtn) moreBtn.classList.toggle('active', name && !PRIMARY_TABS.includes(name));
-    const more = document.getElementById('tab-more');
-    if (more) more.classList.remove('open');
     if (name === 'home')        renderHome();
     if (name === 'santaclara')  renderSantaClara();
     if (name === 'teams')       renderTeams();
@@ -4679,13 +4673,6 @@
     renderMatches();
   }
 
-  /* ---- Navigation: More overflow menu ---- */
-  function toggleMore(ev) {
-    if (ev) ev.stopPropagation();
-    const more = document.getElementById('tab-more');
-    if (more) more.classList.toggle('open');
-  }
-
   /* ---- Global search across teams, venues, matches ---- */
   function search(q) {
     const box = document.getElementById('wc-search-results');
@@ -4989,11 +4976,6 @@
     document.querySelectorAll('.tab[data-tab]').forEach(t => {
       t.addEventListener('click', () => activateTab(t.dataset.tab));
     });
-    // Close the "More" overflow menu when tapping elsewhere
-    document.addEventListener('click', (e) => {
-      const more = document.getElementById('tab-more');
-      if (more && !more.contains(e.target)) more.classList.remove('open');
-    });
     // refresh countdown every second on home
     setInterval(() => {
       if (document.querySelector('.tab.active')?.dataset.tab === 'home') {
@@ -5168,7 +5150,7 @@
     startQuiz, answerQuiz, nextQuestion, resetQuiz,
     openShareBracket, copyShareUrl, openInviteGuest, confirmImportBracket,
     openShareFamilyPool, confirmImportPool,
-    toggleMore, search, searchGo,
+    search, searchGo,
     openCompare, setCompare,
     setFavoriteTeam,
     resetAll,

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=13">
+  <link rel="stylesheet" href="css/world-cup.css?v=14">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -38,20 +38,15 @@
 
     <nav class="tabs" role="tablist">
       <button class="tab active" data-tab="home"      role="tab">🏠 Home</button>
-      <button class="tab"        data-tab="matches"   role="tab">⚽ Matches</button>
-      <button class="tab"        data-tab="pool"      role="tab">👨‍👩‍👧‍👦 Pool</button>
+      <button class="tab"        data-tab="santaclara" role="tab">🌉 Santa Clara</button>
       <button class="tab"        data-tab="teams"     role="tab">🌍 Teams</button>
-      <div class="tab-more" id="tab-more">
-        <button class="tab" id="more-btn" onclick="WC.toggleMore(event)">⋯ More</button>
-        <div class="more-menu" id="more-menu">
-          <button class="tab" data-tab="santaclara" role="tab">🌉 Santa Clara</button>
-          <button class="tab" data-tab="standings" role="tab">📊 Standings</button>
-          <button class="tab" data-tab="venues"    role="tab">🏟 Venues</button>
-          <button class="tab" data-tab="quiz"      role="tab">🧠 Quiz</button>
-          <button class="tab" data-tab="stickers"  role="tab">📒 Stickers</button>
-          <button class="tab" data-tab="about"     role="tab">ℹ About</button>
-        </div>
-      </div>
+      <button class="tab"        data-tab="matches"   role="tab">⚽ Matches</button>
+      <button class="tab"        data-tab="venues"    role="tab">🏟 Venues</button>
+      <button class="tab"        data-tab="standings" role="tab">📊 Standings</button>
+      <button class="tab"        data-tab="pool"      role="tab">👨‍👩‍👧‍👦 Pool</button>
+      <button class="tab"        data-tab="quiz"      role="tab">🧠 Quiz</button>
+      <button class="tab"        data-tab="stickers"  role="tab">📒 Stickers</button>
+      <button class="tab"        data-tab="about"     role="tab">ℹ About</button>
     </nav>
 
     <main>
@@ -77,6 +72,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=13"></script>
+  <script src="js/world-cup.js?v=14"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Fixes the regression you flagged: the **"More" dropdown rendered behind the kickoff-countdown card and was unreadable.**

**Root cause:** the dropdown lived inside the `.tabs` container, which had `overflow-x:auto`. That clips absolutely-positioned children (and forces `overflow-y` to `auto` too), so the menu got clipped and slid under the sibling cards regardless of its z-index.

**Fix:** per your feedback that the all-tabs layout was better, drop the dropdown entirely and show **every tab** again — but with `flex-wrap` so they wrap to multiple rows and stay fully visible instead of horizontal-scrolling. No absolutely-positioned menu = the clipping/z-index bug can't recur. Removed the now-dead `toggleMore`/`more-btn` JS and `.more-menu` CSS. Global search is unchanged.

Cache bumped to `?v=14`.

## Verified (puppeteer)
```
Visible tabs: 10
All tabs activate: true
Search rows for brazil: 4
Errors: 0
```

## Test plan
- [ ] All 10 tabs are visible (wrapping to 2 rows on a phone), none hidden
- [ ] No dropdown overlapping or sliding behind the countdown card
- [ ] Every tab activates on tap
- [ ] Search box still returns and navigates results

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_