### PR TITLE
World Cup: render goal scorers under the score input in the match modal

### DIFF
--- a/css/world-cup.css
+++ b/css/world-cup.css
@@ -650,6 +650,22 @@ body {
 }
 .match-modal-nav .nav-arrow:hover { background: var(--wc-card); }
 
+/* Scorer lists under the score input in the match modal */
+.scorers-grid {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 10px;
+  margin: 6px 0 10px;
+  align-items: start;
+  font-size: 0.86rem;
+}
+.scorers-icon { font-size: 1.05rem; opacity: 0.7; align-self: center; }
+.scorers-col { line-height: 1.45; }
+.scorers-col.home { text-align: right; }
+.scorers-col.away { text-align: left; }
+.scorers-col .scorer { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.scorers-col .og { color: var(--wc-red); font-size: 0.7rem; font-weight: 800; }
+
 /* Family picks list inside the match modal */
 .pool-picks-section {
   margin-top: 14px;

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -4926,6 +4926,34 @@
       </div>`;
   }
 
+  // Render the goal scorers attached to a match's result. Two columns:
+  // home on the left, away on the right. Returns '' when neither side
+  // has scorer data (manual entry, or remote feed didn't include it),
+  // so the modal stays clean.
+  function _renderMatchScorers(m) {
+    const r = m && m.result;
+    const g1 = (r && Array.isArray(r.goals1)) ? r.goals1.slice() : [];
+    const g2 = (r && Array.isArray(r.goals2)) ? r.goals2.slice() : [];
+    if (g1.length === 0 && g2.length === 0) return '';
+    const sortByMin = (a, b) => (a.minute || 999) - (b.minute || 999);
+    g1.sort(sortByMin);
+    g2.sort(sortByMin);
+    function renderList(goals) {
+      if (goals.length === 0) return '<span class="muted" style="font-size:0.78rem;">—</span>';
+      return goals.map(g => {
+        const min = typeof g.minute === 'number' ? `<span class="muted">${g.minute}'</span>` : '';
+        const og  = g.owngoal ? ' <span class="og">(OG)</span>' : '';
+        return `<div class="scorer">${escapeHTML(g.name)}${og} ${min}</div>`;
+      }).join('');
+    }
+    return `
+      <div class="scorers-grid">
+        <div class="scorers-col home">${renderList(g1)}</div>
+        <div class="scorers-icon">⚽</div>
+        <div class="scorers-col away">${renderList(g2)}</div>
+      </div>`;
+  }
+
   // Chronologically sorted match list used by the prev/next nav. Cached
   // per-render is overkill — there are only ~104 matches.
   function _sortedMatchIds() {
@@ -4998,6 +5026,8 @@
         <input type="number" min="0" max="20" id="sc-away" value="${m.result?m.result.away:''}" />
         <div class="side">${away ? away.flag+' '+escapeHTML(away.name) : '<span class="muted">TBD</span>'}</div>
       </div>
+
+      ${_renderMatchScorers(m)}
 
       ${m.stage !== 'group' ? `
         <div class="pick-row"><div class="lbl">PK winner<br><span style="font-size:0.7rem;">(only if draw)</span></div><div>
@@ -5910,6 +5940,22 @@
             local.result = { home: hs, away: as, pkWinner };
             updated++;
           }
+          // Refresh per-match scorer lists whether or not the score
+          // moved — the remote may have just attached a name to an
+          // existing 1-1. Empty arrays clear stale entries so an
+          // edited-then-cleared scorer doesn't linger.
+          const cleanGoals = arr => Array.isArray(arr)
+            ? arr.filter(g => g && g.name).map(g => {
+                const out = { name: g.name };
+                if (typeof g.minute === 'number') out.minute = g.minute;
+                if (g.owngoal) out.owngoal = true;
+                return out;
+              })
+            : null;
+          const g1 = cleanGoals(rm.goals1);
+          const g2 = cleanGoals(rm.goals2);
+          if (g1 !== null) local.result.goals1 = g1;
+          if (g2 !== null) local.result.goals2 = g2;
         }
       }
 

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=18">
+  <link rel="stylesheet" href="css/world-cup.css?v=19">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -73,6 +73,6 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=27"></script>
+  <script src="js/world-cup.js?v=28"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Tier-1 of the match-detail expansion. The VPS ESPN proxy and the OpenFootball fallback already harvest `goals1`/`goals2` (name, minute, owngoal flag) for the Golden Boot tally — we just throw them away after. Persist them onto each match's `result` so the modal can show:

```
Henry Martín  23'           Lyle Foster   67'
Raúl Jiménez  88'    ⚽⚽    Joe Schmoe (OG) 92'
```

Two-column grid under the score input — home on the right edge of the left column (toward the home flag), away on the left edge of the right column. Each list sorted by minute ascending; own goals carry a small red `(OG)` badge.

### Implementation
- `syncScores` now writes cleaned `goals1`/`goals2` onto `local.result` on every sync that includes them, even when the score itself didn't move (so a freshly-attached scorer on an existing 1–1 still lands).
- Manual results without goal arrays render no scorers section, so the modal stays clean for hand-entered scores.
- `clearResult` already nukes `m.result` entirely — no separate cleanup needed.
- `_renderMatchScorers` is a no-op when both arrays are empty, so unplayed matches and manual entries show nothing.

Tier 2 (cards / lineups / stats via ESPN's `summary?event=` endpoint, with a per-match cache) ships in a follow-up PR.

Cache busts: `world-cup.js` v27→28, `world-cup.css` v18→19.

## Test plan
- [ ] Open a played match that's been synced via ESPN → scorers appear under the score input, sorted by minute, home column right-aligned, away left-aligned.
- [ ] Open a played match entered manually (no sync) → no scorer block (clean modal).
- [ ] Open an unplayed match → no scorer block.
- [ ] Own-goal entries render a small red `(OG)` badge.
- [ ] After re-running Sync scores, an existing 1-1 with a newly-attributed scorer shows the new name without needing a score change.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_