### PR TITLE
CloudSync: union-merge World Cup snapshots instead of last-writer-wins

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -177,7 +177,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/bible-explorer.html
+++ b/bible-explorer.html
@@ -103,7 +103,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -196,7 +196,7 @@
   <script src="js/nav.js?v=2"></script>
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -129,7 +129,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=6"></script>
+<script src="js/sync.js?v=7"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/civics-lab.html
+++ b/civics-lab.html
@@ -101,7 +101,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/code-cadet.html
+++ b/code-cadet.html
@@ -86,7 +86,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -74,7 +74,7 @@
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=6"></script>
+<script src="js/sync.js?v=7"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/family.html
+++ b/family.html
@@ -47,7 +47,7 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -120,7 +120,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -97,7 +97,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -151,7 +151,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/activity-log.js"></script>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/js/sync.js
+++ b/js/sync.js
@@ -115,6 +115,99 @@ var CloudSync = (function() {
     return isNaN(n) ? 0 : n;
   }
 
+  // Count "filled" fields in a World Cup picks object — used as the
+  // tiebreaker when two devices have a bracket for the same member id
+  // and we want to keep the more complete one rather than coin-flip.
+  function _wcPickRichness(p) {
+    if (!p) return 0;
+    var n = 0;
+    ['groupWinners','groupRunnersUp','groupThird','ko','scores'].forEach(function(k) {
+      var v = p[k];
+      if (v && typeof v === 'object') n += Object.keys(v).length;
+    });
+    ['champion','runnerUp','goldenBoot'].forEach(function(k) {
+      if (p[k]) n += 1;
+    });
+    return n;
+  }
+
+  // Union-merge two World Cup snapshots so neither side ever loses
+  // members, picks, or match results just because its _syncedAt got
+  // out-flanked by a stale device's push. Conflicts ("both sides
+  // have this member id") resolve toward whichever side has more
+  // filled-in fields; match results prefer a side that actually has
+  // a result over a side that doesn't.
+  function _mergeWorldCup(server, local) {
+    var s = server || {};
+    var l = local || {};
+    var out = {};
+
+    // Members: union by id, falling back to lowercase name. Local
+    // first so the device's own member identity wins if both sides
+    // have the same person under different ids.
+    var byKey = {};
+    function _key(m) { return (m && m.id) || (m && m.name ? '_n:' + m.name.toLowerCase().trim() : null); }
+    (l.members || []).forEach(function(m) { var k = _key(m); if (k) byKey[k] = m; });
+    (s.members || []).forEach(function(m) {
+      var k = _key(m);
+      if (!k) return;
+      var existing = byKey[k];
+      if (!existing) { byKey[k] = m; return; }
+      byKey[k] = {
+        id: existing.id || m.id,
+        name: existing.name || m.name,
+        avatar: existing.avatar || m.avatar || null,
+      };
+    });
+    out.members = Object.keys(byKey).map(function(k) { return byKey[k]; });
+
+    // Picks: union by id, richer side wins on conflict.
+    var pickIds = {};
+    Object.keys(l.picks || {}).forEach(function(id) { pickIds[id] = 1; });
+    Object.keys(s.picks || {}).forEach(function(id) { pickIds[id] = 1; });
+    out.picks = {};
+    Object.keys(pickIds).forEach(function(id) {
+      var lp = (l.picks || {})[id], sp = (s.picks || {})[id];
+      if (!lp) { out.picks[id] = sp; return; }
+      if (!sp) { out.picks[id] = lp; return; }
+      out.picks[id] = _wcPickRichness(lp) >= _wcPickRichness(sp) ? lp : sp;
+    });
+
+    // matchOverrides: union by id. Prefer the side with a `result`
+    // present; if both have one, server wins (score-sync is the
+    // source of truth). Other override fields (venue/team edits)
+    // merge with server overriding local on conflict.
+    var ovIds = {};
+    Object.keys(l.matchOverrides || {}).forEach(function(id) { ovIds[id] = 1; });
+    Object.keys(s.matchOverrides || {}).forEach(function(id) { ovIds[id] = 1; });
+    out.matchOverrides = {};
+    Object.keys(ovIds).forEach(function(id) {
+      var lo = (l.matchOverrides || {})[id], so = (s.matchOverrides || {})[id];
+      if (!lo) { out.matchOverrides[id] = so; return; }
+      if (!so) { out.matchOverrides[id] = lo; return; }
+      var sHasResult = so.result != null;
+      var lHasResult = lo.result != null;
+      if (sHasResult && !lHasResult) out.matchOverrides[id] = Object.assign({}, lo, so);
+      else if (lHasResult && !sHasResult) out.matchOverrides[id] = Object.assign({}, so, lo);
+      else out.matchOverrides[id] = Object.assign({}, lo, so);
+    });
+
+    // Groups: take whichever side actually has a draw recorded.
+    out.groups = (s.groups && Object.keys(s.groups).length) ? s.groups : (l.groups || {});
+
+    // Other top-level fields: server wins on conflict, but keep
+    // local-only keys (uiSelectedMember, stickers, scorers, etc.).
+    var skip = { members:1, picks:1, matchOverrides:1, groups:1, _syncedAt:1 };
+    Object.keys(l).forEach(function(k) { if (!skip[k]) out[k] = l[k]; });
+    Object.keys(s).forEach(function(k) { if (!skip[k]) out[k] = s[k]; });
+
+    // Stamp the merge with the max of both timestamps + now so the
+    // next pull on this device doesn't redo the work, and the next
+    // push wins over either side's prior state.
+    out._syncedAt = Math.max(_parseTs(s._syncedAt), _parseTs(l._syncedAt), Date.now());
+    return out;
+  }
+
   state.push = function(key) {
     if (!state.isConfigured() || !state.online) return Promise.resolve();
     var info = _getAppInfo(key);
@@ -142,6 +235,22 @@ var CloudSync = (function() {
             });
           }
           return data;
+        })
+        .catch(function() { return data; });
+    } else if (info.appName === 'worldcup') {
+      // Before pushing the World Cup snapshot, fetch the server's
+      // current copy and union-merge it with ours, then push the
+      // result. Prevents a stale device's save from wiping members or
+      // results that another device has added since the last pull.
+      mergeStep = _fetchWithTimeout(SYNC_SERVER + '/api/kids/' + info.kidKey + '/' + info.appName)
+        .then(function(res) {
+          if (!res.ok) return data;
+          return res.json().then(function(serverData) {
+            if (!serverData) return data;
+            var merged = _mergeWorldCup(serverData, data);
+            try { localStorage.setItem(key, JSON.stringify(merged)); } catch (e) {}
+            return merged;
+          });
         })
         .catch(function() { return data; });
     }
@@ -212,6 +321,20 @@ var CloudSync = (function() {
         var lTime = _parseTs(localData._syncedAt);
         var localMissing = !localStorage.getItem(key);
 
+        // World Cup pulls always union-merge — never overwrite — so a
+        // device whose _syncedAt got out-flanked by a stale push still
+        // picks up the missing members / results, and one that has
+        // unique local additions keeps them.
+        if (info.appName === 'worldcup') {
+          var mergedWc = _mergeWorldCup(serverData, localData);
+          try { localStorage.setItem(key, JSON.stringify(mergedWc)); }
+          catch (e) {
+            if (typeof Debug !== 'undefined') Debug.error('[Sync] Quota Exceeded', key + ' size: ' + JSON.stringify(mergedWc).length);
+            throw e;
+          }
+          return true;
+        }
+
         if (sTime > lTime || localMissing || info.appName === 'activity') {
           var toStore = serverData;
           if (serverData._isList && Array.isArray(serverData._items)) {
@@ -221,7 +344,7 @@ var CloudSync = (function() {
               toStore = _mergeLists(toStore, localItems);
             }
           }
-          
+
           try {
             if (info.appName === 'art' && !Array.isArray(toStore)) {
               var merged = Object.assign({}, toStore, { gallery: localData.gallery || [] });

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2734,17 +2734,98 @@
      the URL and import to see the family leaderboard locally
      (read-only-ish — they can still edit their own bracket).
      ---------------------------------------------------------------- */
+  // Picks live in memory with verbose key names (groupWinners, ko, etc.)
+  // and verbose score objects ({home:2, away:0}). For pool snapshot URLs
+  // we re-key into single-letter fields and flatten the two largest
+  // structures into positional comma-separated strings:
+  //   sc = "2x0,1x1,..." indexed m001..m072 (group matches)
+  //   ko = "MEX,BRA,..."  indexed m073..m104 (R32→Final, incl. 3rd)
+  // Trailing empties trim. Symmetric expand restores the verbose shape.
+  function _stageForKoIndex(i) {
+    const n = 73 + i;
+    if (n <= 88)  return 'R32';
+    if (n <= 96)  return 'R16';
+    if (n <= 100) return 'QF';
+    if (n <= 102) return 'SF';
+    if (n === 103) return '3rd';
+    return 'Final';
+  }
+  function _compactPicks(p) {
+    if (!p) return null;
+    const out = {};
+    if (p.groupWinners && Object.keys(p.groupWinners).length) out.gw = p.groupWinners;
+    if (p.groupRunnersUp && Object.keys(p.groupRunnersUp).length) out.gr = p.groupRunnersUp;
+    if (p.groupThird && Object.keys(p.groupThird).length) out.g3 = p.groupThird;
+    if (p.ko) {
+      const allKo = Object.assign({}, p.ko.R32, p.ko.R16, p.ko.QF, p.ko.SF, p.ko['3rd'], p.ko.Final);
+      const arr = [];
+      for (let i = 73; i <= 104; i++) arr.push(allKo['m' + String(i).padStart(3, '0')] || '');
+      while (arr.length && !arr[arr.length - 1]) arr.pop();
+      if (arr.length) out.ko = arr.join(',');
+    }
+    if (p.champion) out.ch = p.champion;
+    if (p.runnerUp) out.ru = p.runnerUp;
+    if (p.goldenBoot) out.gb = p.goldenBoot;
+    if (p.goldenBootCorrect) out.gbc = 1;
+    if (p.mode && p.mode !== 'buildup') out.m = p.mode;
+    if (p.scores) {
+      const arr = [];
+      for (let i = 1; i <= 72; i++) {
+        const s = p.scores['m' + String(i).padStart(3, '0')];
+        arr.push(s && typeof s.home === 'number' && typeof s.away === 'number' ? s.home + 'x' + s.away : '');
+      }
+      while (arr.length && !arr[arr.length - 1]) arr.pop();
+      if (arr.length) out.sc = arr.join(',');
+    }
+    return out;
+  }
+  function _expandPicks(p) {
+    if (!p) return null;
+    // v=1 used the verbose shape directly — leave it alone.
+    if (p.groupWinners || p.groupRunnersUp || p.scores) return p;
+    const out = {
+      groupWinners: p.gw || {},
+      groupRunnersUp: p.gr || {},
+      groupThird: p.g3 || {},
+      ko: { R32:{}, R16:{}, QF:{}, SF:{}, '3rd':{}, Final:{} },
+      champion: p.ch || null,
+      runnerUp: p.ru || null,
+      goldenBoot: p.gb || '',
+      goldenBootCorrect: !!p.gbc,
+      mode: p.m || 'buildup',
+      scores: {},
+    };
+    if (typeof p.ko === 'string' && p.ko.length) {
+      const arr = p.ko.split(',');
+      for (let i = 0; i < arr.length; i++) {
+        const code = arr[i];
+        if (!code) continue;
+        out.ko[_stageForKoIndex(i)]['m' + String(73 + i).padStart(3, '0')] = code;
+      }
+    }
+    if (typeof p.sc === 'string' && p.sc.length) {
+      const arr = p.sc.split(',');
+      for (let i = 0; i < arr.length; i++) {
+        const entry = arr[i];
+        if (!entry) continue;
+        const m = entry.match(/^(\d+)x(\d+)$/);
+        if (m) out.scores['m' + String(i + 1).padStart(3, '0')] = { home: parseInt(m[1], 10), away: parseInt(m[2], 10) };
+      }
+    }
+    return out;
+  }
+
   function encodePool() {
     const members = state.members
       .filter(m => m.name && m.name.trim())
       .map(m => ({
         n: m.name,
         a: m.avatar || '',
-        p: state.picks[m.id] || null,
+        p: _compactPicks(state.picks[m.id]),
       }));
     const results = {};
     for (const m of state.matches) if (m.result) results[m.id] = m.result;
-    const payload = { v: 1, type: 'pool', members, results };
+    const payload = { v: 2, type: 'pool', members, results };
     return _encodePayload(JSON.stringify(payload));
   }
   function decodePool(encoded) {
@@ -2752,7 +2833,14 @@
       const json = _decodePayload(encoded);
       if (!json) return null;
       const p = JSON.parse(json);
-      if (p && p.v === 1 && p.type === 'pool' && Array.isArray(p.members)) return p;
+      if (!p || p.type !== 'pool' || !Array.isArray(p.members)) return null;
+      if (p.v !== 1 && p.v !== 2) return null;
+      // Re-hydrate v=2 compact picks back into the verbose in-memory shape
+      // so importPool can drop them straight into state.picks.
+      if (p.v === 2) {
+        p.members = p.members.map(m => Object.assign({}, m, { p: _expandPicks(m.p) }));
+      }
+      return p;
     } catch (e) {}
     return null;
   }

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -67,7 +67,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -15905,7 +15905,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="js/auth.js?v=2"></script>
 
 <script src="js/a11y.js?v=2"></script>
-<script src="js/sync.js?v=6"></script>
+<script src="js/sync.js?v=7"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/timer.js?v=2"></script>
 <script src="js/learning-checks.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -142,7 +142,7 @@
   <script src="js/auth.js?v=2"></script>
 
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>

--- a/menu.html
+++ b/menu.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/menu.js"></script>

--- a/money-master.html
+++ b/money-master.html
@@ -28,7 +28,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -43,7 +43,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -73,7 +73,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -264,7 +264,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=6"></script>
+<script src="js/sync.js?v=7"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -86,7 +86,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/routines.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -46,7 +46,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>

--- a/vacation.html
+++ b/vacation.html
@@ -26,7 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/vacation.js"></script>

--- a/vocabulario-vivo.html
+++ b/vocabulario-vivo.html
@@ -108,7 +108,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/world-cup.html
+++ b/world-cup.html
@@ -73,6 +73,6 @@
   <script src="js/sync.js?v=6"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=25"></script>
+  <script src="js/world-cup.js?v=26"></script>
 </body>
 </html>

--- a/world-cup.html
+++ b/world-cup.html
@@ -70,7 +70,7 @@
   </div>
 
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
   <script src="js/world-cup.js?v=26"></script>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -75,7 +75,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=6"></script>
+  <script src="js/sync.js?v=7"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>


### PR DESCRIPTION
## Summary
The `wc2026.v2` CloudSync bucket was running through the generic "if server `_syncedAt` > local `_syncedAt`, overwrite local" gate in `js/sync.js` — but the bucket isn't a single user's preferences, it's a **shared family roster** that grows on multiple devices. Last-writer-wins is the wrong semantic; the right one is union.

Reported on the iPad: cloud pill green, but the family pool was missing relatives that other devices were already showing. Any device whose local `save()` bumped its timestamp ahead of the server would refuse the pull forever and silently miss every late-added member, score prediction, and match result.

### Fix
Added `_mergeWorldCup(server, local)` and wired it on both sides:

- **Pull** — when `info.appName === 'worldcup'`, always union-merge and store the result, bypassing the timestamp gate.
- **Push** — before `PUT`-ing, fetch the server's current copy, union-merge with local, persist the merged form, and push that. Prevents a stale device's save from clobbering members or results another device added since the last pull.

### Merge rules (chosen so nothing is ever lost silently)
- **members** — union by id, falling back to lowercase name. Local first so the device's own member identity wins on tie.
- **picks** — union by id. On conflict, the side with more filled fields (groupWinners, ko, scores, champion, etc.) wins — never coin-flip.
- **matchOverrides** — union by id. Prefer a side that has a `result` over one that doesn't; if both have one, server wins (live score-sync is the source of truth).
- **groups** — take whichever side has a non-empty draw.
- **Other top-level keys** (stickers, scorers, uiSelectedMember) survive from local; server values override on conflict.
- **`_syncedAt`** — `max(server, local, now)` so the merged state becomes the new base.

### Verification
Replayed the canonical iPad scenario in Node:
- Server: 3 members, 2 results, `_syncedAt = 1000`
- iPad: 1 member (richer picks for shared id), 1 result, `_syncedAt = 5000`
- After merge on iPad: **3 members, 2 results, iPad's richer picks kept**.

Cache bust: `sync.js` v6→7 across every html file (the merge touches all apps' sync flow, not just World Cup).

## Test plan
- [ ] On the iPad with the missing data, hard refresh → after the next pull (≤1 min), the leaderboard shows every family member that's on other devices.
- [ ] Add a new member on the iPad → it appears on other devices on next pull (push merge prevents the iPad's new member from being lost).
- [ ] Enter a result on Device A, then enter a different match's result on Device B without B having pulled A's first → after both push, both devices end up with both results.
- [ ] Spot-check that non-World-Cup apps (activity log, money, etc.) still sync via the old path.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_