### PR TITLE
CloudSync: deep-merge World Cup picks and match overrides

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -177,7 +177,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/bible-explorer.html
+++ b/bible-explorer.html
@@ -103,7 +103,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -196,7 +196,7 @@
   <script src="js/nav.js?v=2"></script>
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -129,7 +129,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=7"></script>
+<script src="js/sync.js?v=8"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/civics-lab.html
+++ b/civics-lab.html
@@ -101,7 +101,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/code-cadet.html
+++ b/code-cadet.html
@@ -86,7 +86,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -74,7 +74,7 @@
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=7"></script>
+<script src="js/sync.js?v=8"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/family.html
+++ b/family.html
@@ -47,7 +47,7 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -153,7 +153,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -97,7 +97,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -151,7 +151,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/activity-log.js"></script>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/js/sync.js
+++ b/js/sync.js
@@ -131,6 +131,61 @@ var CloudSync = (function() {
     return n;
   }
 
+  // Deep-merge two World Cup picks objects. Union every collection
+  // (groupWinners, ko[stage], scores, etc.) so a key entered on either
+  // side never disappears; on a direct key conflict, the newer
+  // snapshot wins. Scalars (champion, runnerUp, goldenBoot) prefer
+  // the newer side's non-empty value.
+  function _mergeWcPicks(local, server, localNewer) {
+    if (!local && !server) return null;
+    if (!local) return server;
+    if (!server) return local;
+    var older = localNewer ? server : local;
+    var newer = localNewer ? local : server;
+    function unionMap(o, n) { return Object.assign({}, o || {}, n || {}); }
+    var oko = older.ko || {}, nko = newer.ko || {};
+    function nonEmpty(a, b) { return (a !== null && a !== undefined && a !== '') ? a : b; }
+    return {
+      groupWinners:    unionMap(older.groupWinners,    newer.groupWinners),
+      groupRunnersUp:  unionMap(older.groupRunnersUp,  newer.groupRunnersUp),
+      groupThird:      unionMap(older.groupThird,      newer.groupThird),
+      ko: {
+        R32:   unionMap(oko.R32,   nko.R32),
+        R16:   unionMap(oko.R16,   nko.R16),
+        QF:    unionMap(oko.QF,    nko.QF),
+        SF:    unionMap(oko.SF,    nko.SF),
+        '3rd': unionMap(oko['3rd'], nko['3rd']),
+        Final: unionMap(oko.Final, nko.Final),
+      },
+      champion:          nonEmpty(newer.champion,   older.champion)   || null,
+      runnerUp:          nonEmpty(newer.runnerUp,   older.runnerUp)   || null,
+      goldenBoot:        nonEmpty(newer.goldenBoot, older.goldenBoot) || '',
+      goldenBootCorrect: !!(older.goldenBootCorrect || newer.goldenBootCorrect),
+      mode:              nonEmpty(newer.mode, older.mode) || 'buildup',
+      // Score predictions: union by match id. On direct conflict
+      // (same match, two predictions), newer side wins so the most
+      // recent typed prediction doesn't get clobbered.
+      scores: unionMap(older.scores, newer.scores),
+    };
+  }
+
+  // Deep-merge two match-override objects (per match id). Every
+  // editable field is unioned with newer-side-wins on conflict, except
+  // that a side with a real `result` always beats a side without one.
+  function _mergeWcOverride(local, server, localNewer) {
+    if (!local) return server;
+    if (!server) return local;
+    var older = localNewer ? server : local;
+    var newer = localNewer ? local : server;
+    var out = Object.assign({}, older, newer);
+    var sHasRes = server.result != null, lHasRes = local.result != null;
+    if (sHasRes && !lHasRes) out.result = server.result;
+    else if (lHasRes && !sHasRes) out.result = local.result;
+    // both have result → newer's wins via Object.assign above; if both
+    // have it as the same score this is a no-op.
+    return out;
+  }
+
   // Union-merge two World Cup snapshots so neither side ever loses
   // members, picks, or match results just because its _syncedAt got
   // out-flanked by a stale device's push. Conflicts ("both sides
@@ -161,35 +216,31 @@ var CloudSync = (function() {
     });
     out.members = Object.keys(byKey).map(function(k) { return byKey[k]; });
 
-    // Picks: union by id, richer side wins on conflict.
+    // Snapshot-level recency for per-field conflict resolution. Lacking
+    // per-field timestamps, the newer snapshot wins on direct collisions
+    // (one device's last edit beats an older one's stale value for the
+    // same key), while every non-conflicting key from both sides
+    // survives the union.
+    var localNewer = _parseTs(l._syncedAt) >= _parseTs(s._syncedAt);
+
+    // Picks: union by id; on shared ids, deep-merge each picks object.
     var pickIds = {};
     Object.keys(l.picks || {}).forEach(function(id) { pickIds[id] = 1; });
     Object.keys(s.picks || {}).forEach(function(id) { pickIds[id] = 1; });
     out.picks = {};
     Object.keys(pickIds).forEach(function(id) {
-      var lp = (l.picks || {})[id], sp = (s.picks || {})[id];
-      if (!lp) { out.picks[id] = sp; return; }
-      if (!sp) { out.picks[id] = lp; return; }
-      out.picks[id] = _wcPickRichness(lp) >= _wcPickRichness(sp) ? lp : sp;
+      out.picks[id] = _mergeWcPicks((l.picks || {})[id], (s.picks || {})[id], localNewer);
     });
 
-    // matchOverrides: union by id. Prefer the side with a `result`
-    // present; if both have one, server wins (score-sync is the
-    // source of truth). Other override fields (venue/team edits)
-    // merge with server overriding local on conflict.
+    // matchOverrides: union by id; on shared ids, deep-merge each
+    // override (field-by-field) so a venue/team edit on one device
+    // can't wipe a `result` recorded on another.
     var ovIds = {};
     Object.keys(l.matchOverrides || {}).forEach(function(id) { ovIds[id] = 1; });
     Object.keys(s.matchOverrides || {}).forEach(function(id) { ovIds[id] = 1; });
     out.matchOverrides = {};
     Object.keys(ovIds).forEach(function(id) {
-      var lo = (l.matchOverrides || {})[id], so = (s.matchOverrides || {})[id];
-      if (!lo) { out.matchOverrides[id] = so; return; }
-      if (!so) { out.matchOverrides[id] = lo; return; }
-      var sHasResult = so.result != null;
-      var lHasResult = lo.result != null;
-      if (sHasResult && !lHasResult) out.matchOverrides[id] = Object.assign({}, lo, so);
-      else if (lHasResult && !sHasResult) out.matchOverrides[id] = Object.assign({}, so, lo);
-      else out.matchOverrides[id] = Object.assign({}, lo, so);
+      out.matchOverrides[id] = _mergeWcOverride((l.matchOverrides || {})[id], (s.matchOverrides || {})[id], localNewer);
     });
 
     // Groups: take whichever side actually has a draw recorded.

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -67,7 +67,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -15905,7 +15905,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="js/auth.js?v=2"></script>
 
 <script src="js/a11y.js?v=2"></script>
-<script src="js/sync.js?v=7"></script>
+<script src="js/sync.js?v=8"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/timer.js?v=2"></script>
 <script src="js/learning-checks.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -142,7 +142,7 @@
   <script src="js/auth.js?v=2"></script>
 
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>

--- a/menu.html
+++ b/menu.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/menu.js"></script>

--- a/money-master.html
+++ b/money-master.html
@@ -28,7 +28,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -43,7 +43,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -73,7 +73,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -264,7 +264,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=7"></script>
+<script src="js/sync.js?v=8"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -86,7 +86,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -27,7 +27,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/routines.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -46,7 +46,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>

--- a/vacation.html
+++ b/vacation.html
@@ -26,7 +26,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/vacation.js"></script>

--- a/vocabulario-vivo.html
+++ b/vocabulario-vivo.html
@@ -108,7 +108,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/world-cup.html
+++ b/world-cup.html
@@ -70,7 +70,7 @@
   </div>
 
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
   <script src="js/world-cup.js?v=26"></script>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -75,7 +75,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=7"></script>
+  <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>


### PR DESCRIPTION
## Summary
Follow-up to #363 — the picks merge was still too coarse. "Richer side wins entirely" meant that if the iPad had one extra field (a runnerUp, an extra score prediction) while the server had a *different* field set (a champion, a different score), the iPad's whole bracket beat the server's wholesale and the server's distinct fields were lost. Reported in practice: predictions and relatives' scores disappeared after the previous union-merge change.

### Fix
- **`_mergeWcPicks(local, server, localNewer)`** — deep-merges every collection (`groupWinners`, `ko[stage]`, `scores`, etc.) with newer-side-wins on direct key conflict. Scalars (`champion`, `runnerUp`, `goldenBoot`) prefer the newer side's non-empty value. `goldenBootCorrect` ORs across.
- **`_mergeWcOverride(local, server, localNewer)`** — same field-by-field merge, with one rule: a side with a real `result` always beats a side without one, so a venue/team edit can never silently drop a recorded score.
- Snapshot-level `_syncedAt` is the recency tiebreaker. Without per-field timestamps this is the closest we can get without schema changes.

### Verified scenario
- Server `m_a`: `{ gw:{A:MEX,B:SUI}, champion:FRA, scores:{m001:2-0} }`
- iPad  `m_a`: `{ gw:{A:MEX}, runnerUp:ESP, scores:{m002:1-1} }`
- After deep-merge → **both** `champion: FRA` and `runnerUp: ESP` present, groupWinner `B: SUI` kept, both `m001` and `m002` scores present.

Cache bust: `sync.js` v7→8 across every html file.

## Test plan
- [ ] On the iPad, predictions that disappeared after PR #363 reappear after the next pull.
- [ ] On any device, enter a unique field that no other device has (e.g. set Golden Boot) → push → other devices pull → field appears without clobbering their own unique edits.
- [ ] Enter a result on one device while another device has only a venue edit for the same match → after sync, both the result and the venue edit survive.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_