### PR TITLE
little-maestro: fix profile-cap lockout and index/data sync races

### DIFF
--- a/js/lm-bridge.js
+++ b/js/lm-bridge.js
@@ -69,10 +69,33 @@
         if (typeof Debug !== 'undefined') Debug.warn('[LM-Bridge] Create failed, trying load: ' + e.message);
         console.warn('[LM-Bridge] Create failed, trying load:', e.message);
         try { UserManager.loadUser(name); }
-        catch(e2) { 
-          if (typeof Debug !== 'undefined') Debug.error('[LM-Bridge] Cannot create or load', e2.message);
-          console.error('[LM-Bridge] Cannot create or load:', e2); 
-          return; 
+        catch(e2) {
+          // Last resort: the LM index is one synced localStorage key, so
+          // two devices saving it concurrently clobber each other
+          // (last-writer-wins). A student created on this device can
+          // vanish from the index while their data blob survives. If
+          // that orphaned blob exists, re-register it through importUser
+          // (which re-adds the index entry) instead of stranding the kid
+          // at a dead screen (#diag: "Cannot create or load: Student
+          // \"Isabel\" not found").
+          var orphanKey = 'littlemaestro_' + name.toLowerCase().replace(/\s+/g, '_');
+          var orphan = null;
+          try { orphan = localStorage.getItem(orphanKey); } catch (e3) {}
+          if (orphan) {
+            try {
+              if (typeof Debug !== 'undefined') Debug.warn('[LM-Bridge] Index lost "' + name + '" but data blob exists — re-registering');
+              UserManager.importUser(orphan);
+              UserManager.loadUser(name);
+            } catch (e4) {
+              if (typeof Debug !== 'undefined') Debug.error('[LM-Bridge] Orphan recovery failed', e4.message);
+              console.error('[LM-Bridge] Cannot create or load:', e4);
+              return;
+            }
+          } else {
+            if (typeof Debug !== 'undefined') Debug.error('[LM-Bridge] Cannot create or load', e2.message);
+            console.error('[LM-Bridge] Cannot create or load:', e2);
+            return;
+          }
         }
       }
     }

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -9911,7 +9911,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
       function createUser(name, avatar, color) {
         const idx = _getIndex();
-        if (idx.length >= 6) throw new Error('Maximum 6 profiles reached');
+        // Cap was 6, which the family actually hit (#diag: "Maximum 6
+        // profiles reached" left Isabel unable to use the app at all).
+        // The synced index can also carry ghost names from other
+        // devices, so the cap needs headroom beyond the family size.
+        if (idx.length >= 10) throw new Error('Maximum 10 profiles reached');
         if (idx.some(n => n.toLowerCase() === name.toLowerCase())) {
           throw new Error('A student named "' + name + '" already exists');
         }
@@ -9936,9 +9940,18 @@ document.addEventListener('DOMContentLoaded', () => {
           if (typeof Debug !== 'undefined') Debug.error('[User] Student not found: ' + name);
           throw new Error('Student "' + name + '" not found');
         }
-        const data = JSON.parse(localStorage.getItem(_key(found)));
+        let data = JSON.parse(localStorage.getItem(_key(found)));
         if (!data) {
-          if (typeof Debug !== 'undefined') Debug.error('[User] Data empty in localStorage for ' + name);
+          // The index syncs across devices ahead of the per-student data
+          // blobs (CloudSync.pull above is async and not awaited), so on
+          // a fresh device a student can be in the index with no local
+          // data yet. _current = null here made every screen flaky until
+          // the kid force-reloaded (#diag "very unstable"). Start from a
+          // default profile instead — when the pull lands, the synced
+          // blob takes over on next load.
+          if (typeof Debug !== 'undefined') Debug.warn('[User] No local data for ' + found + ' — starting default profile until sync lands');
+          data = _defaultProfile(found, '🐱', '#7C3AED');
+          try { localStorage.setItem(_key(found), JSON.stringify(data)); } catch (e) {}
         }
         _current = data;
         sessionStorage.setItem('lm_active_user', found);
@@ -9993,7 +10006,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const name = data.profile.name;
         const idx  = _getIndex();
         if (!idx.some(n => n.toLowerCase() === name.toLowerCase())) {
-          if (idx.length >= 6) throw new Error('Maximum 6 profiles reached');
+          if (idx.length >= 10) throw new Error('Maximum 10 profiles reached');
           idx.push(name);
           _saveIndex(idx);
         }


### PR DESCRIPTION
## Summary

The diag branch caught exactly why the piano feels **"very unstable"**: on 06-10, Isabel hit `[LM-Bridge] Create failed: Maximum 6 profiles reached` immediately followed by `Cannot create or load: Student "Isabel" not found` — the login bridge gave up and stranded her at a dead screen.

Three compounding problems, three fixes:

### 1. Profile cap 6 → 10
The family has more hub profiles than Little Maestro's hard cap of 6, and the synced index can carry ghost names from other devices. Raised in both `createUser` and `importUser`.

### 2. `loadUser` null-data fallback
`littlemaestro__index` starts with the synced `littlemaestro_` prefix, so the index arrives on a device ahead of the per-student data blobs (`CloudSync.pull` is async and not awaited). On a fresh device a student can be in the index with **no local data** — `_current` ended up `null` and every screen misbehaved until a reload. Now falls back to a default profile; the synced blob takes over on the next load once the pull lands.

### 3. Bridge orphan recovery
The index is a single synced localStorage key — two devices saving concurrently clobber each other (last-writer-wins). A student created on one device can vanish from the index while their data blob survives locally. The bridge now detects the orphaned `littlemaestro_<name>` blob and re-registers it via `UserManager.importUser` instead of giving up.

## Test plan
- [ ] Isabel (7th profile) can open Little Maestro and gets a working profile
- [ ] Fresh device: open LM as an existing student before sync completes — app stays functional (default profile until pull lands)
- [ ] All 14 inline script blocks + `lm-bridge.js` parse-check clean

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_