### PR TITLE
Fix and complete the Rosary in Fe Explorador

### DIFF
--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -71,6 +71,39 @@
     .quiz-btn.wrong { background: #EF4444; border-color: #EF4444; }
 
     /* Rosary Section */
+    .rosary-today { text-align: center; font-size: 0.95rem; opacity: 0.85; margin: 8px 0 16px; }
+    .rosary-today strong { color: var(--faith-gold-light); }
+
+    .set-tabs { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin-bottom: 16px; }
+    .set-tab {
+      padding: 8px 14px; border-radius: 99px; background: rgba(255,255,255,0.05);
+      border: 1.5px solid rgba(255,255,255,0.12); color: #FFFBEB; font-weight: 700;
+      font-size: 0.85rem; cursor: pointer; transition: all 0.2s; white-space: nowrap;
+    }
+    .set-tab:hover { border-color: var(--faith-gold); }
+    .set-tab.active { background: var(--faith-gold); color: #000; border-color: var(--faith-gold); }
+    .set-tab.is-today { box-shadow: 0 0 0 2px rgba(245,158,11,0.35); }
+
+    .set-days { text-align: center; font-size: 0.85rem; color: var(--faith-gold-light); font-weight: 700; margin-bottom: 16px; }
+
+    .mystery-list { display: grid; gap: 8px; margin-bottom: 8px; }
+    .mystery-item {
+      display: flex; align-items: center; gap: 12px; width: 100%; text-align: left;
+      padding: 12px 14px; border-radius: 12px; background: rgba(255,255,255,0.04);
+      border: 1.5px solid rgba(255,255,255,0.1); color: #FFFBEB; cursor: pointer; transition: all 0.2s;
+    }
+    .mystery-item:hover { border-color: var(--faith-gold); background: rgba(255,255,255,0.08); }
+    .mystery-item.active { border-color: var(--faith-gold); background: rgba(245,158,11,0.12); }
+    .mystery-num {
+      flex: 0 0 28px; width: 28px; height: 28px; border-radius: 50%;
+      background: var(--faith-gold); color: #000; font-weight: 800;
+      display: flex; align-items: center; justify-content: center; font-size: 0.9rem;
+    }
+    .mystery-item.active .mystery-num { box-shadow: 0 0 10px var(--faith-gold); }
+    .mystery-item-text { display: flex; flex-direction: column; gap: 2px; }
+    .mystery-item-name { font-weight: 800; font-size: 1rem; line-height: 1.2; }
+    .mystery-item-desc { font-size: 0.82rem; opacity: 0.75; line-height: 1.35; }
+
     .rosary-beads { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin: 32px 0; }
     .rosary-bead { width: 44px; height: 44px; border-radius: 50%; background: #2D1B0A; border: 3px solid #4D2B1A; cursor: pointer; transition: all 0.3s; display: flex; align-items: center; justify-content: center; font-weight: 800; color: rgba(255,255,255,0.2); }
     .rosary-bead.active { background: var(--faith-gold); border-color: #FFF; color: #000; box-shadow: 0 0 20px var(--faith-gold); transform: scale(1.15); }
@@ -133,7 +166,9 @@
     let prayerIndex = 0;
     let prayerLine = 0;
     let saintIndex = 0;
-    let rosaryBead = 0;
+    let rosarySet = null;   // selected mystery set; null = use today's
+    let rosaryDecade = 0;   // which of the 5 mysteries (0-4)
+    let rosaryBead = 0;     // bead within the current decade (0-9)
     let heritageIndex = 0;
 
     // Auto-pull sync
@@ -250,41 +285,99 @@
     }
 
     function renderRosary(container) {
-      const day = new Date().getDay(); // 0-6, we use Joyful mysteries for weekdays
-      const mIdx = (day === 0 || day === 6) ? 0 : (day - 1) % 5;
-      const m = FeManager.MYSTERIES[mIdx];
-      
+      const today = new Date().getDay();
+      const todayIdx = FeManager.getRosarySetIndexForDay(today);
+      if (rosarySet === null) rosarySet = todayIdx;
+
+      const sets = FeManager.ROSARY_SETS;
+      const set = sets[rosarySet];
+      const todaySet = sets[todayIdx];
+      const m = set.mysteries[rosaryDecade];
+      const dayName = FeManager.DAY_NAMES[today];
+
       const card = document.createElement('div');
       card.className = 'card';
       card.innerHTML = `
-        <h2 style="font-family:'Baloo 2';text-align:center;">Misterios Gozosos</h2>
+        <h2 style="font-family:'Baloo 2';text-align:center;">📿 Santo Rosario</h2>
+        <p class="rosary-today">Hoy es ${dayName}: se rezan los <strong>${todaySet.name}</strong></p>
+
+        <div class="set-tabs">
+          ${sets.map((s, i) => `
+            <button class="set-tab ${i === rosarySet ? 'active' : ''} ${i === todayIdx ? 'is-today' : ''}"
+                    onclick="selectRosarySet(${i})">
+              ${s.emoji} ${s.shortName}${i === todayIdx ? ' · Hoy' : ''}
+            </button>
+          `).join('')}
+        </div>
+
+        <div class="set-days">${set.name} — se rezan ${set.daysLabel}</div>
+
+        <div class="mystery-list">
+          ${set.mysteries.map((my, i) => `
+            <button class="mystery-item ${i === rosaryDecade ? 'active' : ''}" onclick="selectDecade(${i})">
+              <span class="mystery-num">${i + 1}</span>
+              <span class="mystery-item-text">
+                <span class="mystery-item-name">${my.name}</span>
+                <span class="mystery-item-desc">${my.desc}</span>
+              </span>
+            </button>
+          `).join('')}
+        </div>
+
         <div class="mystery-card">
-          <div class="mystery-title">${mIdx + 1}. ${m.name}</div>
+          <div class="mystery-title">${rosaryDecade + 1}. ${m.name}</div>
           <div class="mystery-desc">${m.desc}</div>
         </div>
         <div class="rosary-beads">
           ${Array.from({length: 10}).map((_, i) => `
-            <div class="rosary-bead ${i === rosaryBead ? 'active' : (i < rosaryBead ? 'done' : '')}" 
+            <div class="rosary-bead ${i === rosaryBead ? 'active' : (i < rosaryBead ? 'done' : '')}"
                  onclick="tapBead(${i})">${i + 1}</div>
           `).join('')}
         </div>
-        <p style="text-align:center;font-size:0.9rem;opacity:0.7;">Toca cada cuenta para rezar un Ave María</p>
+        <p style="text-align:center;font-size:0.9rem;opacity:0.7;">
+          Toca cada cuenta para rezar un Ave María (${rosaryBead}/10)
+        </p>
       `;
       container.appendChild(card);
     }
 
+    function selectRosarySet(i) {
+      rosarySet = i;
+      rosaryDecade = 0;
+      rosaryBead = 0;
+      if (typeof playSound === 'function') playSound('click');
+      render();
+    }
+
+    function selectDecade(i) {
+      rosaryDecade = i;
+      rosaryBead = 0;
+      if (typeof playSound === 'function') playSound('click');
+      render();
+    }
+
     function tapBead(i) {
-      if (i === rosaryBead) {
-        if (typeof playSound === 'function') playSound('click');
-        if (rosaryBead < 9) {
-          rosaryBead++;
-        } else {
-          FeManager.addStar();
-          if (typeof playSound === 'function') playSound('success');
-          rosaryBead = 0;
-        }
+      if (i !== rosaryBead) return;
+      if (typeof playSound === 'function') playSound('click');
+
+      if (rosaryBead < 9) {
+        rosaryBead++;
         render();
+        return;
       }
+
+      // Decade complete — award a star and move to the next mystery.
+      FeManager.addStar();
+      if (typeof playSound === 'function') playSound('success');
+      rosaryBead = 0;
+
+      const set = FeManager.ROSARY_SETS[rosarySet];
+      if (rosaryDecade < set.mysteries.length - 1) {
+        rosaryDecade++;
+      } else {
+        rosaryDecade = 0; // full rosary finished
+      }
+      render();
     }
 
     function renderHeritage(container) {

--- a/js/fe-explorador.js
+++ b/js/fe-explorador.js
@@ -249,13 +249,84 @@ const FeManager = (() => {
     }
   ];
 
-  const MYSTERIES = [
-    { name: 'La Encarnación', desc: 'El ángel Gabriel visita a María.' },
-    { name: 'La Visitación', desc: 'María visita a su prima Isabel.' },
-    { name: 'El Nacimiento', desc: 'Jesús nace en Belén.' },
-    { name: 'La Presentación', desc: 'María y José llevan al Niño al Templo.' },
-    { name: 'El Niño Perdido', desc: 'Encuentran a Jesús en el Templo.' }
+  /* The four sets of mysteries of the Holy Rosary, with the traditional
+     weekly schedule (post-2002, including the Luminous mysteries).
+     `days` uses JS Date.getDay() values: 0=Sun, 1=Mon ... 6=Sat. */
+  const ROSARY_SETS = [
+    {
+      id: 'gozosos',
+      name: 'Misterios Gozosos',
+      shortName: 'Gozosos',
+      emoji: '🌟',
+      days: [1, 6],
+      daysLabel: 'Lunes y Sábado',
+      mysteries: [
+        { name: 'La Anunciación', desc: 'El ángel Gabriel anuncia a María que será la Madre de Dios.' },
+        { name: 'La Visitación', desc: 'María visita a su prima Isabel, que espera a Juan el Bautista.' },
+        { name: 'El Nacimiento de Jesús', desc: 'Jesús nace en el portal de Belén.' },
+        { name: 'La Presentación', desc: 'María y José presentan al Niño Jesús en el Templo.' },
+        { name: 'El Niño hallado en el Templo', desc: 'Tras tres días, encuentran a Jesús enseñando entre los doctores del Templo.' }
+      ]
+    },
+    {
+      id: 'luminosos',
+      name: 'Misterios Luminosos',
+      shortName: 'Luminosos',
+      emoji: '💡',
+      days: [4],
+      daysLabel: 'Jueves',
+      mysteries: [
+        { name: 'El Bautismo en el Jordán', desc: 'Juan bautiza a Jesús y el Padre lo proclama su Hijo amado.' },
+        { name: 'Las Bodas de Caná', desc: 'Jesús convierte el agua en vino a petición de María.' },
+        { name: 'El Anuncio del Reino', desc: 'Jesús anuncia el Reino de Dios e invita a la conversión.' },
+        { name: 'La Transfiguración', desc: 'Jesús se transfigura en el monte ante Pedro, Santiago y Juan.' },
+        { name: 'La Institución de la Eucaristía', desc: 'En la Última Cena, Jesús se entrega en el pan y el vino.' }
+      ]
+    },
+    {
+      id: 'dolorosos',
+      name: 'Misterios Dolorosos',
+      shortName: 'Dolorosos',
+      emoji: '✝️',
+      days: [2, 5],
+      daysLabel: 'Martes y Viernes',
+      mysteries: [
+        { name: 'La Oración en el Huerto', desc: 'Jesús ora en Getsemaní la noche antes de su pasión.' },
+        { name: 'La Flagelación', desc: 'Jesús es azotado por orden de Pilato.' },
+        { name: 'La Coronación de Espinas', desc: 'Coronan a Jesús con espinas y se burlan de Él.' },
+        { name: 'Jesús con la Cruz a Cuestas', desc: 'Jesús carga la cruz camino del Calvario.' },
+        { name: 'La Crucifixión', desc: 'Jesús muere en la cruz por amor a todos.' }
+      ]
+    },
+    {
+      id: 'gloriosos',
+      name: 'Misterios Gloriosos',
+      shortName: 'Gloriosos',
+      emoji: '👑',
+      days: [3, 0],
+      daysLabel: 'Miércoles y Domingo',
+      mysteries: [
+        { name: 'La Resurrección', desc: 'Jesús resucita victorioso al tercer día.' },
+        { name: 'La Ascensión', desc: 'Jesús sube al Cielo a la derecha del Padre.' },
+        { name: 'La Venida del Espíritu Santo', desc: 'El Espíritu Santo desciende sobre los apóstoles en Pentecostés.' },
+        { name: 'La Asunción de María', desc: 'María es llevada en cuerpo y alma al Cielo.' },
+        { name: 'La Coronación de María', desc: 'María es coronada como Reina del Cielo y de la Tierra.' }
+      ]
+    }
   ];
+
+  const DAY_NAMES = ['domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado'];
+
+  // Index into ROSARY_SETS for the mysteries traditionally prayed on a given
+  // weekday (defaults to today). Falls back to the Joyful mysteries.
+  function getRosarySetIndexForDay(day) {
+    if (typeof day !== 'number') day = new Date().getDay();
+    const idx = ROSARY_SETS.findIndex(s => s.days.includes(day));
+    return idx === -1 ? 0 : idx;
+  }
+
+  // Backward-compatible alias: the Joyful mysteries as a flat array.
+  const MYSTERIES = ROSARY_SETS[0].mysteries;
 
   const HERITAGE = [
     // PRUNED [2026-06-15]: Removed duplicate 'tirana' object (different structure) to respect MAX 8 limit
@@ -341,8 +412,9 @@ const FeManager = (() => {
     }
   }
 
-  return { 
-    PRAYERS, SAINTS, MYSTERIES, HERITAGE, addStar, 
+  return {
+    PRAYERS, SAINTS, MYSTERIES, ROSARY_SETS, HERITAGE, addStar,
+    getRosarySetIndexForDay, DAY_NAMES,
     getStatus: _getData
   };
 })();


### PR DESCRIPTION
The Rosary tab only exposed the five Joyful mysteries and picked a single
one by weekday, with a hardcoded 'Misterios Gozosos' header and no way to
browse the other days' mysteries.

- Add all four sets of mysteries (Gozosos, Luminosos, Dolorosos,
  Gloriosos) with proper names and descriptions.
- Detect today's weekday and propose the correct set per the traditional
  schedule, badged 'Hoy'.
- Add a set selector so any day's mysteries can be browsed.
- List all five mysteries of the selected set, each selectable.
- Step beads through a full decade and advance to the next mystery on
  completion.