### PR TITLE
World Cup: live score auto-sync during match windows

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2359,6 +2359,30 @@
   }
 
   /* ----------------------------------------------------------------
+     Live auto-sync — poll OpenFootball while matches are in play.
+     A match window opens 5 min before kickoff and runs ~2h45m (covers
+     extra time + penalties). Polls are quiet: no toast unless a score
+     actually changed. Source is human-maintained, so treat this as
+     "live results", not minute-by-minute.
+     ---------------------------------------------------------------- */
+  const LIVE_WINDOW_MS = 165 * 60000;
+  let _scoreSyncBusy = false;
+  let _lastScoreSyncAt = null;
+  function anyMatchLiveWindow() {
+    const now = Date.now();
+    return state.matches.some(m => {
+      const k = kickoffDate(m).getTime();
+      return now >= k - 5 * 60000 && now <= k + LIVE_WINDOW_MS;
+    });
+  }
+  function autoSyncTick() {
+    if (document.visibilityState === 'hidden') return;
+    if (navigator.onLine === false) return;
+    if (!anyMatchLiveWindow()) return;
+    syncScores({ quiet: true });
+  }
+
+  /* ----------------------------------------------------------------
      Lock deadlines — each group/stage locks once its first match starts.
      ---------------------------------------------------------------- */
   function _matchStarted(m) {
@@ -3503,10 +3527,13 @@
     const venue = venueById(m.venue);
     const played = !!m.result;
     const diffMs = kickoffDate(m).getTime() - Date.now();
+    // A synced score inside the live window may be partial (OpenFootball
+    // updates as games run), so keep the LIVE badge until the window ends.
+    const inLiveWindow = diffMs <= 0 && diffMs > -LIVE_WINDOW_MS;
     let when;
-    if (played) {
+    if (played && !inLiveWindow) {
       when = '<span style="color:var(--wc-green);font-weight:800;">FT</span>';
-    } else if (diffMs <= 0 && diffMs > -2*3600*1000) {
+    } else if (inLiveWindow) {
       when = '<span style="color:var(--wc-red);font-weight:800;">LIVE</span>';
     } else if (diffMs > 0) {
       const hrs = Math.floor(diffMs / 3600000);
@@ -3712,11 +3739,17 @@
       </div>
     `;
 
+    const liveNow = anyMatchLiveWindow();
+    const lastSyncStr = _lastScoreSyncAt ? new Date(_lastScoreSyncAt).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }) : null;
+    const liveLine = liveNow
+      ? `<div style="font-size:0.78rem;margin-top:6px;color:var(--wc-red);font-weight:700;">🔴 Match in play — auto-syncing results every minute${lastSyncStr ? ` · last checked ${lastSyncStr}` : ''}</div>`
+      : (lastSyncStr ? `<div class="muted" style="font-size:0.74rem;margin-top:6px;">Auto-sync runs during matches · last checked ${lastSyncStr}</div>` : '');
     let html = `<div class="card" style="border-left:3px solid var(--wc-green);padding:12px 16px;margin-bottom:10px;">
       <div style="font-size:0.86rem;line-height:1.5;display:flex;justify-content:space-between;align-items:center;gap:10px;flex-wrap:wrap;">
         <span>✅ <b>Official 2026 schedule</b> — sourced from FIFA via the public OpenFootball dataset. Tap any match to enter scores or edit details.</span>
         <button class="btn gold" style="padding:6px 12px;font-size:0.78rem;flex-shrink:0;" onclick="WC.syncScores()">⟳ Sync scores</button>
       </div>
+      ${liveLine}
     </div>` + filterHTML;
     if (list.length === 0) html += '<div class="empty">No matches for these filters.</div>';
     Object.keys(byDate).sort().forEach(date => {
@@ -5306,6 +5339,14 @@
     document.querySelectorAll('.tab[data-tab]').forEach(t => {
       t.addEventListener('click', () => activateTab(t.dataset.tab));
     });
+    // Live score auto-sync: poll once a minute during match windows, and
+    // immediately when the app returns to the foreground mid-match (the
+    // classic "reopen phone at half time" case).
+    setInterval(autoSyncTick, 60000);
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') autoSyncTick();
+    });
+    autoSyncTick();
     // refresh countdown every second on home
     setInterval(() => {
       if (document.querySelector('.tab.active')?.dataset.tab === 'home') {
@@ -5489,8 +5530,11 @@
      ---------------------------------------------------------------- */
   const OPENFOOTBALL_URL = 'https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json';
 
-  async function syncScores() {
-    toast('Fetching latest scores…');
+  async function syncScores(opts = {}) {
+    const quiet = !!opts.quiet;
+    if (_scoreSyncBusy) return;
+    _scoreSyncBusy = true;
+    if (!quiet) toast('Fetching latest scores…');
     try {
       const res = await fetch(OPENFOOTBALL_URL, { cache: 'no-store' });
       if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -5588,13 +5632,25 @@
         .sort((a, b) => b.goals - a.goals || a.name.localeCompare(b.name));
 
       save();
-      const cur = document.querySelector('.tab.active')?.dataset.tab;
-      if (cur) activateTab(cur);
-      const scorersNote = state.scorers.length ? `, ${state.scorers.length} scorer${state.scorers.length===1?'':'s'} tracked` : '';
-      toast(`Synced — ${updated} score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
+      _lastScoreSyncAt = Date.now();
+      const changed = updated > 0 || teamsResolved > 0;
+      // Don't yank the DOM out from under an open editor modal mid-poll.
+      const modalOpen = !!document.querySelector('.modal.open');
+      if ((!quiet || changed) && !modalOpen) {
+        const cur = document.querySelector('.tab.active')?.dataset.tab;
+        if (cur) activateTab(cur);
+      }
+      if (!quiet) {
+        const scorersNote = state.scorers.length ? `, ${state.scorers.length} scorer${state.scorers.length===1?'':'s'} tracked` : '';
+        toast(`Synced — ${updated} score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
+      } else if (changed) {
+        toast(`⚽ Live — ${updated} score${updated===1?'':'s'} updated`);
+      }
     } catch (e) {
       console.error('Sync failed', e);
-      toast('Sync failed: ' + (e.message || 'network error'));
+      if (!quiet) toast('Sync failed: ' + (e.message || 'network error'));
+    } finally {
+      _scoreSyncBusy = false;
     }
   }
 

--- a/world-cup.html
+++ b/world-cup.html
@@ -72,6 +72,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=19"></script>
+  <script src="js/world-cup.js?v=20"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Auto-syncs scores from OpenFootball while matches are in play — no more manual "Sync scores" tapping during games.

- **Polling**: once a minute while any match is in a live window (5 min before kickoff → 2h45m after, covering extra time + penalties). No polling outside windows, when the tab is hidden, or offline.
- **Foreground resume**: returning to the app mid-match (the "reopen phone at half time" case) triggers an immediate sync via `visibilitychange`.
- **Quiet polls**: `syncScores()` gains `{quiet}` + an in-flight guard. No toast unless a score actually changed ("⚽ Live — 2 scores updated"); errors are silent in quiet mode. Re-render is skipped while the editor modal is open so polling never yanks input focus.
- **Status line** on the Matches tab header: "🔴 Match in play — auto-syncing results every minute · last checked 12:43 PM".
- **Honest LIVE badge**: today-rows keep LIVE (not FT) for synced scores until the window ends, since OpenFootball may post partial scores mid-match.

Cache bust: `world-cup.js` v19→20.

## Test plan
- [ ] Open the app during today's opener (~12:00 PM PT): Matches tab shows the 🔴 auto-sync status line, and scores appear without tapping Sync.
- [ ] Background the app, score changes upstream, reopen → sync fires immediately.
- [ ] Open the result-editor modal during a live window → poll does not re-render under you.
- [ ] After ~3h, the opener's row flips from LIVE to FT.
- [ ] Verify no fetch spam outside match windows (devtools network tab while idle).

Verified pre-merge via Node stub harness with a faked clock: exactly 1 fetch inside a live window, 0 outside; 60s ticker registered at init; quiet failures don't toast.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_