### PR TITLE
vps: rename Tailscale hostname real-options-dev → all-options-dev

### DIFF
--- a/js/book-movie-check.js
+++ b/js/book-movie-check.js
@@ -8,7 +8,7 @@
 var BMC = (function() {
   'use strict';
 
-  var VPS = 'https://real-options-dev.tail57521e.ts.net';
+  var VPS = 'https://all-options-dev.tail57521e.ts.net';
   var STORAGE_PREFIX = 'zs_bmcheck_';
   var FETCH_TIMEOUT = 60000;  // 60s — Gemini calls with google_search grounding routinely take 15-30s, plus Wikipedia enrichment adds ~1s
 

--- a/js/debug.js
+++ b/js/debug.js
@@ -8,7 +8,7 @@ var Debug = (function() {
 
   var logs = [];
   var MAX_LOGS = 100;
-  var SYNC_SERVER = 'https://real-options-dev.tail57521e.ts.net';
+  var SYNC_SERVER = 'https://all-options-dev.tail57521e.ts.net';
 
   // ── Device Identification ──
   function _getDeviceId() {

--- a/js/sync.js
+++ b/js/sync.js
@@ -7,7 +7,7 @@ var CloudSync = (function() {
   'use strict';
 
   // ── Set this to your VPS Tailscale IP ──────────────────────
-  var SYNC_SERVER = 'https://real-options-dev.tail57521e.ts.net';
+  var SYNC_SERVER = 'https://all-options-dev.tail57521e.ts.net';
   // ──────────────────────────────────────────────────────────
 
   var KEY_MAP = {

--- a/vps/DIAG_SETUP.md
+++ b/vps/DIAG_SETUP.md
@@ -183,12 +183,12 @@ From any device on Tailscale:
 
 ```bash
 # Post one synthetic entry
-curl -X POST https://real-options-dev.tail57521e.ts.net/api/diag \
+curl -X POST https://all-options-dev.tail57521e.ts.net/api/diag \
   -H 'Content-Type: application/json' \
   -d '{"schema":1,"entries":[{"kind":"test","message":"hello from setup","ts":'$(date +%s%3N)'}]}'
 
 # Trigger a push now (equivalent to the dashboard button)
-curl -X POST https://real-options-dev.tail57521e.ts.net/api/diag/flush
+curl -X POST https://all-options-dev.tail57521e.ts.net/api/diag/flush
 ```
 
 Then check the `diag` branch on GitHub — there should be a commit with
@@ -278,7 +278,7 @@ key with very narrow repo scope, not a shell login key.)
 Check `/api/diag/health`:
 
 ```bash
-curl -sS https://real-options-dev.tail57521e.ts.net/api/diag/health
+curl -sS https://all-options-dev.tail57521e.ts.net/api/diag/health
 ```
 
 If `entries_last_24h` is 0, the browser isn't posting. Possible reasons:

--- a/vps/audit-media-prompt.js
+++ b/vps/audit-media-prompt.js
@@ -20,7 +20,7 @@ function argVal(name, def) {
   const i = args.indexOf(name);
   return i >= 0 ? args[i + 1] : def;
 }
-const VPS = argVal('--vps', 'https://real-options-dev.tail57521e.ts.net');
+const VPS = argVal('--vps', 'https://all-options-dev.tail57521e.ts.net');
 const BAIL = args.includes('--bail');
 const ONLY = argVal('--only', null);
 


### PR DESCRIPTION
## Summary

The VPS Tailscale device was renamed to **`all-options-dev`**, but every app + the diag pipeline + the media-audit script still pointed at the old **`real-options-dev`** hostname, breaking sync, diagnostics, and book/movie lookups against the droplet.

Updated all 7 references across 5 files to the new hostname:

| File | What it controls |
|---|---|
| `js/debug.js:11` | Diag log push from any app |
| `js/sync.js:10` | Cloud sync for app data |
| `js/book-movie-check.js:11` | BMC media-evaluation calls |
| `vps/audit-media-prompt.js:23` | Regression audit script default |
| `vps/DIAG_SETUP.md` (×3) | Setup doc curl examples |

## Test plan
- [ ] App data sync round-trips (Sports Arena, Little Maestro, etc.)
- [ ] Push to Cloud from any app lands on the `diag` branch
- [ ] Book & Movie Check returns evaluation results

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_