### PR TITLE
docs: update README.md with World Cup 2026 live-scores proxy feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All content in this repository adheres to the [Content Guidelines](content-guide
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Actualización World Cup 2026**: Integración de proxy de resultados en vivo de ESPN en el VPS, con OpenFootball como respaldo. (World Cup: ESPN live-scores proxy on the VPS, OpenFootball as fallback.)
 - **Actualización Infraestructura**: Se actualizó el hostname de Tailscale para la sincronización familiar (`all-options-dev`). (Updated Tailscale hostname for family sync to `all-options-dev`.)
 - **Actualización World Cup 2026**: Planteles oficiales con los 48 equipos finales, nuevo modo cascada para las llaves, álbum de figuritas, Trophy Room, filtros de partidos y snapshot de la quiniela familiar. (Official 48-team squads, new cascade mode for brackets, sticker album, Trophy Room, match filters, and family-pool snapshot.)
 - **Actualización Book & Movie Check**: Mensajes de error de red más claros. (Clearer network error messages.)
@@ -152,6 +153,7 @@ Para la mejor experiencia en dispositivos móviles:
 The static apps work standalone, but **Book & Movie Check** and cross-device sync require the small Express server in `vps/`. It handles:
 - CloudSync (per-kid app data + family profiles)
 - Book & Movie Check (title lookup, AI evaluation, trailer fetch)
+- World Cup 2026 live-scores proxy
 
 **1. Install deps**
 


### PR DESCRIPTION
# DAILY DOCS UPDATE [2026-03-24] — Documentation Guardian Agent 
 # Task completed: Update README.md with World Cup 2026 live-scores proxy feature

---
*PR created automatically by Jules for task [17092249240929651843](https://jules.google.com/task/17092249240929651843) started by @rozavala*