### PR TITLE
World Cup: wire nominations feed to self-hosted data/squads-2026.json

### DIFF
--- a/data/squads-2026.json
+++ b/data/squads-2026.json
@@ -1,0 +1,5 @@
+{
+  "version": "2026-05-31-stub",
+  "notes": "Nominated-squad data for the FIFA World Cup 2026. Populated as squads are announced (FIFA submission deadline: 2026-06-01; official 2026-06-02). Source: Wikipedia (CC BY-SA) — https://en.wikipedia.org/wiki/2026_FIFA_World_Cup_squads. Per-player schema: name (required), pos, club, age, num (shirt), note (all optional). Country keys are 3-letter FIFA codes (e.g. MEX, USA, BRA). While 'squads' is empty or a country is missing, the app falls back to its curated star-player snapshot.",
+  "squads": {}
+}

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -5284,9 +5284,10 @@
            … } }
      A bare { "MEX": [ … ] } object (no wrapper) is also accepted.
      ---------------------------------------------------------------- */
-  // TODO(Tuesday): set this to the published nominated-squads JSON URL.
-  // Until it's non-empty, the app simply keeps showing the curated stars.
-  const NOMINATIONS_URL = '';
+  // Self-hosted nominated-squad feed, committed to this repo at
+  // data/squads-2026.json. Empty squads -> app falls back to curated stars,
+  // so this is safe to point live before the file is populated.
+  const NOMINATIONS_URL = 'https://raw.githubusercontent.com/rozavala/apps/main/data/squads-2026.json';
   const NOMINATIONS_KEY = 'wc2026.nominations';
   let NOMINATIONS = {};          // { CODE: [ {name,pos,club,age,num,note}, … ] }
 
@@ -5343,7 +5344,9 @@
       const n = Object.keys(NOMINATIONS).length;
       const cur = document.querySelector('.tab.active')?.dataset.tab;
       if (cur) activateTab(cur);
-      if (!quiet) toast(`Squads loaded — ${n} team${n === 1 ? '' : 's'} updated`);
+      if (!quiet) toast(n
+        ? `Squads loaded — ${n} team${n === 1 ? '' : 's'} updated`
+        : 'No nominated squads published yet');
     } catch (e) {
       console.error('Nominations sync failed', e);
       if (!quiet) toast('Squad fetch failed: ' + (e.message || 'network error'));

--- a/world-cup.html
+++ b/world-cup.html
@@ -72,6 +72,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=17"></script>
+  <script src="js/world-cup.js?v=18"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Per the deep-research pass: no free, no-auth, all-48-teams squads JSON feed exists in the wild today. (OpenFootball worldcup.json contains only `{name, matches[]}`; rezarahiminia/worldcup2026 has teams/groups/matches/stadiums but no rosters; BALLDONTLIE FIFA requires an API key and a paid tier; Zafronix is unverified behind Cloudflare.)
- Lowest-risk path: **self-host the feed in this repo** at `data/squads-2026.json`, served via `raw.githubusercontent.com`. Tuesday becomes pure data entry — no third-party schema dependency, no auth, no rate limit.
- Stub committed now so `NOMINATIONS_URL` can point live immediately. Empty `squads` is a safe no-op: every country falls back to its curated star-player snapshot via the existing `rosterFor()` guard.

## Changes
- `data/squads-2026.json` — stub with `{ version, notes, squads: {} }` and schema documentation in `notes`. Source attribution to Wikipedia (CC BY-SA) once populated.
- `js/world-cup.js`:
  - `NOMINATIONS_URL` set to `https://raw.githubusercontent.com/rozavala/apps/main/data/squads-2026.json` (was `''`).
  - `syncNominations` toast: friendlier "No nominated squads published yet" when the feed loads but contains 0 squads (the pre-deadline state).
- Cache tag v=17 → v=18.

## Activation Tuesday (2026-06-02)
Squads become official June 2. Workflow on the day:
1. Pull from Wikipedia's [2026 FIFA World Cup squads](https://en.wikipedia.org/wiki/2026_FIFA_World_Cup_squads) (the canonical aggregator that other sites use as their source).
2. Populate `data/squads-2026.json` keyed by 3-letter FIFA code:
   ```json
   { "version": "2026-06-02", "squads": { "MEX": [ {"name":"…","pos":"ST","club":"…","age":25,"num":9} ] } }
   ```
3. Commit and push to `main`. App auto-refreshes on next page load (and the **⟳ Refresh squads** button pulls updates without a reload).

If we want zero-touch updates later, a tiny GitHub Action can re-scrape Wikipedia daily and PR deltas. Out of scope for now.

## Test plan
- [x] `node --check` JS clean.
- [x] `data/squads-2026.json` parses; stub has 3 top-level keys, 0 squads.
- [x] Empty-`squads` path traced through `rosterFor()` — every country falls back to curated stars (no regression).
- [ ] On main after merge: hit `https://raw.githubusercontent.com/rozavala/apps/main/data/squads-2026.json` in a browser to confirm CORS allows the app's fetch (raw.githubusercontent.com is already used for the OpenFootball schedules sync, so this should be fine).
- [ ] Tuesday: populate one team (e.g. MEX), verify the country page shows the full nominated squad with the curated stars flagged ⭐.

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_