### PR TITLE
World Cup: fix "Open in private app" 404 — strip /apps/ prefix

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2714,7 +2714,10 @@
     return window.location.hostname !== TAILNET_HOST;
   }
   function _tailnetImportUrl(param, encoded) {
-    return 'https://' + TAILNET_HOST + window.location.pathname + '?' + param + '=' + encoded;
+    // Public host serves at /apps/world-cup.html, tailnet host serves at
+    // the root — use just the basename so the path resolves either way.
+    const basename = window.location.pathname.split('/').filter(Boolean).pop() || 'world-cup.html';
+    return 'https://' + TAILNET_HOST + '/' + basename + '?' + param + '=' + encoded;
   }
   function _privateAppHopButton(param, encoded) {
     if (!_onPublicHost()) return '';

--- a/world-cup.html
+++ b/world-cup.html
@@ -72,6 +72,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=21"></script>
+  <script src="js/world-cup.js?v=22"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Follow-up to #352. The hop URL was carrying over `window.location.pathname` from the public host (`/apps/world-cup.html`), but the tailnet server serves the app at root and 404'd with `Cannot GET /apps/world-cup.html`. Use just the basename of the path so it resolves on either host.

Cache bust: `world-cup.js` v21→22.

## Test plan
- [ ] Tap an `?wc_share=…` link on the public host, then the "Open in private app →" link → loads `https://all-options-dev.tail57521e.ts.net/world-cup.html?wc_share=…` and the import prompt fires.
- [ ] Same for `?wc_pool=…`.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_