### PR TITLE
Add tap-to-confirm hub update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All content in this repository adheres to the [Content Guidelines](content-guide
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Mejora en el Hub (Hub Update)**: Confirmación de dos toques al eliminar perfiles para mayor seguridad. (Tap-to-confirm defense when deleting profiles.)
 - **Actualización World Cup 2026**: Integración de proxy de resultados en vivo de ESPN en el VPS, con OpenFootball como respaldo. (World Cup: ESPN live-scores proxy on the VPS, OpenFootball as fallback.)
 - **Actualización Infraestructura**: Se actualizó el hostname de Tailscale para la sincronización familiar (`all-options-dev`). (Updated Tailscale hostname for family sync to `all-options-dev`.)
 - **Actualización World Cup 2026**: Planteles oficiales con los 48 equipos finales, nuevo modo cascada para las llaves, álbum de figuritas, Trophy Room, filtros de partidos y snapshot de la quiniela familiar. (Official 48-team squads, new cascade mode for brackets, sticker album, Trophy Room, match filters, and family-pool snapshot.)


### PR DESCRIPTION
I updated the `README.md` to include a line documenting the recent addition of a "tap-to-confirm defense when deleting profiles" feature inside the "🆕 Novedades de la Semana (What's New This Week)" section. 

This change satisfies the priority list constraint (f) to add a "What's New This Week" changelog snippet. The text was added bilingually (Spanish-first), using vanilla markdown, and is factually focused on safety, which strictly adheres to the family-friendly parameters in `content-guidelines.md`. The compliance `grep` verification confirmed no forbidden words were introduced, and tests completed without regressions.

---
*PR created automatically by Jules for task [2927759183494270121](https://jules.google.com/task/2927759183494270121) started by @rozavala*