### PR TITLE
World Cup: scrollable match modal so tall content works in landscape

### DIFF
--- a/css/world-cup.css
+++ b/css/world-cup.css
@@ -602,6 +602,13 @@ body {
   padding: 18px;
   max-width: 420px;
   width: 100%;
+  /* Tall modals (family picks + scorers + cards) overflowed in
+     landscape on small screens — cap the height and let the body
+     scroll, with smooth iOS momentum. */
+  max-height: 92vh;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
 }
 .modal-inner h3 { font-family: var(--font-display); margin-bottom: 4px; font-size: 1.1rem; }
 .modal-inner .sub { color: var(--text-muted); font-size: 0.82rem; margin-bottom: 12px; }

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=19">
+  <link rel="stylesheet" href="css/world-cup.css?v=20">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">


### PR DESCRIPTION
## Summary
The match modal grew tall after the recent additions (scorer lists, family-picks section, prev/next nav) and overflowed the viewport on iPad landscape — Save/Cancel and the family-picks block ended up off-screen with no way to reach them.

Cap `.modal-inner` at `max-height: 92vh` and let the inner body scroll. `-webkit-overflow-scrolling: touch` gives iOS momentum; `overscroll-behavior: contain` keeps a scroll past the end from bubbling up and dragging the Matches list behind the modal.

Cache bust: `world-cup.css` v19→20.

## Test plan
- [ ] iPad landscape: open any played match → modal stays inside viewport, scroll inside reaches Save/Cancel and the family-picks list at the bottom.
- [ ] Scrolling past the bottom of the modal does not start scrolling the Matches list underneath.
- [ ] Portrait / desktop: no visual change.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_