### PR TITLE
hub: tap-to-confirm Delete + tombstone trim defense

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -152,6 +152,15 @@
   var editEmoji = null;
   var editColor = null;
   var editAge = null;
+  // Tap-to-confirm state for the Delete button. The native confirm()
+  // dialog used to live here, but it is unreliable in iPad PWAs (the
+  // standalone shell silently auto-dismisses with `false`) — which
+  // made Delete look like a dead button: click did nothing, modal
+  // never closed. The button now arms on first tap and commits on the
+  // second tap within ARM_WINDOW_MS.
+  var _deleteArmedAt   = 0;
+  var _deleteArmTimer  = 0;
+  var DELETE_ARM_WINDOW_MS = 5000;
   var pinCallback = null;
 
   // ── Implementation ──
@@ -1668,6 +1677,19 @@
     var mod = document.getElementById('edit-modal');
     if (mod) mod.classList.remove('active');
     editingIndex = -1;
+    _resetDeleteButton();
+  }
+
+  function _resetDeleteButton() {
+    var btn = document.querySelector('.btn-delete-profile');
+    if (btn) {
+      btn.textContent = '🗑 Delete';
+      btn.style.background = '';
+      btn.style.color = '';
+      btn.style.fontWeight = '';
+    }
+    _deleteArmedAt = 0;
+    if (_deleteArmTimer) { clearTimeout(_deleteArmTimer); _deleteArmTimer = 0; }
   }
 
   function _updateEditPreview() {
@@ -1743,10 +1765,36 @@
   }
 
   function deleteEditingProfile() {
+    var armed = _deleteArmedAt > 0 && (Date.now() - _deleteArmedAt) <= DELETE_ARM_WINDOW_MS;
+    if (typeof Debug !== 'undefined') Debug.log('[Profile] delete clicked, editingIndex=' + editingIndex + ' armed=' + armed);
+    if (editingIndex < 0) {
+      if (typeof Debug !== 'undefined') Debug.warn('[Profile] delete: editingIndex < 0 — no-op');
+      return;
+    }
     var profiles = getProfiles();
-    if (editingIndex < 0) return;
-    var name = profiles[editingIndex].name;
-    if (!confirm('Delete ' + name + '?')) return;
+    if (!profiles[editingIndex]) {
+      if (typeof Debug !== 'undefined') Debug.warn('[Profile] delete: profiles[' + editingIndex + '] missing — no-op');
+      return;
+    }
+    var name = (profiles[editingIndex].name || '').trim();
+
+    // First tap arms the button; second tap within the window commits.
+    if (!armed) {
+      _deleteArmedAt = Date.now();
+      var btn = document.querySelector('.btn-delete-profile');
+      if (btn) {
+        btn.textContent = 'Tap again to delete ' + name;
+        btn.style.background = '#EF4444';
+        btn.style.color = '#fff';
+        btn.style.fontWeight = '800';
+      }
+      if (_deleteArmTimer) clearTimeout(_deleteArmTimer);
+      _deleteArmTimer = setTimeout(_resetDeleteButton, DELETE_ARM_WINDOW_MS);
+      if (typeof Debug !== 'undefined') Debug.log('[Profile] delete armed for "' + name + '" (' + DELETE_ARM_WINDOW_MS + 'ms)');
+      return;
+    }
+
+    if (typeof Debug !== 'undefined') Debug.log('[Profile] deleting "' + name + '"');
     profiles.splice(editingIndex, 1);
     saveProfiles(profiles);
 
@@ -1759,13 +1807,17 @@
       try { existing = JSON.parse(localStorage.getItem(key) || '[]'); } catch (e) {}
       if (!Array.isArray(existing)) existing = [];
       // Drop any older tombstone for the same name, then add a fresh one.
+      // Matching is trim+lowercase so a stored name with stray whitespace
+      // can't bypass the tombstone (same defensive normalization we did
+      // for the Little Maestro profile dedup).
       var lname = name.toLowerCase();
       existing = existing.filter(function(t) {
-        return !t || !t.name || t.name.toLowerCase() !== lname;
+        return !t || !t.name || (t.name || '').trim().toLowerCase() !== lname;
       });
       existing.push({ name: name, ts: Date.now() });
       localStorage.setItem(key, JSON.stringify(existing));
       if (typeof CloudSync !== 'undefined' && CloudSync.push) CloudSync.push(key);
+      if (typeof Debug !== 'undefined') Debug.log('[Profile] tombstone written for "' + name + '"');
     } catch (e) {
       if (typeof Debug !== 'undefined') Debug.error('[Profile] tombstone failed', e.message);
     }

--- a/js/sync.js
+++ b/js/sync.js
@@ -364,13 +364,16 @@ var CloudSync = (function() {
         // Read tombstones (zs_deleted_profiles) so a profile that was
         // deleted on any device stays gone on this one. Tombstones are
         // synced as part of HOUSEHOLD_KEYS so they reach every device.
+        // Trim+lowercase both sides of the tombstone match so a name with
+        // stray whitespace (e.g. legacy "Diego " on one device) can't
+        // bypass the skip and resurrect a deleted profile.
         var tombstones = {};
         try {
           var rawTomb = localStorage.getItem('zs_deleted_profiles');
           var tombArr = rawTomb ? JSON.parse(rawTomb) : [];
           if (Array.isArray(tombArr)) {
             tombArr.forEach(function(t) {
-              if (t && t.name) tombstones[t.name.toLowerCase()] = Number(t.ts) || 0;
+              if (t && t.name) tombstones[(t.name || '').trim().toLowerCase()] = Number(t.ts) || 0;
             });
           }
         } catch (e) {}
@@ -382,7 +385,7 @@ var CloudSync = (function() {
         for (var i = 0; i < merged.length; i++) {
           var p = merged[i];
           if (!p || !p.name) continue;
-          var key = p.name.toLowerCase();
+          var key = (p.name || '').trim().toLowerCase();
           // Skip tombstoned names unless the profile was created after
           // the deletion (createdAt > tombstone ts) — that lets you
           // legitimately recreate a profile with the same name later.


### PR DESCRIPTION
## Summary

You reported the Delete button in the profile-edit modal acts like a dead button — click does nothing, modal never closes, profile stays. The diag has **zero errors** for the delete path, which means no JS actually throws — the click just no-ops silently.

**Root cause**: the native `confirm('Delete <name>?')` dialog used inside `deleteEditingProfile` is unreliable in iPad PWAs — the standalone shell can silently auto-dismiss with `false`. The function then returns before doing anything else, which is exactly the "dead button" feel.

## Fix

Replaces `confirm()` with an in-button **two-tap confirmation**:

| State | Button |
|---|---|
| Resting | `🗑 Delete` |
| First tap | `Tap again to delete <name>` (red bg, 5-second window) |
| Second tap within 5s | Commits the deletion |
| Timeout / modal close / new edit-modal open | Reverts |

No dialogs, no PWA quirks, and there's a clear visible state so it can't look unresponsive again.

## Defensive additions
- **Debug logs on every step** of the delete path (`clicked`, `armed`, `deleting`, `tombstone written`) and on the dead-button paths (`editingIndex < 0`, missing profile entry) — so if anything still misbehaves, the next diag refresh actually shows where.
- **Trim+lowercase both sides of the tombstone match** in `syncProfiles` and on tombstone write — defensive belt-and-suspenders against a legacy profile stored with stray whitespace bypassing the skip and resurrecting (same class of bug we just fixed in Little Maestro).

## Test plan
- [ ] Open Edit modal on a test profile → tap Delete → button shows "Tap again to delete <name>" in red, doesn't close
- [ ] Tap again within 5s → profile is removed, modal closes, you land on login screen
- [ ] Tap once then wait 6s → button reverts; closing modal also reverts
- [ ] Other devices see the deletion on their next sync (tombstone propagates)

https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh

---
_Generated by [Claude Code](https://claude.ai/code/session_01VChnFjNH2Pai6GtCQbcyKh)_