### PR TITLE
content: factual additions to Descubre Chile, Story Explorer, World Explorer

### DIFF
--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -395,7 +395,9 @@ const QB={
     {q:'¿Qué es un "completo"?',a:'Hot dog con palta',o:['Hot dog con palta','Desayuno completo','Torta','Torneo de fútbol'], tier:'beginner'},
     {q:'¿Cuándo se comen más empanadas?',a:'Fiestas Patrias',o:['Fiestas Patrias','Navidad','Semana Santa','Año Nuevo'], tier:'beginner'},
     {q:'¿Qué famoso sándwich lleva carne, porotos verdes, tomate y ají verde?',a:'Chacarero',o:['Chacarero','Barros Luco','Italiano','Chemilico'], tier:'intermediate'},
-    {q:'¿En qué mes se celebran las Fiestas Patrias en Chile?',a:'Septiembre',o:['Septiembre','Diciembre','Julio','Octubre'], tier:'beginner'}
+    {q:'¿En qué mes se celebran las Fiestas Patrias en Chile?',a:'Septiembre',o:['Septiembre','Diciembre','Julio','Octubre'], tier:'beginner'},
+    {q:'¿En qué ciudad del extremo sur se celebra el Carnaval de Invierno?',a:'Punta Arenas',o:['Punta Arenas','Valparaíso','La Serena','Iquique'], tier:'advanced'},
+    {q:'¿Qué embarcación tradicional usaban los Chonos en los canales del sur?',a:'Dalca',o:['Dalca','Caravela','Goleta','Balsa de totora'], tier:'advanced'}
   ],
   nature:[
     {q:'¿Qué árbol nativo chileno puede vivir miles de años?',a:'Alerce',o:['Alerce','Pino','Eucalipto','Roble',
@@ -411,7 +413,9 @@ const QB={
     {q:'¿Qué corriente trae agua fría?',a:'Corriente de Humboldt',o:['Corriente de Humboldt','Corriente del Golfo','Anillo del Pacífico','Flujo chileno'], tier:'advanced'},
     {q:'¿Qué animal del sur es un ciervo pequeño?',a:'Pudú',o:['Pudú','Huemul','Guanaco','Zorro'], tier:'beginner'},
     {q:'¿En qué parte viven los pingüinos en Chile?',a:'En el sur',o:['En el sur','En el desierto','En Santiago','En Isla de Pascua'], tier:'intermediate'},
-    {q:'¿Qué pájaro habita en los salares del norte?',a:'Flamenco',o:['Flamenco','Cóndor','Gaviota','Pelícano'], tier:'beginner'}
+    {q:'¿Qué pájaro habita en los salares del norte?',a:'Flamenco',o:['Flamenco','Cóndor','Gaviota','Pelícano'], tier:'beginner'},
+    {q:'¿Qué ave corredora habita las estepas patagónicas?',a:'Ñandú',o:['Ñandú','Avestruz','Pingüino','Cóndor'], tier:'intermediate'},
+    {q:'¿Cuál es el árbol nacional de Chile, sagrado para los Mapuche?',a:'Araucaria',o:['Araucaria','Alerce','Coihue','Roble'], tier:'advanced'}
   ],
   famous:[
     {q:'¿Quién escribió "Altazor"?',a:'Vicente Huidobro',o:['Vicente Huidobro','Pablo Neruda','Gabriela Mistral','Nicanor Parra'], tier:'expert'},
@@ -422,7 +426,9 @@ const QB={
     {q:'¿Cuándo ganó Chile la Copa América?',a:'2015',o:['2015','2000','1990','1970'], tier:'intermediate'},
     {q:'¿En qué billete está Gabriela Mistral?',a:'5.000 pesos',o:['5.000 pesos','1.000 pesos','10.000 pesos','20.000 pesos'], tier:'expert'},
     {q:'¿Qué deporte practicaba Marcelo Ríos?',a:'Tenis',o:['Tenis','Fútbol','Gimnasia','Natación'], tier:'beginner'},
-    {q:'¿En qué año fue Marcelo Ríos número 1 del mundo?',a:'1998',o:['1998','2000','1995','2005'], tier:'advanced'}
+    {q:'¿En qué año fue Marcelo Ríos número 1 del mundo?',a:'1998',o:['1998','2000','1995','2005'], tier:'advanced'},
+    {q:'¿Qué explorador cruzó por primera vez el estrecho que lleva su nombre en 1520?',a:'Hernando de Magallanes',o:['Hernando de Magallanes','Cristóbal Colón','Pedro de Valdivia','Diego de Almagro'], tier:'expert'},
+    {q:'¿Quién compuso la canción "Gracias a la vida"?',a:'Violeta Parra',o:['Violeta Parra','Víctor Jara','Los Jaivas','Margot Loyola'], tier:'intermediate'}
   ],
   inventors:[
     {q:'¿Qué científico chileno ayudó a crear la vacuna de la hepatitis B?',a:'Pablo Valenzuela',o:['Pablo Valenzuela','Humberto Maturana','Francisco Varela','Ignacio Domeyko'], tier:'expert'},

--- a/js/story-explorer.js
+++ b/js/story-explorer.js
@@ -10,6 +10,42 @@ const StoryExplorer = (() => {
   // ── Story Library ──
   const STORIES = [
     {
+      id: 'ocean_dive',
+      title: 'The Ocean Dive',
+      titleEs: 'El Buceo en el Océano',
+      tier: 'intermediate', ageMin: 7, region: 'ocean', icon: '🤿',
+      pages: [
+        {
+          en: 'The divers jumped into the deep blue water.',
+          es: 'Los buzos saltaron al agua azul profunda.',
+          vocab: [
+            { word: 'divers', wordEs: 'buzos', def: 'People who swim underwater.', defEs: 'Personas que nadan bajo el agua.' },
+            { word: 'deep', wordEs: 'profunda', def: 'Going far down.', defEs: 'Que va muy abajo.' }
+          ]
+        },
+        {
+          en: 'They saw colorful fish and a large sea turtle.',
+          es: 'Vieron peces coloridos y una gran tortuga marina.',
+          vocab: [
+            { word: 'colorful', wordEs: 'coloridos', def: 'Having many bright colors.', defEs: 'Que tiene muchos colores brillantes.' },
+            { word: 'turtle', wordEs: 'tortuga', def: 'An animal with a hard shell.', defEs: 'Un animal con un caparazón duro.' }
+          ]
+        },
+        {
+          en: 'It was a beautiful day exploring the coral reef.',
+          es: 'Fue un hermoso día explorando el arrecife de coral.',
+          vocab: [
+            { word: 'reef', wordEs: 'arrecife', def: 'A ridge of coral or rock under the sea.', defEs: 'Una cresta de coral o roca bajo el mar.' },
+            { word: 'coral', wordEs: 'coral', def: 'A hard structure built by tiny sea animals.', defEs: 'Una estructura dura construida por pequeños animales marinos.' }
+          ]
+        }
+      ],
+      quiz: [
+        { q: 'Who jumped into the water?', qEs: '¿Quiénes saltaron al agua?', options: ['Pilots', 'Drivers', 'Divers', 'Runners'], optionsEs: ['Pilotos', 'Conductores', 'Buzos', 'Corredores'], answer: 2 },
+        { q: 'What animal did they see?', qEs: '¿Qué animal vieron?', options: ['Shark', 'Turtle', 'Whale', 'Dolphin'], optionsEs: ['Tiburón', 'Tortuga', 'Ballena', 'Delfín'], answer: 1 }
+      ]
+    },
+    {
       id: 'andes_rescue',
       title: 'The Andes Rescue',
       titleEs: 'El Rescate en los Andes',

--- a/js/world-explorer.js
+++ b/js/world-explorer.js
@@ -233,6 +233,25 @@ const WorldExplorer = (() => {
     },
     { id: 'north_america', name: 'North America', nameEs: 'América del Norte', icon: '🌎', color: '#8B5CF6', countries: [
       {
+        id: 'united_states', name: 'United States', nameEs: 'Estados Unidos', flag: '🇺🇸',
+        capital: 'Washington, D.C.', capitalEs: 'Washington, D.C.',
+        facts: [
+          { en: 'The United States is made up of 50 states.', es: 'Estados Unidos está formado por 50 estados.' },
+          { en: 'The Grand Canyon in Arizona is over a mile deep.', es: 'El Gran Cañón en Arizona tiene más de un kilómetro y medio de profundidad.' },
+          { en: 'The Statue of Liberty was a gift from France in 1886.', es: 'La Estatua de la Libertad fue un regalo de Francia en 1886.' },
+          { en: 'The Apollo 11 mission landed astronauts on the Moon in 1969.', es: 'La misión Apolo 11 llevó astronautas a la Luna en 1969.' }
+        ],
+        landmark: { name: 'Statue of Liberty', nameEs: 'Estatua de la Libertad', emoji: '🗽' },
+        animal: { name: 'Bald Eagle', nameEs: 'Águila Calva', emoji: '🦅' },
+        quiz: [
+          { q: 'What is the capital of the United States?', qEs: '¿Cuál es la capital de Estados Unidos?', options: ['New York', 'Washington, D.C.', 'Los Angeles', 'Chicago'], optionsEs: ['Nueva York', 'Washington, D.C.', 'Los Ángeles', 'Chicago'], answer: 1 },
+          { q: 'How many states make up the U.S.?', qEs: '¿Cuántos estados forman EE.UU.?', options: ['48', '50', '52', '45'], optionsEs: ['48', '50', '52', '45'], answer: 1 },
+          { q: 'In which state is the Grand Canyon?', qEs: '¿En qué estado está el Gran Cañón?', options: ['Arizona', 'Texas', 'Florida', 'Nevada'], optionsEs: ['Arizona', 'Texas', 'Florida', 'Nevada'], answer: 0 },
+          { q: 'Where is the Statue of Liberty?', qEs: '¿Dónde está la Estatua de la Libertad?', options: ['Miami', 'Boston', 'New York', 'Seattle'], optionsEs: ['Miami', 'Boston', 'Nueva York', 'Seattle'], answer: 2 },
+          { q: 'What is the U.S. national bird?', qEs: '¿Cuál es el ave nacional de EE.UU.?', options: ['Bald Eagle', 'Hawk', 'Falcon', 'Owl'], optionsEs: ['Águila Calva', 'Halcón', 'Falcón', 'Búho'], answer: 0 }
+        ]
+      },
+      {
         id: 'canada', name: 'Canada', nameEs: 'Canadá', flag: '🇨🇦',
         capital: 'Ottawa', capitalEs: 'Ottawa',
         facts: [


### PR DESCRIPTION
## Summary

The salvageable, in-guidelines content from the closed #342 — rewritten cleanly. No rewrites of working code, no fabricated `PRUNED` comments, no test-baseline overwrites.

### Descubre Chile — +6 quiz Qs (within current per-category caps)
- **culture**: Carnaval de Invierno de Punta Arenas, dalcas de los Chonos
- **nature**: ñandú patagónico, araucaria (national tree, sacred to the Mapuche)
- **famous**: Magallanes 1520 strait crossing, Violeta Parra ("Gracias a la vida")

### Story Explorer — +1 story "Ocean Dive"
3-page intermediate-tier marine-science reading with bilingual vocab definitions and a 2-question comprehension quiz. Matches the existing `def/defEs` + `quiz` schema (no schema drift).

### World Explorer — +1 country "United States" in North America
Capital, 4 facts (50 states, Grand Canyon, Statue of Liberty, Apollo 11), Bald Eagle, 5 quiz questions. Fills a glaring gap — only Canada and Mexico were listed in North America.

## Compliance
- All content factual and historical per `content-guidelines.md`.
- Compliance grep: additions introduce zero banned keywords (the lone pre-existing match for "género" refers to musical genre in a Patricio Manns description, already on `main`).
- Three `.js` files parse-check cleanly.

## Test plan
- [ ] Descubre Chile: load each category (culture/nature/famous), confirm new Qs appear with correct answers
- [ ] Story Explorer: "Ocean Dive" shows in the library, all 3 pages render, vocab tooltips work, quiz scores correctly
- [ ] World Explorer → North America → United States loads facts, landmark, and 5-Q quiz

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_