### PR TITLE
World Cup: tier-2 match detail — ESPN summary endpoint, cards + reliable scorers

### DIFF
--- a/css/world-cup.css
+++ b/css/world-cup.css
@@ -672,6 +672,16 @@ body {
 .scorers-col.away { text-align: left; }
 .scorers-col .scorer { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .scorers-col .og { color: var(--wc-red); font-size: 0.7rem; font-weight: 800; }
+.card-icon {
+  display: inline-block;
+  width: 8px;
+  height: 11px;
+  border-radius: 1px;
+  vertical-align: middle;
+  margin-right: 3px;
+}
+.card-icon.yellow { background: #FBBF24; }
+.card-icon.red    { background: var(--wc-red); }
 
 /* Family picks list inside the match modal */
 .pool-picks-section {

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -4926,6 +4926,91 @@
       </div>`;
   }
 
+  /* ----------------------------------------------------------------
+     Lazy match-detail fetch (ESPN summary endpoint via VPS proxy)
+     Scoreboard JSON loses play-by-play after ~2 days, so on modal
+     open we fetch the summary endpoint for the match's eventId and
+     overlay scorers + cards on top of anything we already had. Cache
+     keyed by event id, 5 min TTL, in-memory only (small, ephemeral).
+     ---------------------------------------------------------------- */
+  const _matchDetailCache = new Map(); // eventId -> { fetchedAt, payload }
+  const MATCH_DETAIL_TTL_MS = 5 * 60 * 1000;
+  const VPS_WC_MATCH_URL = (window.CloudSync && CloudSync.isConfigured && CloudSync.isConfigured())
+    ? 'https://all-options-dev.tail57521e.ts.net/api/wc-match'
+    : null;
+
+  async function _fetchMatchDetail(eventId) {
+    if (!eventId || !VPS_WC_MATCH_URL) return null;
+    const cached = _matchDetailCache.get(eventId);
+    if (cached && Date.now() - cached.fetchedAt < MATCH_DETAIL_TTL_MS) return cached.payload;
+    try {
+      const res = await fetch(VPS_WC_MATCH_URL + '?eventId=' + encodeURIComponent(eventId), { cache: 'no-store' });
+      if (!res.ok) throw new Error('HTTP ' + res.status);
+      const payload = await res.json();
+      _matchDetailCache.set(eventId, { fetchedAt: Date.now(), payload });
+      return payload;
+    } catch (e) {
+      console.warn('match detail fetch failed for', eventId, e.message);
+      return null;
+    }
+  }
+
+  // Kick a lazy fetch and re-render the modal in place when it lands.
+  // Modal might have been closed or stepped to a different match in
+  // the meantime — guard by checking the rendered match id.
+  function _hydrateMatchDetail(m) {
+    const eventId = m && m.result && m.result.eventId;
+    if (!eventId) return;
+    _fetchMatchDetail(eventId).then(detail => {
+      if (!detail) return;
+      // Overlay onto local result so the static scorer renderer picks
+      // it up — and so it sticks through subsequent navigations.
+      if (detail.scorers) {
+        if (Array.isArray(detail.scorers.home)) m.result.goals1 = detail.scorers.home;
+        if (Array.isArray(detail.scorers.away)) m.result.goals2 = detail.scorers.away;
+      }
+      if (detail.cards) {
+        m.result.cards1 = Array.isArray(detail.cards.home) ? detail.cards.home : [];
+        m.result.cards2 = Array.isArray(detail.cards.away) ? detail.cards.away : [];
+      }
+      save();
+      const inner = document.querySelector('#match-modal.open .modal-inner');
+      if (!inner) return;
+      const openId = inner.getAttribute('data-match-id');
+      if (openId !== m.id) return;
+      // In-place re-render without re-opening the modal so the user's
+      // scroll position is preserved as much as possible.
+      editResult(m.id);
+    });
+  }
+
+  // Render yellow/red cards under the scorers, same two-column shape.
+  function _renderMatchCards(m) {
+    const c1 = (m && m.result && Array.isArray(m.result.cards1)) ? m.result.cards1.slice() : [];
+    const c2 = (m && m.result && Array.isArray(m.result.cards2)) ? m.result.cards2.slice() : [];
+    if (c1.length === 0 && c2.length === 0) return '';
+    const sortByMin = (a, b) => (a.minute || 999) - (b.minute || 999);
+    c1.sort(sortByMin); c2.sort(sortByMin);
+    function cardIcon(color) {
+      if (color === 'red') return '<span class="card-icon red" title="Red card"></span>';
+      if (color === 'second-yellow') return '<span class="card-icon yellow"></span><span class="card-icon red" style="margin-left:-3px;"></span>';
+      return '<span class="card-icon yellow" title="Yellow card"></span>';
+    }
+    function renderList(cards) {
+      if (cards.length === 0) return '<span class="muted" style="font-size:0.78rem;">—</span>';
+      return cards.map(c => {
+        const min = typeof c.minute === 'number' ? `<span class="muted">${c.minute}'</span>` : '';
+        return `<div class="scorer">${cardIcon(c.color)} ${escapeHTML(c.name)} ${min}</div>`;
+      }).join('');
+    }
+    return `
+      <div class="scorers-grid" style="margin-top:0;">
+        <div class="scorers-col home">${renderList(c1)}</div>
+        <div class="scorers-icon" style="font-size:0.85rem;">🟨🟥</div>
+        <div class="scorers-col away">${renderList(c2)}</div>
+      </div>`;
+  }
+
   // Render the goal scorers attached to a match's result. Two columns:
   // home on the left, away on the right. Returns '' when neither side
   // has scorer data (manual entry, or remote feed didn't include it),
@@ -5028,6 +5113,7 @@
       </div>
 
       ${_renderMatchScorers(m)}
+      ${_renderMatchCards(m)}
 
       ${m.stage !== 'group' ? `
         <div class="pick-row"><div class="lbl">PK winner<br><span style="font-size:0.7rem;">(only if draw)</span></div><div>
@@ -5046,7 +5132,12 @@
 
       ${_renderMatchPoolPicks(m)}
     `;
+    modal.querySelector('.modal-inner').setAttribute('data-match-id', m.id);
     modal.classList.add('open');
+    // Fire-and-forget summary fetch — if the cached scoreboard entry
+    // already had goals1/goals2 from a recent sync we still upgrade
+    // to the richer summary view (cards become available).
+    _hydrateMatchDetail(m);
   }
 
   function saveResult(matchId) {
@@ -5956,6 +6047,11 @@
           const g2 = cleanGoals(rm.goals2);
           if (g1 !== null) local.result.goals1 = g1;
           if (g2 !== null) local.result.goals2 = g2;
+          // Persist ESPN's event id so the modal can lazy-fetch the
+          // full per-match summary (cards, lineups, stats) on open
+          // even for older matches whose scoreboard details have
+          // been archived.
+          if (rm.eventId) local.result.eventId = rm.eventId;
         }
       }
 

--- a/vps/server.js
+++ b/vps/server.js
@@ -8,6 +8,7 @@ const media = require('./media');
 const diag = require('./diag');
 const ical = require('./ical');
 const wcScores = require('./wc-scores');
+const wcMatch = require('./wc-match');
 
 const app = express();
 const PORT = 3333;
@@ -29,6 +30,9 @@ ical.init(app);
 
 // Register World Cup scores proxy (ESPN scoreboard JSON, CORS-safe live scores)
 wcScores.init(app);
+
+// Register per-match detail proxy (ESPN summary JSON — full scorers + cards)
+wcMatch.init(app);
 
 app.get('/api/kids', (req, res) => {
   try {

--- a/vps/wc-match.js
+++ b/vps/wc-match.js
@@ -1,0 +1,181 @@
+/* ================================================================
+   ZS-SYNC — Per-match summary proxy (ESPN summary?event=)
+
+   The scoreboard endpoint (wc-scores.js) is fast and lightweight but
+   stops carrying play-by-play after a few days — older matches lose
+   their `competitions[0].details` scoring entries entirely. The
+   summary?event=ID endpoint keeps full per-match detail for every
+   game throughout the tournament, including:
+     - goal scorers (name, minute, own-goal flag)
+     - yellow / red cards (player, team, minute)
+     - basic stats (when present in summary.boxscore.teams.statistics)
+
+   This proxy is fetched ON DEMAND when the user opens the match
+   modal, so the per-minute auto-poll (wc-scores.js) doesn't pay
+   the extra round trip during live polling.
+
+   Mounted at GET /api/wc-match?eventId=NNN
+
+   Cache: 5 minutes per event id. The match modal opens infrequently
+   enough that a short TTL is fine, and live matches still get
+   refreshed roughly per-modal-open.
+   ================================================================ */
+
+'use strict';
+
+const https = require('https');
+
+const ESPN_SUMMARY = 'https://site.api.espn.com/apis/site/v2/sports/soccer/fifa.world/summary';
+const TTL_MS = 5 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 15 * 1000;
+const MAX_BYTES = 4 * 1024 * 1024;
+
+const _cache = new Map(); // eventId -> { fetchedAt, payload }
+
+function _fetchUpstream(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, {
+      headers: { 'User-Agent': 'ZavalaSerra-WC-Match/1.0', 'Accept': 'application/json' },
+    }, (res) => {
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        res.resume();
+        return reject(new Error('upstream HTTP ' + res.statusCode));
+      }
+      let size = 0;
+      const chunks = [];
+      res.on('data', (c) => {
+        size += c.length;
+        if (size > MAX_BYTES) { req.destroy(new Error('response too large')); return; }
+        chunks.push(c);
+      });
+      res.on('end', () => {
+        try { resolve(JSON.parse(Buffer.concat(chunks).toString('utf8'))); }
+        catch (e) { reject(e); }
+      });
+    });
+    req.setTimeout(FETCH_TIMEOUT_MS, () => req.destroy(new Error('upstream timeout')));
+    req.on('error', reject);
+  });
+}
+
+// Pull a minute integer out of "23'", "45+2", "90+5'" etc.
+function _minute(clock) {
+  if (!clock) return null;
+  const s = (clock.displayValue || clock.value || '').toString();
+  const m = s.match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+// Walk the summary's plays / scoringPlays / keyEvents block, return
+// { homeTeamId, awayTeamId, goals: [{teamId, name, minute, owngoal?, penalty?}],
+//   cards: [{teamId, name, minute, color}] }.
+function _extract(summary) {
+  const out = { homeTeamId: null, awayTeamId: null, goals: [], cards: [] };
+  const header = summary && summary.header;
+  const competition = header && Array.isArray(header.competitions) ? header.competitions[0] : null;
+  if (!competition || !Array.isArray(competition.competitors)) return out;
+  const home = competition.competitors.find(c => c.homeAway === 'home');
+  const away = competition.competitors.find(c => c.homeAway === 'away');
+  out.homeTeamId = home && home.team ? String(home.team.id) : null;
+  out.awayTeamId = away && away.team ? String(away.team.id) : null;
+
+  // ESPN exposes per-match events under a few field names depending on
+  // the sport/season — accept them all and de-duplicate by (id, minute, type).
+  const sources = []
+    .concat(Array.isArray(summary.keyEvents)        ? summary.keyEvents        : [])
+    .concat(Array.isArray(summary.scoringPlays)     ? summary.scoringPlays     : [])
+    .concat(Array.isArray(summary.plays)            ? summary.plays            : [])
+    .concat(competition && Array.isArray(competition.details) ? competition.details : []);
+
+  const seenGoals = new Set();
+  const seenCards = new Set();
+
+  for (const ev of sources) {
+    if (!ev || !ev.type) continue;
+    const ath = (ev.athletesInvolved || ev.athlete || [])[0] || ev.athlete || null;
+    const name = ath && (ath.displayName || ath.fullName || ath.name) ? (ath.displayName || ath.fullName || ath.name) : null;
+    if (!name) continue;
+    const teamId = ev.team && ev.team.id ? String(ev.team.id) : null;
+    const minute = _minute(ev.clock);
+    const text = (ev.type.text || ev.type.name || '').toLowerCase();
+    const tid  = (ev.type.id || '').toString();
+
+    const isGoal = /goal/.test(text) && !/disallowed|missed/.test(text);
+    const isOwn  = /own goal/.test(text) || ev.scoreValue === -1;
+    const isPen  = /penalty/.test(text);
+    const isYC   = /yellow card/.test(text);
+    const isRC   = /red card/.test(text);
+    const isSY   = /second yellow/.test(text);
+
+    if (isGoal) {
+      const key = name + '|' + (minute || '') + '|' + (teamId || '') + '|G';
+      if (seenGoals.has(key)) continue;
+      seenGoals.add(key);
+      const g = { teamId, name, minute };
+      if (isOwn) g.owngoal = true;
+      if (isPen) g.penalty = true;
+      out.goals.push(g);
+    } else if (isYC || isRC || isSY) {
+      const color = isRC ? 'red' : (isSY ? 'second-yellow' : 'yellow');
+      const key = name + '|' + (minute || '') + '|' + (teamId || '') + '|' + color;
+      if (seenCards.has(key)) continue;
+      seenCards.add(key);
+      out.cards.push({ teamId, name, minute, color });
+    }
+  }
+
+  // Sort by minute (unknown minutes float to the bottom).
+  const byMin = (a, b) => (a.minute || 999) - (b.minute || 999);
+  out.goals.sort(byMin);
+  out.cards.sort(byMin);
+  return out;
+}
+
+// Split into home / away arrays once we know the team ids.
+function _normalize(extracted) {
+  const { homeTeamId, awayTeamId, goals, cards } = extracted;
+  const splitByTeam = list => ({
+    home: list.filter(x => x.teamId === homeTeamId).map(({ teamId, ...rest }) => rest),
+    away: list.filter(x => x.teamId === awayTeamId).map(({ teamId, ...rest }) => rest),
+  });
+  return {
+    scorers: splitByTeam(goals),
+    cards: splitByTeam(cards),
+  };
+}
+
+function init(app) {
+  app.get('/api/wc-match', async (req, res) => {
+    const eventId = (req.query.eventId || '').toString().trim();
+    if (!/^\d+$/.test(eventId)) {
+      return res.status(400).json({ error: 'eventId required (digits only)' });
+    }
+    const cached = _cache.get(eventId);
+    if (cached && Date.now() - cached.fetchedAt < TTL_MS) {
+      res.set('Cache-Control', 'no-store');
+      return res.json(cached.payload);
+    }
+    try {
+      const data = await _fetchUpstream(ESPN_SUMMARY + '?event=' + encodeURIComponent(eventId));
+      const extracted = _extract(data);
+      const payload = {
+        eventId,
+        fetchedAt: new Date().toISOString(),
+        ..._normalize(extracted),
+      };
+      _cache.set(eventId, { fetchedAt: Date.now(), payload });
+      res.set('Cache-Control', 'no-store');
+      res.json(payload);
+    } catch (e) {
+      console.warn('[wc-match]', eventId, 'fetch failed:', e.message);
+      // Serve stale cache if we have one — better than nothing.
+      if (cached) {
+        res.set('Cache-Control', 'no-store');
+        return res.json(cached.payload);
+      }
+      res.status(502).json({ error: e.message || 'upstream error' });
+    }
+  });
+}
+
+module.exports = { init };

--- a/vps/wc-scores.js
+++ b/vps/wc-scores.js
@@ -96,6 +96,7 @@ function _normalizeEvent(ev) {
 
   const out = {
     date,
+    eventId: ev.id ? String(ev.id) : null,
     team1: home.team.displayName || home.team.name,
     team1_abbr: home.team.abbreviation || null,
     team2: away.team.displayName || away.team.name,

--- a/world-cup.html
+++ b/world-cup.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/world-cup.css?v=20">
+  <link rel="stylesheet" href="css/world-cup.css?v=21">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -73,6 +73,6 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=28"></script>
+  <script src="js/world-cup.js?v=29"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Tier-2 match detail. ESPN's scoreboard endpoint stops carrying `competitions[0].details` after ~2 days, so older matches sync the score but not who scored — every Matchday 1 game showed empty scorer lists this week (Korea–Czechia, USA–Paraguay, Haiti–Scotland, Australia–Türkiye, Sweden–Tunisia, Iran–New Zealand). The `summary?event=ID` endpoint keeps full per-match detail for every match throughout the tournament: scorers, yellow/red cards, all minute-tagged.

### VPS side (new)
- **`vps/wc-match.js`** — `GET /api/wc-match?eventId=NNN`. Proxies ESPN summary, walks `keyEvents` / `scoringPlays` / `plays` / `competition.details` (ESPN's field varies by season), extracts goals + cards, dedupes by `(name, minute, team, type)`, splits into home/away. 5-min in-memory cache per event id; stale-cache fallback on upstream failure.
- **`vps/wc-scores.js`** — now also emits `eventId` on each match so the client can look up the summary.

### Client side
- `syncScores` persists `rm.eventId` onto `local.result.eventId`.
- `_fetchMatchDetail` / `_hydrateMatchDetail` — lazy fetch on `editResult` open, in-memory cache (5-min TTL). Overlays scorers + cards onto `m.result` and persists via `save()`. Re-renders modal in place only if the user hasn't navigated away (guards via `data-match-id` on `.modal-inner`).
- `_renderMatchCards` — yellow/red glyphs (8×11 rounded rects, `#FBBF24` / `--wc-red`) + player + minute, same two-column shape as scorers. Second-yellow renders as yellow + red stacked.
- Modal hydrates from cache instantly on repeat opens; first open of an older match flashes scorers in once the summary fetch returns.

Cache busts: `world-cup.js` v28→29, `world-cup.css` v20→21.
VPS auto-deploys via `.github/workflows/deploy-vps.yml` (`paths: vps/**`).

### Verified
VPS modules syntax-check, `_extract` + `_normalize` roundtrip on sample summary data (goal / yellow / red / own-goal all categorized correctly), card icon HTML renders with second-yellow stacking.

## Test plan
- [ ] After deploy, `curl https://all-options-dev.tail57521e.ts.net/api/wc-match?eventId=XXXXX` returns `{ scorers: {home, away}, cards: {home, away} }`.
- [ ] Open a Matchday 1 game (e.g. South Korea vs Czech Republic) → after ~1s, scorer names + minutes appear, and yellow/red cards if any.
- [ ] Open a current-day game → same; cards beat the scoreboard for accuracy.
- [ ] Re-open the same modal → renders instantly from cache (no flash).
- [ ] Navigate via prev/next arrows — each new match fires its own lazy fetch; the open prior one doesn't get stomped.
- [ ] Manual-entered result with no `eventId` → no fetch fired, no errors.
- [ ] Guest device off Tailscale (no CloudSync) → no fetch attempted, scorers fall back to whatever was synced via the scoreboard.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_