### PR TITLE
Update README.md changelog for World Cup 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ All content in this repository adheres to the [Content Guidelines](content-guide
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Actualización World Cup 2026**: Nuevo formato de enlace compartido más corto para enviar quinielas familiares grandes por WhatsApp. (New shorter share link format to send large family pools via WhatsApp.)
 - **Actualización Infraestructura**: Se actualizó el hostname de Tailscale para la sincronización familiar (`all-options-dev`). (Updated Tailscale hostname for family sync to `all-options-dev`.)
 - **Actualización World Cup 2026**: Planteles oficiales con los 48 equipos finales, nuevo modo cascada para las llaves, álbum de figuritas, Trophy Room, filtros de partidos y snapshot de la quiniela familiar. (Official 48-team squads, new cascade mode for brackets, sticker album, Trophy Room, match filters, and family-pool snapshot.)
 - **Actualización Book & Movie Check**: Mensajes de error de red más claros. (Clearer network error messages.)


### PR DESCRIPTION
Added a changelog entry for the new WhatsApp share link format for World Cup 2026 family pools to the README.md `Novedades de la Semana` section.

This ensures the documentation reflects the latest functional update in the repository. Compliant with `content-guidelines.md`.

---
*PR created automatically by Jules for task [5679414828020691146](https://jules.google.com/task/5679414828020691146) started by @rozavala*