### PR TITLE
docs: add world cup 2026 cascade mode update to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ All content in this repository adheres to the [Content Guidelines](content-guide
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Actualización World Cup 2026**: ¡Agregamos modo cascada (grupos → final) para la quiniela! (Added build-up cascade mode (groups → final) to the bracket!)
 - **Actualización Book & Movie Check**: Mensajes de error de red más claros. (Clearer network error messages.)
 - **Actualización World Cup 2026**: ¡Agregamos álbum de figuritas, Trophy Room, filtros de partidos y snapshot de la quiniela familiar! (Added sticker album, Trophy Room, match filters, and family-pool snapshot!)
 - **Nuevas Apps**: ¡Agregamos Civics Lab y World Cup 2026! (Added Civics Lab and World Cup 2026!)


### PR DESCRIPTION
# DAILY DOCS UPDATE [2026-03-24] — Documentation Guardian Agent 
 # Task completed: Added World Cup 2026 cascade mode update to README changelog

---
*PR created automatically by Jules for task [6100536480126820141](https://jules.google.com/task/6100536480126820141) started by @rozavala*