### PR TITLE
Add rosary prayer texts so kids can learn them

### DIFF
--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -168,7 +168,18 @@
     let saintIndex = 0;
     let rosarySet = null;   // selected mystery set; null = use today's
     let rosaryDecade = 0;   // which of the 5 mysteries (0-4)
-    let rosaryBead = 0;     // bead within the current decade (0-9)
+    let rosaryStep = 0;     // prayer within the current decade (0-11)
+    let rosarySalve = false; // true when showing the closing Salve
+
+    // The prayers prayed in each decade (mystery) of the rosary, in order:
+    // 1 Padre Nuestro, 10 Ave Marías, 1 Gloria. After the 5th decade comes
+    // the Salve. Kids can read each prayer's text as they pray it.
+    const DECADE_PRAYERS = [
+      'padrenuestro',
+      'avemaria', 'avemaria', 'avemaria', 'avemaria', 'avemaria',
+      'avemaria', 'avemaria', 'avemaria', 'avemaria', 'avemaria',
+      'gloria'
+    ];
     let heritageIndex = 0;
 
     // Auto-pull sync
@@ -297,7 +308,8 @@
 
       const card = document.createElement('div');
       card.className = 'card';
-      card.innerHTML = `
+
+      const header = `
         <h2 style="font-family:'Baloo 2';text-align:center;">📿 Santo Rosario</h2>
         <p class="rosary-today">Hoy es ${dayName}: se rezan los <strong>${todaySet.name}</strong></p>
 
@@ -311,7 +323,42 @@
         </div>
 
         <div class="set-days">${set.name} — se rezan ${set.daysLabel}</div>
+      `;
 
+      // Closing Salve: shown once after the 5th decade is finished.
+      if (rosarySalve) {
+        const salve = FeManager.getPrayer('salve');
+        card.innerHTML = header + `
+          <div class="mystery-card">
+            <div class="mystery-title">🎉 ¡Rosario completo!</div>
+            <div class="mystery-desc">Para terminar, recemos juntos la Salve.</div>
+          </div>
+          <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-light);">${salve.title}</h3>
+          <div id="prayer-lines">
+            ${salve.lines.map(l => `<div class="prayer-line active">${l}</div>`).join('')}
+          </div>
+          <div class="bottom-actions">
+            <button class="next-btn" onclick="finishRosary()">¡Terminar! 🌟</button>
+          </div>
+        `;
+        container.appendChild(card);
+        return;
+      }
+
+      const prayerId = DECADE_PRAYERS[rosaryStep];
+      const prayer = FeManager.getPrayer(prayerId);
+      // For Ave Marías, show which of the ten we're on (steps 1–10).
+      const aveNum = rosaryStep; // step 1 => Ave María 1, ... step 10 => 10
+      const prayerLabel = prayerId === 'avemaria'
+        ? `${prayer.title} (${aveNum} de 10)`
+        : prayer.title;
+      const isLastStep = rosaryStep === DECADE_PRAYERS.length - 1;
+      const isLastDecade = rosaryDecade === set.mysteries.length - 1;
+      const nextLabel = isLastStep
+        ? (isLastDecade ? 'Rezar la Salve ➔' : 'Siguiente misterio ➔')
+        : 'Continuar ➔';
+
+      card.innerHTML = header + `
         <div class="mystery-list">
           ${set.mysteries.map((my, i) => `
             <button class="mystery-item ${i === rosaryDecade ? 'active' : ''}" onclick="selectDecade(${i})">
@@ -328,15 +375,23 @@
           <div class="mystery-title">${rosaryDecade + 1}. ${m.name}</div>
           <div class="mystery-desc">${m.desc}</div>
         </div>
+
         <div class="rosary-beads">
-          ${Array.from({length: 10}).map((_, i) => `
-            <div class="rosary-bead ${i === rosaryBead ? 'active' : (i < rosaryBead ? 'done' : '')}"
-                 onclick="tapBead(${i})">${i + 1}</div>
-          `).join('')}
+          ${DECADE_PRAYERS.map((id, i) => {
+            const label = id === 'padrenuestro' ? 'PN' : (id === 'gloria' ? 'G' : String(i));
+            const state = i === rosaryStep ? 'active' : (i < rosaryStep ? 'done' : '');
+            return `<div class="rosary-bead ${state}" onclick="goToStep(${i})">${label}</div>`;
+          }).join('')}
         </div>
-        <p style="text-align:center;font-size:0.9rem;opacity:0.7;">
-          Toca cada cuenta para rezar un Ave María (${rosaryBead}/10)
-        </p>
+
+        <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-light);">${prayerLabel}</h3>
+        <div id="prayer-lines">
+          ${prayer.lines.map(l => `<div class="prayer-line active">${l}</div>`).join('')}
+        </div>
+
+        <div class="bottom-actions">
+          <button class="next-btn" onclick="nextRosaryStep()">${nextLabel}</button>
+        </div>
       `;
       container.appendChild(card);
     }
@@ -344,39 +399,59 @@
     function selectRosarySet(i) {
       rosarySet = i;
       rosaryDecade = 0;
-      rosaryBead = 0;
+      rosaryStep = 0;
+      rosarySalve = false;
       if (typeof playSound === 'function') playSound('click');
       render();
     }
 
     function selectDecade(i) {
       rosaryDecade = i;
-      rosaryBead = 0;
+      rosaryStep = 0;
+      rosarySalve = false;
       if (typeof playSound === 'function') playSound('click');
       render();
     }
 
-    function tapBead(i) {
-      if (i !== rosaryBead) return;
+    // Jump to a specific prayer within the current decade by tapping its bead.
+    function goToStep(i) {
+      rosaryStep = i;
       if (typeof playSound === 'function') playSound('click');
+      render();
+    }
 
-      if (rosaryBead < 9) {
-        rosaryBead++;
+    function nextRosaryStep() {
+      // Still prayers left in this decade (Padre Nuestro → 10 Aves → Gloria).
+      if (rosaryStep < DECADE_PRAYERS.length - 1) {
+        rosaryStep++;
+        if (typeof playSound === 'function') playSound('click');
         render();
         return;
       }
 
-      // Decade complete — award a star and move to the next mystery.
+      // Decade complete — award a star and move on.
       FeManager.addStar();
       if (typeof playSound === 'function') playSound('success');
-      rosaryBead = 0;
+      rosaryStep = 0;
 
       const set = FeManager.ROSARY_SETS[rosarySet];
       if (rosaryDecade < set.mysteries.length - 1) {
         rosaryDecade++;
       } else {
-        rosaryDecade = 0; // full rosary finished
+        // All five mysteries done — close with the Salve.
+        rosarySalve = true;
       }
+      render();
+    }
+
+    // Finish the full rosary after the closing Salve.
+    function finishRosary() {
+      FeManager.addStar();
+      if (typeof playSound === 'function') playSound('success');
+      if (typeof showConfetti === 'function') showConfetti();
+      rosarySalve = false;
+      rosaryDecade = 0;
+      rosaryStep = 0;
       render();
     }
 

--- a/js/fe-explorador.js
+++ b/js/fe-explorador.js
@@ -61,6 +61,24 @@ const FeManager = (() => {
         'que me perdería.',
         'Amén.'
       ]
+    },
+    {
+      id: 'salve',
+      title: 'Salve',
+      lines: [
+        'Dios te salve, Reina y Madre de misericordia,',
+        'vida, dulzura y esperanza nuestra;',
+        'Dios te salve.',
+        'A ti llamamos los desterrados hijos de Eva;',
+        'a ti suspiramos, gimiendo y llorando,',
+        'en este valle de lágrimas.',
+        'Ea, pues, Señora, abogada nuestra,',
+        'vuelve a nosotros esos tus ojos misericordiosos;',
+        'y después de este destierro,',
+        'muéstranos a Jesús, fruto bendito de tu vientre.',
+        '¡Oh clemente, oh piadosa, oh dulce Virgen María!',
+        'Amén.'
+      ]
     }
   ];
 
@@ -328,6 +346,12 @@ const FeManager = (() => {
   // Backward-compatible alias: the Joyful mysteries as a flat array.
   const MYSTERIES = ROSARY_SETS[0].mysteries;
 
+  // Look up a prayer by its id (e.g. 'padrenuestro', 'avemaria', 'gloria',
+  // 'salve'). Used by the rosary so kids can read each prayer as they pray it.
+  function getPrayer(id) {
+    return PRAYERS.find(p => p.id === id) || null;
+  }
+
   const HERITAGE = [
     // PRUNED [2026-06-15]: Removed duplicate 'tirana' object (different structure) to respect MAX 8 limit
     // PRUNED [2026-06-15]: Removed 'vasquez' to make room for 'fiesta_san_pedro' and stay within MAX 8 limit
@@ -414,7 +438,7 @@ const FeManager = (() => {
 
   return {
     PRAYERS, SAINTS, MYSTERIES, ROSARY_SETS, HERITAGE, addStar,
-    getRosarySetIndexForDay, DAY_NAMES,
+    getRosarySetIndexForDay, DAY_NAMES, getPrayer,
     getStatus: _getData
   };
 })();


### PR DESCRIPTION
## What

In Fe Explorador's **Rosario** tab, kids now walk through the actual prayers prayed in each decade so they can read and learn them:

- **1 Padre Nuestro**
- **10 Ave Marías** (labeled "Ave María 1 de 10" … "10 de 10")
- **1 Gloria**

…and after the 5th mystery, it closes with the **Salve**.

## Details

- Each step shows the **full prayer text** on screen.
- The bead row reflects the real sequence: a **PN** bead, beads **1–10**, and a **G** bead. Taps jump to any prayer; the **Continuar / Siguiente misterio / Rezar la Salve** button advances.
- A star is awarded after each decade; finishing the Salve triggers confetti + a final star.
- Added the **Salve** prayer (it was missing) to the prayers list, so it also appears in the 🙏 Oración tab.

## Files
- `fe-explorador.html` — rewrote the rosary flow to show prayer texts step by step
- `js/fe-explorador.js` — added the Salve prayer and a `getPrayer(id)` helper

Both the JS file and inline HTML scripts validate cleanly; the existing smoke test for `fe-explorador.html` is unaffected.

https://claude.ai/code/session_012fEUW7qNgCWLETT433sz8d

---
_Generated by [Claude Code](https://claude.ai/code/session_012fEUW7qNgCWLETT433sz8d)_