### PR TITLE
# DAILY DOCS UPDATE [2026-03-24] — Documentation Guardian Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All content in this repository adheres to the [Content Guidelines](content-guide
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Nuevo Contenido**: Agregamos contenido factual a Descubre Chile, Story Explorer y World Explorer. (Added factual content to Descubre Chile, Story Explorer, and World Explorer.)
 - **Mejora en el Hub (Hub Update)**: Confirmación de dos toques al eliminar perfiles para mayor seguridad. (Tap-to-confirm defense when deleting profiles.)
 - **Actualización World Cup 2026**: Integración de proxy de resultados en vivo de ESPN en el VPS, con OpenFootball como respaldo. (World Cup: ESPN live-scores proxy on the VPS, OpenFootball as fallback.)
 - **Actualización Infraestructura**: Se actualizó el hostname de Tailscale para la sincronización familiar (`all-options-dev`). (Updated Tailscale hostname for family sync to `all-options-dev`.)


### PR DESCRIPTION
As the Documentation Guardian Agent, I successfully:
- Checked the `README.md` for the "Novedades de la Semana" section.
- Added a new bullet point acknowledging recent content updates (`- **Nuevo Contenido**: Agregamos contenido factual a Descubre Chile, Story Explorer y World Explorer. (Added factual content to Descubre Chile, Story Explorer, and World Explorer.)`).
- Verified compliance via the mandatory `grep` check.
- Ran tests and confirmed no new regressions were introduced by this documentation-only update.
- Recorded learning regarding test evaluations during documentation updates.

---
*PR created automatically by Jules for task [16935631431571722810](https://jules.google.com/task/16935631431571722810) started by @rozavala*