### PR TITLE
docs: optimize grep hook command and add notes on expected matches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,8 +43,10 @@ Antes de hacer commit, debes verificar tu código:
 Antes de cada push, ejecuta el siguiente comando obligatorio para asegurarte de que no se hayan introducido palabras prohibidas:
 
 ```bash
-grep -r -i -E "genero|género|identidad|diversidad|inclusi[oó]n|pronombre|trans |gay|lesbiana|queer|pride|diverso|equidad|justicia social|colonialismo|opres|patriarcado|feminis|woke|diversity|equity|inclusion|gender |lgbt|transgender" --include="*.html" --include="*.js" --include="*.md" .
+grep -r -i -E "genero|género|identidad|diversidad|inclusi[oó]n|pronombre|trans |gay|lesbiana|queer|pride|diverso|equidad|justicia social|colonialismo|opres|patriarcado|feminis|woke|diversity|equity|inclusion|gender |lgbt|transgender" --include="*.html" --include="*.js" --include="*.md" --exclude-dir="node_modules" --exclude-dir=".git" .
 ```
+
+*Nota: Las coincidencias en la documentación de reglas (content-guidelines.md, CONTRIBUTING.md) o en la lógica de pruebas se esperan y no constituyen una violación.* (Note: Matches in rule documentation or test logic are expected and do not constitute a violation.)
 
 ## 🤖 Reglas para Agentes de IA (AI Agent Rules)
 

--- a/content-guidelines.md
+++ b/content-guidelines.md
@@ -67,8 +67,10 @@ The following topics must **never** appear in any app, quiz, story, image captio
 Run this before each push to catch accidental keyword drift:
 
 ```bash
-grep -r -i -E "genero|género|identidad|diversidad|inclusi[oó]n|pronombre|trans |gay|lesbiana|queer|pride|diverso|equidad|justicia social|colonialismo|opres|patriarcado|feminis|woke|diversity|equity|inclusion|gender |lgbt|transgender" --include="*.html" --include="*.js" --include="*.md" .
+grep -r -i -E "genero|género|identidad|diversidad|inclusi[oó]n|pronombre|trans |gay|lesbiana|queer|pride|diverso|equidad|justicia social|colonialismo|opres|patriarcado|feminis|woke|diversity|equity|inclusion|gender |lgbt|transgender" --include="*.html" --include="*.js" --include="*.md" --exclude-dir="node_modules" --exclude-dir=".git" .
 ```
+
+*Note: Matches in rule documentation (`content-guidelines.md`, `CONTRIBUTING.md`) or test logic are expected and do not constitute a violation.*
 
 ## Review Checklist (Per Feature)
 


### PR DESCRIPTION
Optimized the required pre-commit `grep` hook command described in `CONTRIBUTING.md` and `content-guidelines.md` by appending `--exclude-dir="node_modules" --exclude-dir=".git"`. This prevents the command from timing out or returning irrelevant matches from dependencies or git history. Also added a clarifying note indicating that self-referential matches within the rule documentation itself (or test logic) are expected and do not constitute a policy violation. Checked with compliance tests and `npm run test` strictly to verify isolating test changes.

---
*PR created automatically by Jules for task [17245948399407002520](https://jules.google.com/task/17245948399407002520) started by @rozavala*