### PR TITLE
CloudSync: retry ping + reconnect on focus/online; revert WC private-app hop

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -177,7 +177,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/bible-explorer.html
+++ b/bible-explorer.html
@@ -103,7 +103,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -196,7 +196,7 @@
   <script src="js/nav.js?v=2"></script>
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=5"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -129,7 +129,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js"></script>
+<script src="js/sync.js?v=6"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/civics-lab.html
+++ b/civics-lab.html
@@ -101,7 +101,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/code-cadet.html
+++ b/code-cadet.html
@@ -86,7 +86,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -74,7 +74,7 @@
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
 <script src="js/a11y.js"></script>
-<script src="js/sync.js"></script>
+<script src="js/sync.js?v=6"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/family.html
+++ b/family.html
@@ -47,7 +47,7 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=5"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -120,7 +120,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -97,7 +97,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -151,7 +151,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/activity-log.js"></script>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=5"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/js/sync.js
+++ b/js/sync.js
@@ -509,58 +509,91 @@ var CloudSync = (function() {
     pill.style.animation = (status === 'syncing') ? 'syncPulse 1s infinite' : '';
   }
 
-  document.addEventListener('DOMContentLoaded', function() {
+  // Run the initial sync flow once a successful ping comes back. Split
+  // out of the DOMContentLoaded handler so we can retry/reconnect later
+  // without re-doing the household pull every visibilitychange.
+  var _initialSynced = false;
+  function _runInitialSync() {
+    if (_initialSynced) return;
+    _initialSynced = true;
+    var path = window.location.pathname;
+    var isHub = path.indexOf('index.html') !== -1 || path === '/' || (path.length > 0 && path[path.length - 1] === '/');
+    state.pullHousehold().then(function() {
+      try { window.dispatchEvent(new CustomEvent('zs:household-synced')); } catch (e) {}
+      state.pushHousehold();
+      if (isHub) {
+        state.syncProfiles()
+          .then(function() {
+            var loginScr = document.getElementById('login-screen');
+            if (typeof renderLogin === 'function' && loginScr && loginScr.style.display !== 'none') {
+              renderLogin();
+            }
+          })
+          .catch(function() { _updatePill('offline'); });
+      } else {
+        var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
+        if (user) {
+          var kidKey = user.name.toLowerCase().replace(/\s+/g, '_');
+          state.pullAll(kidKey).catch(function() { _updatePill('offline'); });
+        }
+      }
+    }).catch(function() { _updatePill('offline'); _initialSynced = false; });
+  }
+
+  // Ping the VPS, flip the pill, and kick the initial sync on first
+  // success. On failure, schedule the next attempt with backoff (up to
+  // ~1 min) so a cold Tailscale handshake or transient drop heals on
+  // its own — previously a single 5s timeout left the pill stuck red.
+  var _pingAttempt = 0;
+  var _pingTimer = null;
+  var _pinging = false;
+  function _scheduleReping(delayMs) {
+    if (_pingTimer) clearTimeout(_pingTimer);
+    _pingTimer = setTimeout(_pingNow, delayMs);
+  }
+  function _pingNow() {
+    if (_pinging) return;
     if (!state.isConfigured()) { _updatePill('unconfigured'); return; }
-    
+    _pinging = true;
     _fetchWithTimeout(SYNC_SERVER + '/api/ping', { timeout: 5000 })
       .then(function(res) {
-        if (res.ok) {
+        _pinging = false;
+        if (res && res.ok) {
+          _pingAttempt = 0;
           state.online = true;
           _updatePill('idle');
-
-          var path = window.location.pathname;
-          var isHub = path.indexOf('index.html') !== -1 || path === '/' || (path.length > 0 && path[path.length - 1] === '/');
-
-          // Pull household-shared state first (shopping list, menu,
-          // calendar URLs, sports matches, home location, *and the
-          // profile-deletion tombstones*) before profile sync, so the
-          // syncProfiles merge can honor the latest tombstones. Then
-          // push any local household state that was changed while
-          // CloudSync was still offline (so this device's edits before
-          // the first ping resolved propagate to others).
-          // Network can drop between the ping and the follow-up calls.
-          // Swallow transient sync failures so they don't surface as
-          // unhandled promise rejections (#diag).
-          state.pullHousehold().then(function() {
-            try { window.dispatchEvent(new CustomEvent('zs:household-synced')); } catch (e) {}
-            state.pushHousehold();
-
-            if (isHub) {
-              state.syncProfiles()
-                .then(function() {
-                  var loginScr = document.getElementById('login-screen');
-                  if (typeof renderLogin === 'function' && loginScr && loginScr.style.display !== 'none') {
-                    renderLogin();
-                  }
-                })
-                .catch(function() { _updatePill('offline'); });
-            } else {
-              var user = typeof getActiveUser === 'function' ? getActiveUser() : null;
-              if (user) {
-                var kidKey = user.name.toLowerCase().replace(/\s+/g, '_');
-                state.pullAll(kidKey).catch(function() { _updatePill('offline'); });
-              }
-            }
-          }).catch(function() { _updatePill('offline'); });
+          _runInitialSync();
         } else {
-          state.online = false;
-          _updatePill('offline');
+          throw new Error('ping http ' + (res && res.status));
         }
       })
-      .catch(function(e) {
+      .catch(function() {
+        _pinging = false;
         state.online = false;
         _updatePill('offline');
+        _pingAttempt++;
+        // 2s, 5s, 10s, 20s, 30s, then cap at 60s.
+        var schedule = [2000, 5000, 10000, 20000, 30000];
+        var delay = schedule[_pingAttempt - 1] || 60000;
+        _scheduleReping(delay);
       });
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    _pingNow();
+    // Reconnect attempts triggered by the tab returning to the
+    // foreground or the OS reporting the network back. Both are
+    // common scenarios where the initial 5s ping lost a race with a
+    // cold Tailscale handshake.
+    document.addEventListener('visibilitychange', function() {
+      if (document.visibilityState === 'visible' && !state.online) {
+        _pingAttempt = 0;
+        _pingNow();
+      }
+    });
+    window.addEventListener('online', function() {
+      if (!state.online) { _pingAttempt = 0; _pingNow(); }
+    });
   });
 
   return state;

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2703,33 +2703,6 @@
   }
 
   /* ----------------------------------------------------------------
-     Tailnet "private app" hop for imports
-     The CloudSync VPS lives on the Tailscale tailnet, so importing on
-     the public host saves locally but doesn't push out to the rest of
-     the family. When we see an import URL on the public host, offer a
-     one-tap relaunch onto the tailnet host with the same payload.
-     ---------------------------------------------------------------- */
-  const TAILNET_HOST = 'all-options-dev.tail57521e.ts.net';
-  function _onPublicHost() {
-    return window.location.hostname !== TAILNET_HOST;
-  }
-  function _tailnetImportUrl(param, encoded) {
-    // Public host serves at /apps/world-cup.html, tailnet host serves at
-    // the root — use just the basename so the path resolves either way.
-    const basename = window.location.pathname.split('/').filter(Boolean).pop() || 'world-cup.html';
-    return 'https://' + TAILNET_HOST + '/' + basename + '?' + param + '=' + encoded;
-  }
-  function _privateAppHopButton(param, encoded) {
-    if (!_onPublicHost()) return '';
-    const href = _tailnetImportUrl(param, encoded);
-    return `
-      <div style="background:rgba(34,197,94,0.08);border:1px solid rgba(34,197,94,0.3);border-radius:10px;padding:10px 12px;margin:10px 0;font-size:0.82rem;line-height:1.45;">
-        🔒 <b>Hosting this pool?</b> Import on the private app so the family sees it:
-        <a href="${escapeHTML(href)}" style="display:block;margin-top:6px;color:var(--wc-gold);font-weight:700;word-break:break-all;text-decoration:underline;">Open in private app →</a>
-      </div>`;
-  }
-
-  /* ----------------------------------------------------------------
      Full-family-pool snapshot — host can share a single URL bundling
      every member's bracket plus all recorded results. Guests open
      the URL and import to see the family leaderboard locally
@@ -2798,7 +2771,6 @@
       <div class="sub">${memberCount} bracket${memberCount===1?'':'s'} · ${resultCount} match result${resultCount===1?'':'s'}</div>
       <p style="margin:10px 0;font-size:0.9rem;line-height:1.5;">${escapeHTML(memberList)}${memberCount > 8 ? ' …' : ''}</p>
       <p style="font-size:0.82rem;color:var(--text-muted);">Existing brackets with the same name will be updated. Your own bracket is preserved unless someone with your name is in the snapshot.</p>
-      ${encoded ? _privateAppHopButton('wc_pool', encoded) : ''}
       <div class="modal-actions">
         <button class="btn ghost" onclick="WC.closeModal()">Not now</button>
         <button class="btn" onclick="WC.confirmImportPool()">✓ Import snapshot</button>
@@ -2831,7 +2803,6 @@
       <div class="sub">From <b>${payload.avatar ? escapeHTML(payload.avatar)+' ' : ''}${escapeHTML(payload.name)}</b></div>
       <p style="margin:10px 0;font-size:0.9rem;">Add this bracket to the family pool? Picks will start scoring as results come in.</p>
       ${guess ? `<p style="font-size:0.82rem;color:var(--text-muted);">${guess}</p>` : ''}
-      ${encoded ? _privateAppHopButton('wc_share', encoded) : ''}
       <div class="modal-actions">
         <button class="btn ghost" onclick="WC.closeModal()">Not now</button>
         <button class="btn" onclick="WC.confirmImportBracket()">✓ Add to pool</button>

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -67,7 +67,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -15905,7 +15905,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="js/auth.js?v=2"></script>
 
 <script src="js/a11y.js?v=2"></script>
-<script src="js/sync.js?v=2"></script>
+<script src="js/sync.js?v=6"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/timer.js?v=2"></script>
 <script src="js/learning-checks.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -142,7 +142,7 @@
   <script src="js/auth.js?v=2"></script>
 
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=5"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>

--- a/menu.html
+++ b/menu.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/menu.js"></script>

--- a/money-master.html
+++ b/money-master.html
@@ -28,7 +28,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -43,7 +43,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -73,7 +73,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -264,7 +264,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js"></script>
+<script src="js/sync.js?v=6"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -86,7 +86,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/routines.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -46,7 +46,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>

--- a/vacation.html
+++ b/vacation.html
@@ -26,7 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/vacation.js"></script>

--- a/vocabulario-vivo.html
+++ b/vocabulario-vivo.html
@@ -108,7 +108,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/world-cup.html
+++ b/world-cup.html
@@ -70,8 +70,8 @@
   </div>
 
   <script src="js/auth.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=22"></script>
+  <script src="js/world-cup.js?v=23"></script>
 </body>
 </html>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -75,7 +75,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js"></script>
+  <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>


### PR DESCRIPTION
## Summary
Real fix for the "red cloud dot after opening a share link" issue, plus a revert of the wrong fix.

### The bug
CloudSync's `DOMContentLoaded` handler in `js/sync.js` did exactly one `/api/ping` with a 5-second timeout, and on failure left the pill stuck red **forever** — no retry, no reconnect. Tailscale handshakes on a cold network (screen just unlocked, switched networks, transient drop) frequently take longer than 5s, so the same URL would flip green if reloaded a moment later. The "red dot in tab A, green in tab B opened seconds later" symptom is exactly this race.

### The fix (`js/sync.js`)
- **Retry with backoff** (2s → 5s → 10s → 20s → 30s, then 60s cap) until the VPS answers.
- **Reconnect listeners**: `visibilitychange` re-pings when the tab refocuses; `window.online` re-pings when the OS reports the network back. Reopening after a screen-lock now reconnects in seconds.
- **Initial pull/push** is split out and gated so it runs exactly once per session, even if the ping has to retry.

### Revert (`js/world-cup.js`)
PRs #352 and #353 added an "Open in private app" hop button to the World Cup import modals, pointing at the Tailscale tailnet host. The premise was wrong: `vps/server.js` is API-only (`/api/*` routes) and doesn't serve `world-cup.html` — so the tailnet host could never host the app. That whole feature is removed. With the ping retry above, both the share-link tab and a fresh tab converge to the same connected state on the public host.

Cache busts: `world-cup.js` v22→23, `sync.js` v5→6 across every HTML file (the sync fix is global, not WC-only).

## Test plan
- [ ] Open World Cup via a `?wc_share=…` link with the tab in the background or right after a screen unlock → cloud pill turns green within ~30s without a manual reload.
- [ ] Switch networks (e.g. wifi → cellular) → pill goes red, then green again on its own when the network settles.
- [ ] Lock phone for a minute, return to the app → pill reconnects on visibility change.
- [ ] Hub (`index.html`) profile sync still runs on first successful ping (login screen rerenders).
- [ ] Confirm no "Open in private app →" link is shown on the import modal anymore.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_