### PR TITLE
World Cup: ESPN live-scores proxy on the VPS, OpenFootball as fallback

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -5524,11 +5524,43 @@
   }
 
   /* ----------------------------------------------------------------
-     SYNC — pull latest scores from OpenFootball (community-maintained
-     public-domain dataset). Updates results without overwriting any
-     manual edits unless the remote also has a score for that match.
+     SYNC — pull latest scores. Primary source is the VPS-side ESPN
+     scoreboard proxy (truly live, minute-by-minute) when CloudSync is
+     connected; fallback is the OpenFootball community dataset (lags,
+     but works without the VPS for guests on the public host).
      ---------------------------------------------------------------- */
   const OPENFOOTBALL_URL = 'https://raw.githubusercontent.com/openfootball/worldcup.json/master/2026/worldcup.json';
+  const VPS_WC_SCORES_URL = (window.CloudSync && CloudSync.isConfigured && CloudSync.isConfigured())
+    ? 'https://all-options-dev.tail57521e.ts.net/api/wc-scores'
+    : null;
+
+  // Dates the proxy should query — every distinct match date through today
+  // plus a one-day buffer either side. Tournament size is bounded (~40
+  // match-days), so the URL stays compact.
+  function _vpsQueryDates() {
+    const cutoff = Date.now() + 24 * 3600 * 1000;
+    const dates = new Set();
+    for (const m of state.matches) {
+      const kt = kickoffDate(m).getTime();
+      if (kt <= cutoff) dates.add(m.date.replace(/-/g, ''));
+    }
+    return Array.from(dates).sort();
+  }
+
+  async function _fetchEspn() {
+    if (!VPS_WC_SCORES_URL || !window.CloudSync || !CloudSync.online) return null;
+    const dates = _vpsQueryDates();
+    if (dates.length === 0) return null;
+    try {
+      const res = await fetch(VPS_WC_SCORES_URL + '?dates=' + dates.join(','), { cache: 'no-store' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const data = await res.json();
+      return Array.isArray(data.matches) ? data.matches : null;
+    } catch (e) {
+      console.warn('ESPN scoreboard fetch failed, falling back to OpenFootball:', e.message);
+      return null;
+    }
+  }
 
   async function syncScores(opts = {}) {
     const quiet = !!opts.quiet;
@@ -5536,10 +5568,17 @@
     _scoreSyncBusy = true;
     if (!quiet) toast('Fetching latest scores…');
     try {
-      const res = await fetch(OPENFOOTBALL_URL, { cache: 'no-store' });
-      if (!res.ok) throw new Error('HTTP ' + res.status);
-      const data = await res.json();
-      const remote = data.matches || [];
+      // Try ESPN-via-VPS first; fall back to OpenFootball when the VPS
+      // is unreachable (offline, guest device, transient hiccup).
+      let remote = await _fetchEspn();
+      let sourceLabel = 'ESPN';
+      if (!remote) {
+        const res = await fetch(OPENFOOTBALL_URL, { cache: 'no-store' });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        remote = data.matches || [];
+        sourceLabel = 'OpenFootball';
+      }
 
       let updated = 0, teamsResolved = 0;
       // Build a lookup: by (date, team1, team2) and also by team codes if mapping known.
@@ -5568,15 +5607,35 @@
       nameToCode['Iraq'] = 'IRQ';
       nameToCode['Haiti'] = 'HAI';
       nameToCode['Algeria'] = 'ALG';
-      // Inverse for placeholders like "1A" (Group A winner)
-      function placeholderMatchesCode(label, code) {
-        // We don't compute placeholders dynamically here — just match by date+raw labels.
-        return false;
+      // ESPN-side variants
+      nameToCode['Türkiye'] = 'TUR';
+      nameToCode['Cape Verde Islands'] = 'CPV';
+      nameToCode['Korea Republic'] = 'KOR';
+      nameToCode['IR Iran'] = 'IRN';
+      nameToCode['United States of America'] = 'USA';
+
+      // ESPN sends a 3-letter abbreviation alongside the display name —
+      // most line up with our FIFA codes but a handful differ (e.g.
+      // GHA→GHA, but SUI vs SWZ etc). Build the abbr lookup defensively
+      // and let the team-name match win on ties.
+      const abbrToCode = {};
+      for (const c of COUNTRIES) abbrToCode[c.code] = c.code;
+      abbrToCode['RSA'] = 'ZAF';   // ESPN uses RSA for South Africa
+      abbrToCode['CZR'] = 'CZE';   // ESPN: Czech Republic
+      abbrToCode['IVO'] = 'CIV';   // ESPN: Ivory Coast
+      abbrToCode['CTA'] = 'CIV';   // alt
+      abbrToCode['MOR'] = 'MAR';   // ESPN: Morocco
+      abbrToCode['SAU'] = 'KSA';
+      abbrToCode['CRC'] = 'CRC';
+      abbrToCode['NED'] = 'NED';
+      abbrToCode['POR'] = 'POR';
+      function _resolveCode(name, abbr) {
+        return nameToCode[name] || (abbr && abbrToCode[abbr]) || null;
       }
 
       for (const rm of remote) {
-        const rh = nameToCode[rm.team1] || rm.team1;  // real code or placeholder string
-        const ra = nameToCode[rm.team2] || rm.team2;
+        const rh = _resolveCode(rm.team1, rm.team1_abbr) || rm.team1;
+        const ra = _resolveCode(rm.team2, rm.team2_abbr) || rm.team2;
         // Find local match: same date, and either (codes match) or (labels match)
         const local = state.matches.find(lm => {
           if (lm.date !== rm.date) return false;
@@ -5587,8 +5646,14 @@
         if (!local) continue;
 
         // If local has placeholder labels but remote has resolved teams, fill them in
-        if (!local.home && nameToCode[rm.team1]) { local.home = nameToCode[rm.team1]; local.home_label = null; teamsResolved++; }
-        if (!local.away && nameToCode[rm.team2]) { local.away = nameToCode[rm.team2]; local.away_label = null; teamsResolved++; }
+        if (!local.home) {
+          const code = _resolveCode(rm.team1, rm.team1_abbr);
+          if (code) { local.home = code; local.home_label = null; teamsResolved++; }
+        }
+        if (!local.away) {
+          const code = _resolveCode(rm.team2, rm.team2_abbr);
+          if (code) { local.away = code; local.away_label = null; teamsResolved++; }
+        }
 
         // Score: OpenFootball uses rm.score.ft = [home, away] (or sometimes top-level rm.score1/rm.score2)
         let hs = null, as = null;
@@ -5642,7 +5707,7 @@
       }
       if (!quiet) {
         const scorersNote = state.scorers.length ? `, ${state.scorers.length} scorer${state.scorers.length===1?'':'s'} tracked` : '';
-        toast(`Synced — ${updated} score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
+        toast(`Synced from ${sourceLabel} — ${updated} score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
       } else if (changed) {
         toast(`⚽ Live — ${updated} score${updated===1?'':'s'} updated`);
       }

--- a/vps/server.js
+++ b/vps/server.js
@@ -7,6 +7,7 @@ const path = require('path');
 const media = require('./media');
 const diag = require('./diag');
 const ical = require('./ical');
+const wcScores = require('./wc-scores');
 
 const app = express();
 const PORT = 3333;
@@ -25,6 +26,9 @@ diag.init(app, DATA_DIR);
 
 // Register iCal proxy (CORS-safe family calendar fetches)
 ical.init(app);
+
+// Register World Cup scores proxy (ESPN scoreboard JSON, CORS-safe live scores)
+wcScores.init(app);
 
 app.get('/api/kids', (req, res) => {
   try {

--- a/vps/wc-scores.js
+++ b/vps/wc-scores.js
@@ -1,0 +1,158 @@
+/* ================================================================
+   ZS-SYNC — World Cup live scores proxy
+
+   ESPN publishes the JSON that powers their own scoreboard pages at
+   site.api.espn.com — no API key, no signup, generally minute-by-minute
+   updates. The browser can't fetch it directly (CORS), so we proxy it
+   server-side and normalize the payload into roughly the OpenFootball
+   shape the World Cup app already knows how to consume.
+
+   Mounted at GET /api/wc-scores?dates=YYYYMMDD[,YYYYMMDD...]
+   (defaults to today UTC if `dates` is omitted).
+
+   Notes:
+   - 60s in-memory cache per date to be kind to upstream during live
+     polling — the WC app polls every minute while a match is in play.
+   - 15s timeout, 2 MB ceiling. Bad responses are logged and skipped
+     rather than 500'ing the whole request when only one date fails.
+   - We deliberately only proxy the FIFA World Cup league
+     (`soccer/fifa.world`) — no arbitrary URL fetches.
+   ================================================================ */
+
+'use strict';
+
+const https = require('https');
+
+const ESPN_URL = 'https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/scoreboard';
+const TTL_MS = 60 * 1000;
+const FETCH_TIMEOUT_MS = 15 * 1000;
+const MAX_BYTES = 2 * 1024 * 1024;
+
+const _cache = new Map(); // dateYYYYMMDD -> { fetchedAt, matches }
+
+function _fetchUpstream(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, {
+      headers: { 'User-Agent': 'ZavalaSerra-WC-Scores/1.0', 'Accept': 'application/json' },
+    }, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error('upstream HTTP ' + res.statusCode));
+      }
+      let size = 0;
+      const chunks = [];
+      res.on('data', (c) => {
+        size += c.length;
+        if (size > MAX_BYTES) { req.destroy(new Error('response too large')); return; }
+        chunks.push(c);
+      });
+      res.on('end', () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8'))); }
+        catch (e) { reject(e); }
+      });
+    });
+    req.setTimeout(FETCH_TIMEOUT_MS, () => req.destroy(new Error('upstream timeout')));
+    req.on('error', reject);
+  });
+}
+
+// Pull the minute integer out of "23'", "45+2'", "90'+5" etc. Defensive
+// against ESPN occasionally emitting non-string clock values.
+function _minute(clock) {
+  if (!clock) return null;
+  const s = (clock.displayValue || clock.value || '').toString();
+  const m = s.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+function _normalizeEvent(ev) {
+  const comp = ev && ev.competitions && ev.competitions[0];
+  if (!comp || !Array.isArray(comp.competitors)) return null;
+  const home = comp.competitors.find((c) => c.homeAway === 'home');
+  const away = comp.competitors.find((c) => c.homeAway === 'away');
+  if (!home || !away || !home.team || !away.team) return null;
+
+  const state = ev.status && ev.status.type && ev.status.type.state; // 'pre' | 'in' | 'post'
+  const completed = state === 'post';
+  const live = state === 'in';
+  const date = (ev.date || '').slice(0, 10);
+  const hs = parseInt(home.score, 10);
+  const as = parseInt(away.score, 10);
+
+  const goals1 = [], goals2 = [];
+  for (const d of (comp.details || [])) {
+    if (!d.scoringPlay) continue;
+    const ath = (d.athletesInvolved || [])[0];
+    if (!ath || !ath.displayName) continue;
+    const g = { name: ath.displayName };
+    const min = _minute(d.clock);
+    if (min !== null) g.minute = min;
+    if (d.scoreValue === -1 || (d.type && /own goal/i.test(d.type.text || ''))) {
+      g.owngoal = true;
+    }
+    if (d.team && home.team && d.team.id === home.team.id) goals1.push(g);
+    else if (d.team && away.team && d.team.id === away.team.id) goals2.push(g);
+  }
+
+  const out = {
+    date,
+    team1: home.team.displayName || home.team.name,
+    team1_abbr: home.team.abbreviation || null,
+    team2: away.team.displayName || away.team.name,
+    team2_abbr: away.team.abbreviation || null,
+    live,
+    completed,
+  };
+  // Only emit a score once the match is in progress or done — pre-match
+  // ESPN sometimes returns "0" placeholders which would otherwise look
+  // like a real 0-0 final.
+  if (!isNaN(hs) && !isNaN(as) && (completed || live)) {
+    out.score = { ft: [hs, as] };
+  }
+  if (goals1.length) out.goals1 = goals1;
+  if (goals2.length) out.goals2 = goals2;
+  return out;
+}
+
+async function _matchesForDate(dateStr) {
+  const cached = _cache.get(dateStr);
+  if (cached && Date.now() - cached.fetchedAt < TTL_MS) return cached.matches;
+  let data;
+  try { data = await _fetchUpstream(ESPN_URL + '?dates=' + encodeURIComponent(dateStr)); }
+  catch (e) {
+    console.warn('[wc-scores]', dateStr, 'upstream fetch failed:', e.message);
+    // Serve stale cache if we have one — better than nothing during a hiccup.
+    return cached ? cached.matches : [];
+  }
+  const events = (data && data.events) || [];
+  const matches = events.map(_normalizeEvent).filter(Boolean);
+  _cache.set(dateStr, { fetchedAt: Date.now(), matches });
+  return matches;
+}
+
+function _todayUTC() {
+  return new Date().toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function init(app) {
+  app.get('/api/wc-scores', async (req, res) => {
+    try {
+      const raw = (req.query.dates || '').toString().trim();
+      let dates = raw ? raw.split(',').map((d) => d.trim()).filter((d) => /^\d{8}$/.test(d)) : [];
+      if (dates.length === 0) dates = [_todayUTC()];
+      if (dates.length > 40) {
+        return res.status(400).json({ error: 'at most 40 dates per call' });
+      }
+      const results = await Promise.all(dates.map((d) => _matchesForDate(d)));
+      const matches = [];
+      for (const arr of results) for (const m of arr) matches.push(m);
+      res.set('Cache-Control', 'no-store');
+      res.json({ source: 'espn', fetchedAt: new Date().toISOString(), matches });
+    } catch (e) {
+      console.error('[wc-scores] handler error:', e);
+      res.status(500).json({ error: e.message || 'internal error' });
+    }
+  });
+}
+
+module.exports = { init };

--- a/world-cup.html
+++ b/world-cup.html
@@ -72,6 +72,6 @@
   <script src="js/auth.js"></script>
   <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
-  <script src="js/world-cup.js?v=23"></script>
+  <script src="js/world-cup.js?v=24"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
OpenFootball is volunteer-maintained and was lagging the broadcast by hours on opening day — "Sync scores" kept returning 0 updated because the source had nothing new. This wires up a truly-live alternative without an API key.

- **`vps/wc-scores.js`** — new module that proxies ESPN's public scoreboard JSON (`site.api.espn.com/.../soccer/fifa.world/scoreboard?dates=YYYYMMDD`) server-side and normalizes the payload into the OpenFootball-ish shape the WC client already consumes (`date`, `team1`, `team2`, `score.ft`, `goals1`/`goals2` with name/minute/owngoal). 60s in-memory cache, 15s timeout, 2 MB ceiling, multi-date fan-out via comma-separated `dates`. Bad upstream responses serve stale cache rather than 500'ing the whole request.
- **`vps/server.js`** — mounts the proxy at `/api/wc-scores`.
- **`js/world-cup.js` `syncScores()`** — tries the VPS proxy first when CloudSync is configured + online, falls back to OpenFootball otherwise (so guests on the public host without Tailscale still get something). Toasts now name the source. Adds abbreviation lookup for ESPN team codes that diverge from FIFA's (RSA→ZAF, CZR→CZE, MOR→MAR, SAU→KSA, etc.) plus ESPN display-name variants ("Türkiye", "Korea Republic", "IR Iran").
- Pre-match events from ESPN deliberately drop their phantom "0" scores so we don't fake a 0-0 final on unplayed fixtures.

The VPS auto-deploys on merge via `.github/workflows/deploy-vps.yml` (it watches `vps/**`).

Cache bust: `world-cup.js` v23→24.

## Test plan
- [ ] After deploy, `curl https://all-options-dev.tail57521e.ts.net/api/wc-scores?dates=20260611` returns `{ source: "espn", matches: [...] }` with Mexico–South Africa and a `score.ft`.
- [ ] In the app on a Tailscale device, tap **⟳ Sync scores** → toast reads "Synced from ESPN — N scores updated" and the leaderboard rebuilds.
- [ ] Auto-poll during a live match picks up updates inside a minute via the VPS, with the live-window LIVE badge in place.
- [ ] On a guest device off Tailscale, sync falls back to OpenFootball without erroring.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_