### PR TITLE
Light redesign: roll the 2026 light theme across all sub-apps

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/art-studio.css">
   <link rel="stylesheet" href="css/copy-the-master.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/bible-explorer.html
+++ b/bible-explorer.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/bible-explorer.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#818CF8">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/book-movie-check.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/chess-quest.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/civics-lab.html
+++ b/civics-lab.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/civics-lab.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#FBBF24">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/code-cadet.html
+++ b/code-cadet.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/code-cadet.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#22D3EE">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/css/art-studio.css
+++ b/css/art-studio.css
@@ -66,7 +66,7 @@ body {
 /* Toolbar */
 .toolbar {
   background: var(--bg-surface);
-  border-top: 2px solid rgba(255,255,255,0.08);
+  border-top: 2px solid #e6e6ee;
   padding: 12px;
   display: flex;
   gap: 16px;
@@ -81,7 +81,7 @@ body {
   gap: 8px;
   align-items: center;
   padding: 0 8px;
-  border-right: 1.5px solid rgba(255,255,255,0.05);
+  border-right: 1.5px solid #e6e6ee;
 }
 .tool-section:last-child { border-right: none; }
 
@@ -103,14 +103,14 @@ body {
   transition: transform 0.2s;
 }
 .color-swatch:hover { transform: scale(1.15); }
-.color-swatch.active { border-color: #fff; box-shadow: 0 0 10px rgba(255,255,255,0.5); transform: scale(1.15); }
+.color-swatch.active { border-color: #1c1b29; box-shadow: 0 0 0 2px #d6d2ea; transform: scale(1.15); }
 
 /* Brush Sizes */
 .brush-size {
   width: 36px;
   height: 36px;
-  background: rgba(255,255,255,0.05);
-  border: 2px solid transparent;
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
   border-radius: 8px;
   cursor: pointer;
   position: relative;
@@ -120,7 +120,7 @@ body {
   content: '';
   width: var(--size);
   height: var(--size);
-  background: #fff;
+  background: #1c1b29;
   border-radius: 50%;
 }
 .brush-size.active { border-color: var(--art-accent); background: rgba(244, 114, 182, 0.1); }
@@ -129,15 +129,15 @@ body {
 .tool-btn, .action-btn {
   width: 44px;
   height: 44px;
-  background: rgba(255,255,255,0.05);
-  border: 2px solid transparent;
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
   border-radius: 10px;
   font-size: 1.2rem;
   cursor: pointer;
   display: flex; align-items: center; justify-content: center;
   transition: all 0.2s;
 }
-.tool-btn:hover, .action-btn:hover { background: rgba(255,255,255,0.1); }
+.tool-btn:hover, .action-btn:hover { background: #ece9f5; }
 .tool-btn.active { border-color: var(--art-accent); background: rgba(244, 114, 182, 0.15); }
 .action-btn.primary { background: var(--art-accent); color: #000; }
 
@@ -154,8 +154,8 @@ body {
   border: 2px solid var(--art-accent);
 }
 .modal-card input {
-  width: 100%; padding: 12px; border-radius: 12px; background: rgba(0,0,0,0.2);
-  border: 2px solid rgba(255,255,255,0.1); color: #fff; margin: 20px 0;
+  width: 100%; padding: 12px; border-radius: 12px; background: #ece9f5;
+  border: 2px solid #e6e6ee; color: #1c1b29; margin: 20px 0;
   font-family: var(--font-body); font-size: 1rem;
 }
 .modal-btns { display: flex; gap: 12px; }
@@ -175,7 +175,7 @@ body {
 }
 .gallery-card {
   background: var(--bg-surface); border-radius: 16px; overflow: hidden;
-  border: 2px solid rgba(255,255,255,0.06); cursor: pointer;
+  border: 2px solid #e6e6ee; cursor: pointer;
   transition: transform 0.2s;
 }
 .gallery-card:hover { transform: translateY(-4px); border-color: var(--art-accent); }
@@ -208,7 +208,7 @@ body {
   padding: 20px;
 }
 .lesson-card {
-  background: var(--bg-surface); border: 2px solid rgba(255,255,255,0.06);
+  background: var(--bg-surface); border: 2px solid #e6e6ee;
   border-radius: 20px; padding: 24px; cursor: pointer; transition: all 0.2s;
   display: flex; flex-direction: column; align-items: center; text-align: center; gap: 12px;
 }
@@ -270,8 +270,8 @@ body {
 .mixing-area { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 40px; padding: 20px; }
 .mixing-pots { display: flex; align-items: center; gap: 20px; }
 .mix-pot {
-  width: 80px; height: 80px; border-radius: 50%; border: 4px solid rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.05); display: flex; align-items: center; justify-content: center;
+  width: 80px; height: 80px; border-radius: 50%; border: 4px solid #e6e6ee;
+  background: #ece9f5; display: flex; align-items: center; justify-content: center;
   font-size: 2rem; font-weight: 800; cursor: pointer; transition: all 0.2s;
 }
 .mix-pot.empty { color: var(--text-muted); border-style: dashed; }

--- a/css/bible-explorer.css
+++ b/css/bible-explorer.css
@@ -4,9 +4,9 @@
    ============================================================ */
 
 :root {
-  --bx-accent: #818CF8;       /* indigo-400 */
+  --bx-accent: #4338CA;       /* indigo-700 (deep for text on light) */
   --bx-accent-deep: #4338CA;  /* indigo-700 */
-  --bx-gold: #FBBF24;
+  --bx-gold: #B45309;
   --bx-gold-deep: #B45309;
 }
 
@@ -168,8 +168,8 @@
 .bx-story-detail-tag {
   display: inline-block;
   margin-top: 6px;
-  background: rgba(129,140,248,0.18);
-  color: var(--bx-accent);
+  background: #4338CA;
+  color: #fff;
   border-radius: 999px;
   padding: 4px 12px;
   font-size: 0.8rem;
@@ -249,12 +249,14 @@
 }
 .bx-quiz-opt:hover { transform: translateY(-2px); border-color: var(--bx-accent); }
 .bx-quiz-opt.bx-correct {
-  background: rgba(52,211,153,0.25);
+  background: #059669;
   border-color: var(--green);
+  color: #fff;
 }
 .bx-quiz-opt.bx-wrong {
-  background: rgba(248,113,113,0.25);
+  background: #B91C1C;
   border-color: var(--red);
+  color: #fff;
 }
 .bx-quiz-result {
   text-align: center;
@@ -317,7 +319,7 @@
 .bx-blank {
   border: none;
   border-bottom: 2px solid var(--bx-accent);
-  background: rgba(129,140,248,0.10);
+  background: #ece9f5;
   color: var(--text);
   font-family: var(--font-body);
   font-weight: 700;
@@ -330,15 +332,18 @@
 .bx-blank:focus { outline: 2px solid var(--bx-accent); }
 .bx-blank-correct {
   border-bottom-color: var(--green);
-  background: rgba(52,211,153,0.25);
+  background: #059669;
+  color: #fff;
 }
 .bx-blank-wrong {
   border-bottom-color: var(--red);
-  background: rgba(248,113,113,0.25);
+  background: #B91C1C;
+  color: #fff;
 }
 .bx-blank-hint {
   border-bottom-color: var(--bx-gold);
-  background: rgba(251,191,36,0.25);
+  background: #B45309;
+  color: #fff;
 }
 .bx-verse-actions {
   margin-top: 16px;
@@ -387,8 +392,8 @@
 .bx-book-card:hover { transform: translateY(-2px); border-color: var(--bx-accent); }
 .bx-book-card.bx-done { border-color: var(--bx-gold); }
 .bx-book-tag {
-  background: rgba(129,140,248,0.20);
-  color: var(--bx-accent);
+  background: #4338CA;
+  color: #fff;
   font-size: 0.7rem;
   font-weight: 800;
   letter-spacing: 0.06em;

--- a/css/book-movie-check.css
+++ b/css/book-movie-check.css
@@ -3,13 +3,13 @@
    ================================================================ */
 
 :root {
-  --bmc-accent: #60A5FA;
-  --bmc-glow: rgba(96, 165, 250, 0.3);
-  --bmc-approved: #10B981;
-  --bmc-caution: #F59E0B;
-  --bmc-notrec: #EF4444;
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --bmc-accent: #2563EB;
+  --bmc-glow: rgba(37, 99, 235, 0.25);
+  --bmc-approved: #059669;
+  --bmc-caution: #B45309;
+  --bmc-notrec: #B91C1C;
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -80,7 +80,7 @@ body {
   margin-bottom: 12px;
   transition: all 0.2s;
 }
-.back-btn:hover { background: rgba(255,255,255,0.08); }
+.back-btn:hover { background: #ece9f5; }
 
 /* Search card */
 .bmc-search-card {
@@ -105,7 +105,7 @@ body {
 .bmc-search-row input {
   flex: 1;
   padding: 12px 14px;
-  background: rgba(0,0,0,0.25);
+  background: #ece9f5;
   border: 1.5px solid var(--border-subtle);
   border-radius: 12px;
   color: var(--text-primary);
@@ -136,7 +136,7 @@ body {
   transition: all 0.2s;
 }
 .bmc-btn-primary {
-  background: linear-gradient(135deg, #2563EB, var(--bmc-accent));
+  background: linear-gradient(135deg, #4338CA, #6366F1);
   color: #fff;
   box-shadow: 0 4px 14px var(--bmc-glow);
 }
@@ -148,7 +148,7 @@ body {
   flex: 1;
   min-width: 140px;
 }
-.bmc-btn-secondary:hover { background: rgba(255,255,255,0.08); }
+.bmc-btn-secondary:hover { background: #ece9f5; }
 .bmc-btn-ghost {
   background: transparent;
   border: 1.5px solid var(--border-subtle);
@@ -185,9 +185,9 @@ body {
   transition: all 0.2s;
 }
 .bmc-tab-btn.active {
-  color: var(--text-primary);
+  color: #fff;
   border-color: var(--bmc-accent);
-  background: rgba(96,165,250,0.12);
+  background: var(--bmc-accent);
 }
 
 /* Section headers (non-home screens) */
@@ -215,11 +215,11 @@ body {
   cursor: pointer;
   transition: all 0.2s;
 }
-.bmc-filter-chip:hover { background: rgba(255,255,255,0.06); color: var(--text-primary); }
+.bmc-filter-chip:hover { background: #ece9f5; color: var(--text-primary); }
 .bmc-filter-chip.active {
-  color: var(--text-primary);
+  color: #fff;
   border-color: var(--bmc-accent);
-  background: rgba(96,165,250,0.12);
+  background: var(--bmc-accent);
 }
 
 /* Lists — shared */
@@ -274,9 +274,9 @@ body {
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  border: 1.5px solid rgba(239,68,68,0.45);
-  background: rgba(11,11,26,0.85);
-  color: #F87171;
+  border: 1.5px solid rgba(185,28,28,0.45);
+  background: #ffffff;
+  color: #B91C1C;
   font-size: 0.85rem;
   font-weight: 800;
   line-height: 1;
@@ -290,7 +290,7 @@ body {
   z-index: 2;
 }
 .bmc-list-remove:hover {
-  background: rgba(239,68,68,0.2);
+  background: #B91C1C;
   color: #fff;
   transform: scale(1.08);
 }
@@ -302,7 +302,7 @@ body {
 .bmc-list-cover {
   width: 46px; height: 64px;
   border-radius: 6px;
-  background: rgba(255,255,255,0.05);
+  background: #ece9f5;
   flex-shrink: 0;
   background-size: cover;
   background-position: center;
@@ -332,10 +332,10 @@ body {
   align-self: center;
   flex-shrink: 0;
 }
-.bmc-list-verdict.verdict-approved { background: rgba(16,185,129,0.15); color: var(--bmc-approved); }
-.bmc-list-verdict.verdict-caution { background: rgba(245,158,11,0.15); color: var(--bmc-caution); }
-.bmc-list-verdict.verdict-not_recommended { background: rgba(239,68,68,0.15); color: var(--bmc-notrec); }
-.bmc-list-verdict.verdict-lowconf { background: rgba(96,165,250,0.15); color: var(--bmc-accent); }
+.bmc-list-verdict.verdict-approved { background: var(--bmc-approved); color: #fff; }
+.bmc-list-verdict.verdict-caution { background: var(--bmc-caution); color: #fff; }
+.bmc-list-verdict.verdict-not_recommended { background: var(--bmc-notrec); color: #fff; }
+.bmc-list-verdict.verdict-lowconf { background: var(--bmc-accent); color: #fff; }
 
 .bmc-empty {
   text-align: center;
@@ -359,7 +359,7 @@ body {
   width: 88px; height: 130px;
   border-radius: 8px;
   background-size: cover; background-position: center;
-  background-color: rgba(255,255,255,0.05);
+  background-color: #ece9f5;
   flex-shrink: 0;
   font-size: 3rem;
   display: flex; align-items: center; justify-content: center;
@@ -385,17 +385,17 @@ body {
   font-size: 0.85rem;
   font-weight: 800;
   letter-spacing: 0.3px;
-  background: rgba(96,165,250,0.18);
-  color: var(--bmc-accent);
-  border: 1.5px solid rgba(96,165,250,0.35);
+  background: var(--bmc-accent);
+  color: #fff;
+  border: 1.5px solid var(--bmc-accent);
   padding: 5px 12px;
   border-radius: 99px;
 }
 .bmc-result-type-movie,
 .bmc-result-type-series {
-  background: rgba(244,114,182,0.18);
-  color: #f472b6;
-  border-color: rgba(244,114,182,0.35);
+  background: #BE185D;
+  color: #fff;
+  border-color: #BE185D;
 }
 
 /* Verdict banner */
@@ -452,7 +452,7 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  background: rgba(255,255,255,0.05);
+  background: #ece9f5;
   border: 1.5px solid var(--border-subtle);
   border-radius: 99px;
   padding: 6px 14px;
@@ -497,24 +497,24 @@ body {
   border: 1.5px solid;
 }
 .bmc-chip-mild {
-  background: rgba(251,191,36,0.08);
-  border-color: rgba(251,191,36,0.35);
-  color: #FCD34D;
+  background: #B45309;
+  border-color: #B45309;
+  color: #fff;
 }
 .bmc-chip-moderate {
-  background: rgba(249,115,22,0.1);
-  border-color: rgba(249,115,22,0.4);
-  color: #FB923C;
+  background: #C2410C;
+  border-color: #C2410C;
+  color: #fff;
 }
 .bmc-chip-significant {
-  background: rgba(239,68,68,0.12);
-  border-color: rgba(239,68,68,0.45);
-  color: #F87171;
+  background: #B91C1C;
+  border-color: #B91C1C;
+  color: #fff;
 }
 .bmc-chip-positive {
-  background: rgba(16,185,129,0.1);
-  border-color: rgba(16,185,129,0.35);
-  color: #34D399;
+  background: #059669;
+  border-color: #059669;
+  color: #fff;
 }
 
 .bmc-card {
@@ -563,9 +563,9 @@ body {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  background: rgba(16,185,129,0.12);
-  border: 1.5px solid rgba(16,185,129,0.35);
-  color: var(--bmc-approved);
+  background: var(--bmc-approved);
+  border: 1.5px solid var(--bmc-approved);
+  color: #fff;
   border-radius: 99px;
   padding: 4px 10px;
   font-size: 0.72rem;
@@ -595,7 +595,7 @@ body {
 }
 .bmc-candidate:hover {
   border-color: var(--bmc-accent);
-  background: rgba(96,165,250,0.06);
+  background: #ece9f5;
 }
 .bmc-candidate strong, .bmc-candidate > div > div:first-child {
   color: var(--text-primary);
@@ -696,7 +696,7 @@ body {
   width: 32px; height: 32px;
   border-radius: 8px;
 }
-.bmc-modal-close:hover { background: rgba(255,255,255,0.08); }
+.bmc-modal-close:hover { background: #ece9f5; }
 .bmc-modal-panel video {
   width: 100%;
   border-radius: 12px;

--- a/css/chess-quest.css
+++ b/css/chess-quest.css
@@ -50,7 +50,7 @@
     .mode-header{text-align:center;margin:60px 0 28px;animation:fadeUp 0.6s ease-out both}
     .mode-header .icon{font-size:56px;display:block;margin-bottom:4px;animation:pieceBounce 3s ease-in-out infinite}
     @keyframes pieceBounce{0%,100%{transform:translateY(0) rotate(-3deg)}50%{transform:translateY(-10px) rotate(3deg)}}
-    .mode-header h1{font-family:var(--font-display);font-size:clamp(2rem,6vw,2.8rem);font-weight:800;background:linear-gradient(135deg,var(--gold),var(--cream),var(--brown-light));background-size:200% 200%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;animation:gradShift 5s ease-in-out infinite}
+    .mode-header h1{font-family:var(--font-display);font-size:clamp(2rem,6vw,2.8rem);font-weight:800;background:none;background-size:200% 200%;-webkit-background-clip:border-box;-webkit-text-fill-color:#312e81;background-clip:border-box;color:#312e81;animation:gradShift 5s ease-in-out infinite}
     @keyframes gradShift{0%,100%{background-position:0% 50%}50%{background-position:100% 50%}}
     .mode-header p{color:var(--text-muted);font-weight:600;margin-top:6px;font-size:1rem}
     .mode-header .greeting{color:var(--gold);font-weight:700;font-size:0.9rem}
@@ -65,8 +65,8 @@
     .mode-card .m-title{font-family:var(--font-display);font-size:1.2rem;font-weight:700;color:var(--gold)}
     .mode-card .m-desc{font-size:0.85rem;color:var(--text-muted);font-weight:600;margin-top:2px}
     .mode-card .m-badge{margin-top:6px;display:inline-block;padding:2px 10px;border-radius:99px;font-size:0.7rem;font-weight:700}
-    .m-badge.rec{background:rgba(52,211,153,0.12);color:var(--green)}
-    .m-badge.prog{background:rgba(251,191,36,0.12);color:var(--gold)}
+    .m-badge.rec{background:#059669;color:#fff}
+    .m-badge.prog{background:#B45309;color:#fff}
     /* ================================================================ CHESSBOARD ================================================================ */
     .board-wrap{width:100%;max-width:400px;margin:0 auto}
     .board{width:100%;aspect-ratio:1;display:grid;grid-template-columns:repeat(8,1fr);grid-template-rows:repeat(8,1fr);border-radius:8px;overflow:hidden;box-shadow:0 8px 40px rgba(0,0,0,0.5);border:3px solid var(--brown-dark)}
@@ -89,14 +89,14 @@
     .piece-card{background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius-sm);padding:20px 12px;text-align:center;cursor:pointer;transition:all 0.3s ease;animation:fadeUp 0.4s ease-out both}
     .piece-card:hover{transform:translateY(-3px);border-color:var(--gold);box-shadow:0 8px 24px -8px var(--gold-glow)}
     .piece-card .p-icon{font-size:40px;display:block;margin-bottom:6px}
-    .piece-card .p-name{font-family:var(--font-display);font-size:0.95rem;font-weight:700;color:var(--cream)}
+    .piece-card .p-name{font-family:var(--font-display);font-size:0.95rem;font-weight:700;color:var(--text)}
     .piece-card .p-val{font-size:0.72rem;color:var(--text-muted);font-weight:600}
     .piece-card.completed{border-color:var(--green)}
     .piece-card.completed .p-name::after{content:' ✓';color:var(--green)}
     .lesson-info{background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius);padding:20px;margin:16px 0;line-height:1.7;width:100%}
     .lesson-info h3{font-family:var(--font-display);font-size:1.1rem;font-weight:700;margin-bottom:6px;color:var(--gold)}
     .lesson-info p{color:var(--text-muted);font-size:0.9rem;font-weight:600}
-    .lesson-info .tip{margin-top:10px;padding:8px 12px;border-radius:var(--radius-sm);background:rgba(251,191,36,0.06);border-left:3px solid var(--gold);font-size:0.82rem;color:var(--amber)}
+    .lesson-info .tip{margin-top:10px;padding:8px 12px;border-radius:var(--radius-sm);background:rgba(251,191,36,0.12);border-left:3px solid var(--gold);font-size:0.82rem;color:#B45309}
     .lesson-nav{display:flex;gap:10px;margin-top:16px;width:100%}
     .lesson-nav button{flex:1;padding:14px;border-radius:var(--radius-sm);border:none;font-family:var(--font-display);font-size:1rem;font-weight:700;cursor:pointer;transition:all 0.25s ease}
     .btn-gold{background:linear-gradient(135deg,var(--amber),var(--gold));color:#1A1410;box-shadow:0 4px 16px var(--gold-glow)}
@@ -105,12 +105,12 @@
     .btn-outline:hover{border-color:var(--gold)!important;color:var(--text)}
     /* ================================================================ PUZZLE MODE ================================================================ */
     .puzzle-top{width:100%;display:flex;align-items:center;justify-content:space-between;margin:16px 0 12px}
-    .puzzle-badge{font-family:var(--font-display);font-size:0.9rem;font-weight:700;padding:6px 14px;border-radius:99px;background:rgba(251,191,36,0.12);color:var(--gold)}
-    .puzzle-hint{background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius);padding:16px;text-align:center;margin:12px 0;width:100%;font-weight:700;color:var(--cream)}
+    .puzzle-badge{font-family:var(--font-display);font-size:0.9rem;font-weight:700;padding:6px 14px;border-radius:99px;background:#B45309;color:#fff}
+    .puzzle-hint{background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius);padding:16px;text-align:center;margin:12px 0;width:100%;font-weight:700;color:var(--text)}
     .puzzle-feedback{font-family:var(--font-display);font-size:1.1rem;font-weight:700;text-align:center;min-height:32px;margin:8px 0}
     /* ================================================================ PLAY MODE ================================================================ */
     .play-top{width:100%;display:flex;align-items:center;justify-content:space-between;margin:16px 0 12px}
-    .play-status{font-family:var(--font-display);font-size:0.95rem;font-weight:700;padding:8px 16px;border-radius:99px;background:var(--bg-card);border:1.5px solid var(--border-subtle);color:var(--cream)}
+    .play-status{font-family:var(--font-display);font-size:0.95rem;font-weight:700;padding:8px 16px;border-radius:99px;background:var(--bg-card);border:1.5px solid var(--border-subtle);color:var(--text)}
     .play-info{width:100%;display:flex;justify-content:space-between;padding:8px 0;font-size:0.82rem;color:var(--text-muted);font-weight:600}
     .captured-row{display:flex;gap:2px;font-size:18px;min-height:24px;flex-wrap:wrap}
     .game-over-box{background:var(--bg-card);border:1.5px solid var(--gold);border-radius:var(--radius);padding:28px;text-align:center;width:100%;margin:16px 0;animation:popIn 0.4s ease-out}
@@ -129,7 +129,7 @@
     .rush-intro h2 { font-family: var(--font-display); font-size: 1.7rem; font-weight: 800; margin: 8px 0 4px; }
     .rush-intro p { color: var(--text-muted); font-weight: 700; margin: 8px 0 18px; }
     .rush-big { font-size: 4rem; line-height: 1; }
-    .rush-best { display: inline-block; padding: 6px 14px; border-radius: 99px; background: rgba(251,191,36,0.12); color: var(--gold); font-weight: 800; margin-bottom: 16px; }
+    .rush-best { display: inline-block; padding: 6px 14px; border-radius: 99px; background: #B45309; color: #fff; font-weight: 800; margin-bottom: 16px; }
     .rush-actions { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
     .rush-result-num { font-family: var(--font-display); font-size: 4rem; font-weight: 800; color: var(--gold); line-height: 1; margin: 8px 0 4px; }
     .rush-result-sub { color: var(--text-muted); font-weight: 700; margin-bottom: 16px; }
@@ -139,23 +139,23 @@
       padding: 8px 4px; margin-bottom: 4px;
     }
     .rush-chip {
-      padding: 6px 12px; border-radius: 99px; background: rgba(255,255,255,0.06);
+      padding: 6px 12px; border-radius: 99px; background: #ece9f5;
       font-family: var(--font-display); font-weight: 800; font-size: 0.9rem; color: var(--text);
     }
-    .rush-chip.rush-score { background: rgba(52,211,153,0.15); color: #34D399; }
+    .rush-chip.rush-score { background: #059669; color: #fff; }
     .rush-chip.rush-strikes { background: rgba(248,113,113,0.12); letter-spacing: 2px; }
     .rush-hint { text-align: center; color: var(--text-muted); font-size: 0.9rem; font-weight: 700; margin-top: 8px; min-height: 22px; }
     .rush-feedback { text-align: center; font-size: 2.4rem; min-height: 50px; transition: transform 0.25s cubic-bezier(0.34,1.56,0.64,1); }
-    .rush-feedback.correct { color: #34D399; animation: popIn 0.25s; }
-    .rush-feedback.wrong { color: #F87171; animation: shake 0.3s; }
+    .rush-feedback.correct { color: #059669; animation: popIn 0.25s; }
+    .rush-feedback.wrong { color: #B91C1C; animation: shake 0.3s; }
 
     /* ============================================================
        OPENINGS PRIMER
        ============================================================ */
     .op-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; padding: 0 4px; }
     .op-card {
-      padding: 18px 14px; background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08); border-radius: 16px;
+      padding: 18px 14px; background: #ffffff;
+      border: 1.5px solid #e6e6ee; border-radius: 16px;
       color: var(--text); cursor: pointer; text-align: center;
       font-family: var(--font-body); transition: all 0.2s;
     }
@@ -165,21 +165,21 @@
     .op-era { font-size: 0.72rem; color: var(--text-muted); font-weight: 700; margin-top: 4px; }
 
     .op-card-view {
-      background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08);
+      background: #ffffff;
+      border: 1.5px solid #e6e6ee;
       border-radius: 20px; padding: 22px 20px;
       display: flex; flex-direction: column; gap: 14px;
       animation: fadeUp 0.3s ease-out both;
     }
     .op-idea {
-      padding: 12px 14px; background: rgba(251,191,36,0.08);
+      padding: 12px 14px; background: rgba(251,191,36,0.12);
       border: 1px solid rgba(251,191,36,0.2); border-radius: 12px;
-      color: #FDE68A; font-size: 0.9rem; font-weight: 700; line-height: 1.4;
+      color: #B45309; font-size: 0.9rem; font-weight: 700; line-height: 1.4;
     }
     .op-step-badge {
       align-self: flex-start;
       padding: 4px 12px; border-radius: 99px;
-      background: rgba(167,139,250,0.15); color: #A78BFA;
+      background: #6D28D9; color: #fff;
       font-family: var(--font-display); font-weight: 800; font-size: 0.78rem;
     }
     .op-move {

--- a/css/code-cadet.css
+++ b/css/code-cadet.css
@@ -202,7 +202,7 @@
   text-align: center;
   cursor: pointer;
   border-radius: var(--radius-xs);
-  background: rgba(255,255,255,0.02);
+  background: #ece9f5;
 }
 
 .cc-block {
@@ -329,8 +329,8 @@
 }
 .cc-ctrl-btn:hover { transform: translateY(-2px); border-color: var(--cc-accent); }
 .cc-ctrl-btn.cc-primary {
-  background: var(--cc-accent);
-  color: #0E1A2E;
+  background: linear-gradient(135deg,#4338CA,#6366F1);
+  color: #fff;
   border: none;
   box-shadow: 0 6px 18px var(--cc-glow);
 }

--- a/css/copy-the-master.css
+++ b/css/copy-the-master.css
@@ -8,10 +8,10 @@
 .cm-entry-btn {
   display: flex; align-items: center; gap: 10px;
   padding: 10px 16px; margin: 10px auto 0;
-  background: linear-gradient(135deg, rgba(236,72,153,0.15), rgba(167,139,250,0.12));
-  border: 1.5px solid rgba(236,72,153,0.35);
+  background: #BE185D;
+  border: 1.5px solid #BE185D;
   border-radius: 99px;
-  color: var(--text);
+  color: #fff;
   font-family: var(--font-display); font-weight: 800; font-size: 0.9rem;
   cursor: pointer; transition: transform 0.2s;
 }
@@ -36,8 +36,8 @@
   gap: 12px;
 }
 .cm-card {
-  padding: 0; background: rgba(255,255,255,0.04);
-  border: 1.5px solid rgba(255,255,255,0.08); border-radius: 18px;
+  padding: 0; background: #ffffff;
+  border: 1.5px solid #e6e6ee; border-radius: 18px;
   overflow: hidden; cursor: pointer; transition: all 0.2s;
   display: flex; flex-direction: column;
   color: var(--text); font-family: var(--font-body); text-align: left;
@@ -47,7 +47,7 @@
   aspect-ratio: 4 / 3; display: flex; align-items: center; justify-content: center;
   overflow: hidden;
 }
-.cm-thumb .cm-thumb-svg { width: 100%; height: 100%; opacity: 0.32; stroke: rgba(255,255,255,0.9) !important; }
+.cm-thumb .cm-thumb-svg { width: 100%; height: 100%; opacity: 0.32; stroke: rgba(28,27,41,0.9) !important; }
 .cm-card-title {
   padding: 10px 12px 2px; font-family: var(--font-display);
   font-weight: 800; font-size: 0.95rem; line-height: 1.2;
@@ -61,7 +61,7 @@
   border: 1.5px solid rgba(251,191,36,0.22);
   border-radius: 14px;
   font-size: 0.88rem; font-weight: 700; line-height: 1.4;
-  color: #FCD34D;
+  color: #B45309;
 }
 
 /* Stage (guide under, canvas over)
@@ -110,7 +110,7 @@
 .cm-palette { display: flex; gap: 6px; flex-wrap: wrap; justify-content: center; }
 .cm-swatch {
   width: 32px; height: 32px; border-radius: 50%;
-  border: 3px solid rgba(255,255,255,0.25);
+  border: 3px solid #d6d2ea;
   cursor: pointer; transition: transform 0.15s, border-color 0.15s;
   padding: 0;
 }
@@ -121,8 +121,8 @@
 .cm-size {
   width: 40px; height: 40px; border-radius: 10px;
   display: flex; align-items: center; justify-content: center;
-  background: rgba(255,255,255,0.06);
-  border: 1.5px solid rgba(255,255,255,0.1);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   cursor: pointer; transition: all 0.15s;
 }
 .cm-size.active { border-color: #FBBF24; background: rgba(251,191,36,0.08); }
@@ -131,8 +131,8 @@
 .cm-actions { display: flex; gap: 8px; justify-content: center; flex-wrap: wrap; }
 .cm-action {
   padding: 8px 14px; border-radius: 99px;
-  border: 1.5px solid rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.04);
+  border: 1.5px solid #e6e6ee;
+  background: #ffffff;
   color: var(--text);
   font-weight: 700; font-size: 0.82rem;
   cursor: pointer; transition: all 0.15s;
@@ -141,7 +141,7 @@
 
 .back-btn {
   width: 40px; height: 40px; border-radius: 50%;
-  border: 1.5px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04);
+  border: 1.5px solid #e6e6ee; background: #ffffff;
   color: var(--text); font-size: 1.2rem; cursor: pointer;
 }
-.back-btn:hover { background: rgba(255,255,255,0.1); border-color: rgba(255,255,255,0.25); }
+.back-btn:hover { background: #ece9f5; border-color: #d6d2ea; }

--- a/css/descubre-chile.css
+++ b/css/descubre-chile.css
@@ -19,7 +19,7 @@
     .user-badge-avatar{width:28px;height:28px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:16px;border:2px solid}
     .app-header{text-align:center;margin:60px 0 24px;animation:fadeDown 0.6s ease-out both}
     .app-header .flag{font-size:48px;display:block;margin-bottom:4px;animation:flagWave 3s ease-in-out infinite}
-    .app-header h1{font-family:var(--font-display);font-size:clamp(1.8rem,5vw,2.4rem);font-weight:800;background:linear-gradient(135deg,var(--chile-red),var(--snow-white),var(--chile-blue));background-size:200% 200%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;background-clip:text;animation:gradShift 5s ease-in-out infinite}
+    .app-header h1{font-family:var(--font-display);font-size:clamp(1.8rem,5vw,2.4rem);font-weight:800;background:none;-webkit-text-fill-color:#312e81;background-clip:border-box;-webkit-background-clip:border-box;color:#312e81}
     .app-header p{color:var(--text-muted);font-weight:600;font-size:0.9rem}
     .app-header .greeting{color:var(--andes-gold);font-weight:700;font-size:0.85rem}
     .progress-bar{width:100%;height:8px;background:var(--bg-card);border-radius:99px;overflow:hidden;margin:8px 0 4px;border:1px solid var(--border-subtle)}
@@ -28,13 +28,13 @@
     .tab-bar{display:flex;gap:4px;background:var(--bg-surface);border:1px solid var(--border-subtle);border-radius:var(--radius-sm);padding:4px;margin-bottom:20px;overflow-x:auto;scrollbar-width:none}
     .tab-bar::-webkit-scrollbar{display:none}
     .tab-btn{flex:1;padding:10px 8px;border-radius:10px;border:none;background:none;color:var(--text-muted);font-family:var(--font-display);font-size:0.78rem;font-weight:700;cursor:pointer;transition:all 0.2s ease;white-space:nowrap;text-align:center}
-    .tab-btn:hover{color:var(--text);background:rgba(255,255,255,0.04)}
+    .tab-btn:hover{color:var(--text);background:#ece9f5}
     .tab-btn.active{background:var(--chile-red);color:#fff;box-shadow:0 2px 12px var(--chile-red-glow)}
     .tab-content{display:none;flex-direction:column;align-items:center;width:100%;animation:fadeUp 0.4s ease-out}
     .tab-content.active{display:flex}
     .map-wrap{width:100%;max-width:280px;margin:0 auto 20px}
     .map-svg{width:100%;height:auto}
-    .map-region{cursor:pointer;transition:all 0.3s ease;stroke:#1A2234;stroke-width:2}
+    .map-region{cursor:pointer;transition:all 0.3s ease;stroke:#ffffff;stroke-width:2}
     .map-region:hover{filter:brightness(1.2);stroke:var(--andes-gold);stroke-width:3}
     .map-region.visited{stroke:var(--green);stroke-width:2.5}
     .region-label{font-family:var(--font-display);font-size:8px;font-weight:700;fill:var(--text);pointer-events:none;text-anchor:middle}
@@ -43,15 +43,15 @@
     .map-legend-dot{width:10px;height:10px;border-radius:50%}
     .region-modal{display:none;position:fixed;inset:0;background:rgba(0,0,0,0.75);backdrop-filter:blur(6px);z-index:1000;align-items:center;justify-content:center;padding:20px}
     .region-modal.active{display:flex}
-    .region-card{background:var(--bg-surface);border:1.5px solid rgba(255,255,255,0.1);border-radius:var(--radius);padding:28px;width:100%;max-width:460px;max-height:80vh;overflow-y:auto;animation:popIn 0.3s ease-out;position:relative}
+    .region-card{background:var(--bg-surface);border:1.5px solid #e6e6ee;border-radius:var(--radius);padding:28px;width:100%;max-width:460px;max-height:80vh;overflow-y:auto;animation:popIn 0.3s ease-out;position:relative}
     .region-card h2{font-family:var(--font-display);font-size:1.4rem;font-weight:800;margin-bottom:4px;display:flex;align-items:center;gap:10px}
     .region-card .region-sub{color:var(--text-muted);font-size:0.85rem;font-weight:600;margin-bottom:16px}
-    .region-card .fact-item{padding:12px 0;border-top:1px solid rgba(255,255,255,0.05)}
+    .region-card .fact-item{padding:12px 0;border-top:1px solid #e6e6ee}
     .region-card .fact-item h4{font-family:var(--font-display);font-size:0.95rem;font-weight:700;margin-bottom:4px}
     .region-card .fact-item p{color:var(--text-muted);font-size:0.85rem;line-height:1.6;font-weight:600}
-    .fun-fact{margin-top:8px;padding:8px 12px;border-radius:var(--radius-sm);background:rgba(232,168,56,0.06);border-left:3px solid var(--andes-gold);font-size:0.8rem;color:var(--andes-gold)}
-    .close-modal{position:absolute;top:12px;right:12px;width:32px;height:32px;border-radius:50%;border:1px solid rgba(255,255,255,0.1);background:none;color:var(--text-muted);font-size:16px;cursor:pointer;display:flex;align-items:center;justify-content:center}
-    .close-modal:hover{color:var(--text);border-color:rgba(255,255,255,0.2)}
+    .fun-fact{margin-top:8px;padding:8px 12px;border-radius:var(--radius-sm);background:#ece9f5;border-left:3px solid var(--andes-gold);font-size:0.8rem;color:#B45309}
+    .close-modal{position:absolute;top:12px;right:12px;width:32px;height:32px;border-radius:50%;border:1px solid #e6e6ee;background:none;color:var(--text-muted);font-size:16px;cursor:pointer;display:flex;align-items:center;justify-content:center}
+    .close-modal:hover{color:var(--text);border-color:#d6d2ea}
     .story-list{display:flex;flex-direction:column;gap:14px;width:100%}
     .story-card{background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius);padding:22px;line-height:1.7;cursor:pointer;transition:all 0.25s ease}
     .story-card:hover{border-color:var(--chile-red);transform:translateY(-2px)}
@@ -79,7 +79,7 @@
     .quiz-progress-wrap{width:100%;height:10px;background:var(--bg-card);border-radius:99px;overflow:hidden;margin-bottom:20px;border:1px solid var(--border-subtle)}
     .quiz-progress-fill{height:100%;border-radius:99px;background:linear-gradient(90deg,var(--chile-red),var(--atacama-orange));transition:width 0.5s cubic-bezier(0.34,1.56,0.64,1);box-shadow:0 0 12px var(--chile-red-glow)}
     .quiz-top{width:100%;display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}
-    .quiz-badge{font-family:var(--font-display);font-size:0.85rem;font-weight:700;padding:6px 14px;border-radius:99px;background:rgba(217,54,54,0.12);color:var(--chile-red)}
+    .quiz-badge{font-family:var(--font-display);font-size:0.85rem;font-weight:700;padding:6px 14px;border-radius:99px;background:#D93636;color:#fff}
     .quiz-score{font-family:var(--font-display);font-size:1rem;font-weight:700;color:var(--andes-gold)}
     .quiz-card{width:100%;background:var(--bg-card);border:1.5px solid var(--border-subtle);border-radius:var(--radius);padding:28px 20px;text-align:center;margin-bottom:16px;min-height:100px;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;transition:border-color 0.3s,box-shadow 0.3s}
     .quiz-card.correct{border-color:var(--green);box-shadow:0 0 24px var(--green-glow)}
@@ -87,7 +87,7 @@
     .quiz-q-text{font-family:var(--font-display);font-size:clamp(1.1rem,3.5vw,1.4rem);font-weight:800;line-height:1.4}
     .quiz-opts{width:100%;display:flex;flex-direction:column;gap:8px}
     .quiz-opt-btn{width:100%;padding:14px;border-radius:var(--radius-sm);border:1.5px solid var(--border-subtle);background:var(--bg-card);color:var(--text);font-family:var(--font-body);font-size:0.92rem;font-weight:700;cursor:pointer;text-align:left;transition:all 0.25s}
-    .quiz-opt-btn:hover{border-color:var(--chile-red);background:rgba(217,54,54,0.06)}
+    .quiz-opt-btn:hover{border-color:var(--chile-red);background:#ece9f5}
     .quiz-opt-btn.disabled{pointer-events:none}
     .quiz-opt-btn.sel-correct{background:var(--green);border-color:var(--green);color:#fff}
     .quiz-opt-btn.sel-wrong{background:var(--red);border-color:var(--red);color:#fff}
@@ -100,7 +100,7 @@
     .btn-red{padding:14px 24px;border-radius:var(--radius-sm);border:none;background:linear-gradient(135deg,var(--chile-red),var(--atacama-orange));color:#fff;font-family:var(--font-display);font-size:1rem;font-weight:700;cursor:pointer;transition:all 0.25s;box-shadow:0 4px 16px var(--chile-red-glow)}
     .btn-red:hover{transform:translateY(-2px);box-shadow:0 8px 24px var(--chile-red-glow)}
     .btn-ghost{padding:14px 24px;border-radius:var(--radius-sm);border:1.5px solid var(--border-subtle);background:none;color:var(--text-muted);font-family:var(--font-display);font-size:1rem;font-weight:700;cursor:pointer;transition:all 0.25s}
-    .btn-ghost:hover{border-color:rgba(255,255,255,0.2);color:var(--text)}
+    .btn-ghost:hover{border-color:#d6d2ea;color:var(--text)}
     .feedback-float{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%) scale(0);font-size:80px;pointer-events:none;z-index:2000;transition:transform 0.3s cubic-bezier(0.34,1.56,0.64,1),opacity 0.3s;opacity:0}
     .feedback-float.show{transform:translate(-50%,-50%) scale(1);opacity:1}
     @media(max-width:480px){.app{padding:16px 14px 32px}.memory-grid{grid-template-columns:repeat(3,1fr);gap:8px}.map-wrap{max-width:240px}}

--- a/css/guess-quest.css
+++ b/css/guess-quest.css
@@ -8,8 +8,8 @@
   --gq-yes: #10B981;
   --gq-no: #EF4444;
   --gq-maybe: #F59E0B;
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -96,7 +96,7 @@ body {
 .answer-display {
   width: 100%;
   min-height: 160px;
-  background: rgba(255,255,255,0.02);
+  background: #ffffff;
   border-radius: 24px;
   display: flex;
   flex-direction: column;
@@ -141,7 +141,7 @@ body {
   cursor: pointer; transition: all 0.2s; text-align: left;
   display: flex; align-items: center; gap: 8px; min-height: 56px;
 }
-.q-btn:hover { border-color: var(--gq-accent); background: rgba(255,255,255,0.08); }
+.q-btn:hover { border-color: var(--gq-accent); background: #ece9f5; }
 .q-btn:active { transform: scale(0.98); }
 .q-btn.asked { opacity: 0.4; text-decoration: line-through; pointer-events: none; }
 
@@ -176,7 +176,7 @@ body {
 .btn-guess:hover { transform: translateY(-2px); box-shadow: 0 6px 20px var(--gq-glow); }
 
 .btn-primary { background: linear-gradient(135deg, var(--gq-accent), #FBBF24); color: #fff; }
-.btn-secondary { background: rgba(255,255,255,0.08); color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
+.btn-secondary { background: #ffffff; color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
 
 /* Results */
 .results-wrap { text-align: center; padding: 40px 20px; display: flex; flex-direction: column; align-items: center; }
@@ -199,8 +199,8 @@ body {
 
 /* Scrollbar */
 .question-categories::-webkit-scrollbar { width: 6px; }
-.question-categories::-webkit-scrollbar-track { background: rgba(255,255,255,0.02); }
-.question-categories::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.1); border-radius: 10px; }
+.question-categories::-webkit-scrollbar-track { background: #ece9f5; }
+.question-categories::-webkit-scrollbar-thumb { background: #d6d2ea; border-radius: 10px; }
 
 @media (max-width: 480px) {
   .q-grid { grid-template-columns: 1fr; }
@@ -216,15 +216,15 @@ body {
   gap: 16px;
   padding: 18px 20px;
   margin-bottom: 20px;
-  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(167,139,250,0.08));
-  border: 1.5px solid rgba(251,191,36,0.3);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   border-radius: 16px;
   cursor: pointer;
   transition: all 0.25s;
 }
 .dw-daily-card:hover {
   transform: translateY(-2px);
-  border-color: rgba(251,191,36,0.6);
+  border-color: #d6d2ea;
   box-shadow: 0 8px 24px -8px rgba(251,191,36,0.4);
 }
 .dw-daily-card .dw-dc-emoji { font-size: 2.2rem; flex-shrink: 0; }
@@ -233,7 +233,7 @@ body {
   font-family: var(--font-display);
   font-size: 1.2rem;
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
 }
 .dw-daily-card .dw-dc-sub {
   font-size: 0.85rem;
@@ -241,7 +241,7 @@ body {
   color: var(--text-muted);
   margin-top: 2px;
 }
-.dw-daily-card .dw-dc-arrow { color: #FBBF24; font-size: 1.4rem; }
+.dw-daily-card .dw-dc-arrow { color: #B45309; font-size: 1.4rem; }
 
 .dw-status {
   text-align: center;
@@ -261,8 +261,8 @@ body {
   gap: 8px;
 }
 .dw-stat {
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 10px;
   padding: 8px 4px;
   text-align: center;
@@ -271,7 +271,7 @@ body {
   font-family: var(--font-display);
   font-size: 1.3rem;
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
 }
 .dw-stat-lbl {
   font-size: 0.7rem;
@@ -292,7 +292,7 @@ body {
 .dw-tile {
   width: 52px;
   height: 52px;
-  border: 2px solid rgba(255,255,255,0.15);
+  border: 2px solid #d6d2ea;
   border-radius: 8px;
   display: flex;
   align-items: center;
@@ -302,7 +302,7 @@ body {
   font-weight: 800;
   color: var(--text-primary);
   text-transform: uppercase;
-  background: rgba(255,255,255,0.02);
+  background: #ece9f5;
   transition: transform 0.15s;
 }
 .dw-tile.typing {
@@ -312,14 +312,14 @@ body {
 .dw-tile.filled { animation: popIn 0.25s ease-out; }
 .dw-tile.correct { background: #10B981; border-color: #10B981; color: #fff; }
 .dw-tile.present { background: #F59E0B; border-color: #F59E0B; color: #fff; }
-.dw-tile.absent  { background: #3f3f46; border-color: #3f3f46; color: #a1a1aa; }
+.dw-tile.absent  { background: #d6d2ea; border-color: #d6d2ea; color: #6b6878; }
 
 .dw-flash {
   text-align: center;
   height: 22px;
   font-weight: 700;
   font-size: 0.9rem;
-  color: #F87171;
+  color: #B91C1C;
   opacity: 0;
   transition: opacity 0.2s;
   margin: 6px 0;
@@ -340,7 +340,7 @@ body {
   height: 48px;
   border: none;
   border-radius: 6px;
-  background: rgba(255,255,255,0.1);
+  background: #ece9f5;
   color: var(--text-primary);
   font-family: var(--font-display);
   font-size: 0.95rem;
@@ -350,10 +350,10 @@ body {
   padding: 0 4px;
 }
 .dw-key.wide { flex: 1.5; max-width: 68px; font-size: 0.75rem; }
-.dw-key:hover { background: rgba(255,255,255,0.18); }
+.dw-key:hover { background: #d6d2ea; }
 .dw-key.correct { background: #10B981; color: #fff; }
 .dw-key.present { background: #F59E0B; color: #fff; }
-.dw-key.absent  { background: #3f3f46; color: #a1a1aa; }
+.dw-key.absent  { background: #b8b4c8; color: #ffffff; }
 
 .dw-actions {
   margin-top: 16px;

--- a/css/guitar-jam.css
+++ b/css/guitar-jam.css
@@ -14,16 +14,16 @@ body {
 /* Tabs */
 .tabs-bar {
   display: flex;
-  background: rgba(0, 0, 0, 0.4);
+  background: #ffffff;
   padding: 12px;
   gap: 8px;
   overflow-x: auto;
-  border-bottom: 2px solid rgba(255,255,255,0.05);
+  border-bottom: 2px solid #e6e6ee;
 }
 .tab {
   padding: 10px 20px;
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.05);
+  background: #ece9f5;
   color: var(--text);
   font-family: var(--font-display);
   font-size: 1rem;
@@ -33,7 +33,7 @@ body {
   white-space: nowrap;
   transition: all 0.2s;
 }
-.tab:hover { background: rgba(255,255,255,0.1); }
+.tab:hover { background: #d6d2ea; }
 .tab.active { background: var(--guitar-accent); color: #000; }
 
 .content-container {
@@ -49,9 +49,9 @@ body {
 .placeholder-msg {
   text-align: center;
   padding: 60px 20px;
-  background: rgba(255,255,255,0.02);
+  background: #ffffff;
   border-radius: 24px;
-  border: 2px dashed rgba(255,255,255,0.1);
+  border: 2px dashed #d6d2ea;
   margin-top: 20px;
 }
 .placeholder-msg h2 { font-family: var(--font-display); font-size: 2rem; margin: 16px 0; }
@@ -65,16 +65,16 @@ body {
 }
 .chord-sidebar {
   flex: 0 0 240px;
-  background: rgba(255,255,255,0.03);
+  background: #ffffff;
   padding: 16px;
   border-radius: 20px;
-  border: 1px solid rgba(255,255,255,0.08);
+  border: 1px solid #e6e6ee;
   max-height: calc(100vh - 150px);
   overflow-y: auto;
 }
 .chord-main {
   flex: 1;
-  background: rgba(0,0,0,0.2);
+  background: #ffffff;
   padding: 32px 20px;
   border-radius: 24px;
   display: flex;
@@ -90,11 +90,11 @@ body {
   gap: 10px;
 }
 .chord-btn {
-  background: rgba(255,255,255,0.05);
+  background: #ece9f5;
   border: 2px solid transparent;
   padding: 12px;
   border-radius: 12px;
-  color: #fff;
+  color: var(--text-primary);
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 1.2rem;
@@ -102,19 +102,19 @@ body {
   transition: all 0.2s;
   text-align: center;
 }
-.chord-btn:hover { background: rgba(255,255,255,0.1); }
+.chord-btn:hover { background: #d6d2ea; }
 .chord-btn.active {
-  background: rgba(52, 211, 153, 0.15);
-  border-color: var(--guitar-accent);
-  color: var(--guitar-accent);
+  background: #059669;
+  border-color: #059669;
+  color: #fff;
 }
-.chord-btn.viewed { border-color: rgba(255,255,255,0.2); }
+.chord-btn.viewed { border-color: #d6d2ea; }
 
 /* Fretboard SVG */
 .fretboard-wrap {
   width: 100%;
   max-width: 300px;
-  background: rgba(255,255,255,0.02);
+  background: #ece9f5;
   border-radius: 16px;
   padding: 20px;
 }
@@ -129,7 +129,7 @@ body {
   font-size: 2.5rem;
   font-weight: 800;
   margin-top: 20px;
-  color: var(--guitar-accent);
+  color: #059669;
 }
 .chord-fact {
   text-align: center;
@@ -166,7 +166,7 @@ body {
 }
 .song-card {
   background: var(--bg-surface);
-  border: 2px solid rgba(255,255,255,0.06);
+  border: 2px solid #e6e6ee;
   border-radius: 20px;
   padding: 20px;
   cursor: pointer;
@@ -179,9 +179,9 @@ body {
 .song-title { font-family: var(--font-display); font-size: 1.3rem; font-weight: 800; }
 .song-meta { font-size: 0.85rem; color: var(--text-muted); font-weight: 700; }
 .song-chords { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
-.chord-mini { 
-  font-size: 0.75rem; background: rgba(255,255,255,0.1); 
-  padding: 2px 6px; border-radius: 4px; font-weight: 800; 
+.chord-mini {
+  font-size: 0.75rem; background: #ece9f5;
+  padding: 2px 6px; border-radius: 4px; font-weight: 800;
 }
 
 /* Gameplay */
@@ -194,15 +194,15 @@ body {
 .game-header { display: flex; align-items: center; justify-content: space-between; }
 .game-song-title { font-family: var(--font-display); font-size: 1.5rem; font-weight: 800; }
 .back-to-songs, .metro-toggle {
-  background: rgba(255,255,255,0.05); border: none; padding: 8px 16px;
+  background: #ffffff; border: 1px solid #e6e6ee; padding: 8px 16px;
   border-radius: 10px; color: var(--text-muted); font-weight: 700; cursor: pointer;
 }
-.metro-toggle.on { color: var(--guitar-accent); background: rgba(52, 211, 153, 0.1); }
+.metro-toggle.on { color: #059669; background: #ece9f5; }
 
 .chord-strip-container {
   position: relative;
   height: 80px;
-  background: rgba(0,0,0,0.3);
+  background: #ece9f5;
   border-radius: 16px;
   overflow: hidden;
   display: flex;
@@ -218,8 +218,8 @@ body {
 .strip-chord {
   min-width: 60px;
   height: 50px;
-  background: rgba(255,255,255,0.05);
-  border: 2px solid rgba(255,255,255,0.1);
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
   border-radius: 12px;
   display: flex;
   align-items: center;
@@ -249,7 +249,7 @@ body {
 
 .game-main { flex: 1; display: flex; align-items: center; justify-content: center; }
 .fretboard-display {
-  background: rgba(255,255,255,0.02);
+  background: #ece9f5;
   padding: 20px;
   border-radius: 20px;
   display: flex;
@@ -258,7 +258,7 @@ body {
   gap: 12px;
 }
 #game-fretboard { height: 200px; width: auto; }
-.game-chord-name { font-family: var(--font-display); font-size: 2rem; font-weight: 800; color: var(--guitar-accent); }
+.game-chord-name { font-family: var(--font-display); font-size: 2rem; font-weight: 800; color: #059669; }
 
 .big-strum-btn {
   width: 100%;
@@ -305,17 +305,17 @@ body {
   font-family: var(--font-display); cursor: pointer; transition: all 0.2s;
 }
 .results-btn.primary { background: var(--guitar-accent); color: #000; }
-.results-btn:not(.primary) { background: rgba(255,255,255,0.05); color: var(--text); }
+.results-btn:not(.primary) { background: #ece9f5; color: var(--text); }
 .results-btn:hover { transform: translateY(-2px); filter: brightness(1.1); }
 
 /* Ear Training */
 .ear-game-screen { display: flex; flex-direction: column; gap: 24px; }
 .ear-header { display: flex; justify-content: space-between; font-weight: 800; font-family: var(--font-display); font-size: 1.2rem; }
-.ear-streak { color: #F59E0B; }
+.ear-streak { color: #B45309; }
 .ear-main { display: flex; flex-direction: column; gap: 32px; align-items: center; }
 .ear-question-card {
-  background: rgba(255,255,255,0.03); padding: 40px; border-radius: 24px;
-  border: 2px solid rgba(255,255,255,0.08); text-align: center; width: 100%;
+  background: #ffffff; padding: 40px; border-radius: 24px;
+  border: 2px solid #e6e6ee; text-align: center; width: 100%;
 }
 .ear-replay-btn {
   background: var(--guitar-accent); color: #000; border: none; padding: 12px 24px;
@@ -323,11 +323,11 @@ body {
 }
 .ear-options { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; width: 100%; }
 .ear-opt-btn {
-  background: rgba(255,255,255,0.05); border: 2px solid rgba(255,255,255,0.1);
-  border-radius: 16px; padding: 20px; color: #fff; font-family: var(--font-display);
+  background: #ffffff; border: 2px solid #e6e6ee;
+  border-radius: 16px; padding: 20px; color: var(--text-primary); font-family: var(--font-display);
   font-weight: 800; font-size: 1.5rem; cursor: pointer; transition: all 0.2s;
 }
-.ear-opt-btn:hover { background: rgba(255,255,255,0.1); border-color: var(--guitar-accent); }
+.ear-opt-btn:hover { background: #ece9f5; border-color: var(--guitar-accent); }
 .ear-opt-btn.correct { background: #10B981; border-color: #10B981; }
 .ear-opt-btn.wrong { background: #EF4444; border-color: #EF4444; }
 
@@ -335,23 +335,23 @@ body {
 .tuner-container { display: flex; flex-direction: column; align-items: center; gap: 24px; }
 .string-buttons { display: flex; flex-direction: column; gap: 12px; width: 100%; max-width: 300px; }
 .tuner-btn {
-  background: rgba(255,255,255,0.05); border: 2px solid rgba(255,255,255,0.1);
-  border-radius: 16px; padding: 16px; color: #fff; font-family: var(--font-display);
+  background: #ffffff; border: 2px solid #e6e6ee;
+  border-radius: 16px; padding: 16px; color: var(--text-primary); font-family: var(--font-display);
   font-weight: 800; font-size: 1.4rem; cursor: pointer; display: flex; align-items: center;
   justify-content: center; gap: 8px; transition: all 0.2s;
 }
 .tuner-btn span { font-size: 0.8rem; color: var(--text-muted); }
-.tuner-btn:hover { background: rgba(255,255,255,0.1); border-color: var(--guitar-accent); }
-.tuner-btn.playing { 
-  background: rgba(52, 211, 153, 0.1); border-color: var(--guitar-accent); 
-  color: var(--guitar-accent); box-shadow: 0 0 20px var(--guitar-glow);
+.tuner-btn:hover { background: #ece9f5; border-color: var(--guitar-accent); }
+.tuner-btn.playing {
+  background: #ece9f5; border-color: var(--guitar-accent);
+  color: #059669; box-shadow: 0 0 20px var(--guitar-glow);
   animation: pulse 1s infinite;
 }
 @keyframes pulse { 0% { transform: scale(1); } 50% { transform: scale(1.02); } 100% { transform: scale(1); } }
 .tuner-help { text-align: center; color: var(--text-muted); font-weight: 600; max-width: 400px; }
-.tuner-tuning { 
-  font-family: var(--font-display); font-size: 2rem; font-weight: 900; 
-  letter-spacing: 8px; color: var(--guitar-accent); opacity: 0.5; 
+.tuner-tuning {
+  font-family: var(--font-display); font-size: 2rem; font-weight: 900;
+  letter-spacing: 8px; color: #059669; opacity: 0.5;
 }
 
 /* Responsive */

--- a/css/home-timer.css
+++ b/css/home-timer.css
@@ -12,11 +12,11 @@
   font-family: var(--font-display);
   font-size: clamp(1.8rem, 5vw, 2.4rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #FBBF24, #EC4899, #60A5FA);
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: none;
+  -webkit-text-fill-color: #312e81;
+  background-clip: border-box;
+  -webkit-background-clip: border-box;
+  color: #312e81;
   animation: gradShift 6s ease-in-out infinite;
 }
 .ht-header p {
@@ -35,8 +35,8 @@
 }
 .ht-profile {
   padding: 12px 10px;
-  background: rgba(255,255,255,0.04);
-  border: 1.5px solid rgba(255,255,255,0.08);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   border-radius: 14px;
   cursor: pointer;
   text-align: center;
@@ -47,7 +47,7 @@
 .ht-profile:hover { transform: translateY(-2px); border-color: #60A5FA; }
 .ht-profile.active {
   border-color: #FBBF24;
-  background: rgba(251,191,36,0.08);
+  background: #ece9f5;
 }
 .ht-profile-avatar {
   font-size: 1.8rem;
@@ -69,8 +69,8 @@
 }
 .ht-mode {
   padding: 16px 12px;
-  background: rgba(255,255,255,0.04);
-  border: 1.5px solid rgba(255,255,255,0.08);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   border-radius: 16px;
   cursor: pointer;
   text-align: center;
@@ -97,8 +97,8 @@
 /* Session */
 .ht-session {
   padding: 24px 18px;
-  background: rgba(255,255,255,0.03);
-  border: 1.5px solid rgba(255,255,255,0.08);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   border-radius: 20px;
   text-align: center;
 }
@@ -133,7 +133,7 @@
 .ht-timer svg { width: 100%; height: 100%; transform: rotate(-90deg); }
 .ht-timer-track {
   fill: none;
-  stroke: rgba(255,255,255,0.08);
+  stroke: #ece9f5;
   stroke-width: 10;
 }
 .ht-timer-fill {
@@ -182,9 +182,9 @@
   transition: transform 0.15s;
 }
 .ht-actions button:hover { transform: translateY(-2px); }
-.ht-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
-.ht-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); border: 1.5px solid rgba(255,255,255,0.12) !important; }
-.ht-btn-danger { background: rgba(248,113,113,0.12); color: #F87171; border: 1.5px solid rgba(248,113,113,0.25) !important; }
+.ht-btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; }
+.ht-btn-secondary { background: #ffffff; color: var(--text); border: 1.5px solid #e6e6ee !important; }
+.ht-btn-danger { background: #B91C1C; color: #fff; border: 1.5px solid #B91C1C !important; }
 
 .ht-progress {
   display: flex;
@@ -196,7 +196,7 @@
 .ht-prog-dot {
   width: 10px; height: 10px;
   border-radius: 50%;
-  background: rgba(255,255,255,0.12);
+  background: #ece9f5;
 }
 .ht-prog-dot.done { background: #34D399; }
 .ht-prog-dot.active {
@@ -222,12 +222,12 @@
 .ht-skip-log {
   margin-top: 16px;
   padding: 10px 14px;
-  background: rgba(248,113,113,0.06);
-  border: 1px solid rgba(248,113,113,0.18);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 10px;
   font-size: 0.82rem;
   font-weight: 700;
-  color: #F87171;
+  color: #B91C1C;
 }
 
 .ht-mute-toggle {
@@ -236,8 +236,8 @@
   gap: 6px;
   margin-top: 10px;
   padding: 6px 12px;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.1);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 99px;
   font-size: 0.78rem;
   font-weight: 700;

--- a/css/lab-explorer.css
+++ b/css/lab-explorer.css
@@ -4,10 +4,10 @@
    ================================================================ */
 
 :root {
-  --lab-accent: #10B981;
-  --lab-glow: rgba(16, 185, 129, 0.3);
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --lab-accent: #059669;
+  --lab-glow: rgba(5, 150, 105, 0.25);
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -86,7 +86,7 @@ body {
 .lab-title { font-family: var(--font-display); font-weight: 800; font-size: 1.2rem; margin-bottom: 4px; }
 .lab-desc { font-size: 0.85rem; color: var(--text-muted); line-height: 1.4; }
 
-.lab-progress { width: 100%; height: 6px; background: rgba(255,255,255,0.06); border-radius: 99px; margin: 16px 0 4px; overflow: hidden; }
+.lab-progress { width: 100%; height: 6px; background: #ece9f5; border-radius: 99px; margin: 16px 0 4px; overflow: hidden; }
 .lab-progress-bar { height: 100%; background: linear-gradient(90deg, #10B981, #34D399); border-radius: 99px; transition: width 0.5s; }
 .lab-progress-text { font-size: 0.75rem; color: var(--text-muted); font-weight: 700; }
 
@@ -94,7 +94,7 @@ body {
 .plant-controls { display: flex; flex-direction: column; gap: 12px; margin-top: 16px; align-items: center; }
 .plant-controls .action-btn { margin-bottom: 0; padding: 12px 24px; font-size: 1rem; }
 .resource-bars { display: flex; width: 100%; max-width: 280px; gap: 12px; margin-top: 8px; }
-.resource-bar { flex: 1; height: 8px; background: rgba(255,255,255,0.1); border-radius: 99px; overflow: hidden; }
+.resource-bar { flex: 1; height: 8px; background: #ece9f5; border-radius: 99px; overflow: hidden; }
 .resource-fill { height: 100%; transition: width 0.2s linear; }
 .bg-blue { background: #3B82F6; }
 .bg-yellow { background: #FBBF24; }
@@ -110,14 +110,14 @@ body {
 .exp-title { font-family: var(--font-display); font-weight: 800; font-size: 1.3rem; }
 .exp-stars { font-weight: 800; color: var(--gold); font-size: 1.1rem; }
 
-.exp-canvas-wrap { border-radius: var(--radius); overflow: hidden; border: 1.5px solid var(--border-subtle); background: #1a1a2e; margin-top: 8px; }
+.exp-canvas-wrap { border-radius: var(--radius); overflow: hidden; border: 1.5px solid var(--border-subtle); background: #ffffff; margin-top: 8px; }
 .exp-canvas-wrap canvas { width: 100%; height: auto; display: block; touch-action: none; }
 
-.exp-controls { padding: 16px; background: rgba(255,255,255,0.02); border-bottom: 1px solid var(--border-subtle); }
+.exp-controls { padding: 16px; background: #ffffff; border-bottom: 1px solid var(--border-subtle); }
 .exp-instruction { font-size: 0.95rem; font-weight: 700; text-align: center; color: var(--text-muted); }
 
-.exp-journal { flex: 1; padding: 16px; overflow-y: auto; max-height: 150px; background: rgba(0,0,0,0.2); }
-.journal-entry { padding: 8px 12px; background: rgba(16,185,129,0.06); border-radius: 8px; margin: 4px 0; font-size: 0.85rem; animation: slideIn 0.3s ease-out; }
+.exp-journal { flex: 1; padding: 16px; overflow-y: auto; max-height: 150px; background: #ece9f5; }
+.journal-entry { padding: 8px 12px; background: #ffffff; border-radius: 8px; margin: 4px 0; font-size: 0.85rem; animation: slideIn 0.3s ease-out; }
 .journal-time { color: var(--text-muted); font-size: 0.75rem; float: right; }
 
 @keyframes slideIn { from { opacity: 0; transform: translateX(-10px); } to { opacity: 1; transform: translateX(0); } }
@@ -142,10 +142,10 @@ body {
   font-weight: 800; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease;
   border: none; width: 100%; max-width: 280px; margin-bottom: 12px;
 }
-.btn-primary { background: linear-gradient(135deg, var(--lab-accent), #34D399); color: #fff; box-shadow: 0 4px 15px var(--lab-glow); }
+.btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; box-shadow: 0 4px 15px var(--lab-glow); }
 .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 20px var(--lab-glow); }
-.btn-secondary { background: rgba(255,255,255,0.08); color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
-.btn-secondary:hover { background: rgba(255,255,255,0.12); }
+.btn-secondary { background: #ffffff; color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
+.btn-secondary:hover { background: #ece9f5; }
 
 /* Feedback Overlay */
 .feedback {
@@ -162,7 +162,7 @@ body {
 .wx-date {
   align-self: center;
   padding: 4px 14px; border-radius: 99px;
-  background: rgba(96,165,250,0.15); color: #60A5FA;
+  background: #2563EB; color: #fff;
   font-family: var(--font-display); font-weight: 800; font-size: 0.9rem;
 }
 .wx-group { display: flex; flex-direction: column; gap: 6px; }
@@ -172,34 +172,34 @@ body {
 .wx-chip {
   display: inline-flex; align-items: center; gap: 6px;
   padding: 8px 12px; border-radius: 99px;
-  background: rgba(255,255,255,0.05);
-  border: 1.5px solid rgba(255,255,255,0.1);
-  color: var(--text, #F0EDFF);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
+  color: var(--text, #1c1b29);
   font-family: var(--font-body); font-size: 0.82rem; font-weight: 700;
   cursor: pointer; transition: all 0.15s;
 }
-.wx-chip:hover { border-color: rgba(96,165,250,0.45); }
+.wx-chip:hover { border-color: #2563EB; }
 .wx-chip.sel {
-  background: rgba(96,165,250,0.18); border-color: #60A5FA;
-  box-shadow: 0 0 0 2px rgba(96,165,250,0.25);
+  background: #2563EB; border-color: #2563EB; color: #fff;
+  box-shadow: 0 0 0 2px rgba(37,99,235,0.25);
 }
 .wx-chip-ic { font-size: 1.1rem; }
 .wx-wind { justify-content: flex-start; }
 .wx-temp {
   padding: 10px 12px; border-radius: 10px;
-  border: 1.5px solid rgba(255,255,255,0.1);
-  background: rgba(0,0,0,0.2); color: var(--text, #F0EDFF);
+  border: 1.5px solid #e6e6ee;
+  background: #ece9f5; color: var(--text, #1c1b29);
   font-family: var(--font-body); font-size: 1rem; font-weight: 700;
   outline: none; max-width: 180px;
 }
-.wx-temp:focus { border-color: #60A5FA; }
+.wx-temp:focus { border-color: #2563EB; }
 .wx-actions { display: flex; justify-content: center; margin-top: 4px; }
 .wx-actions button:disabled { opacity: 0.45; cursor: not-allowed; }
 
 .wx-journal {
   margin-top: 10px; padding: 12px 14px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 14px;
 }
 .wx-j-head {
@@ -211,7 +211,7 @@ body {
 .wx-tally {
   display: flex; flex-direction: column; align-items: center; gap: 2px;
   padding: 8px 4px; border-radius: 10px;
-  background: rgba(255,255,255,0.04);
+  background: #ece9f5;
   font-size: 1rem;
 }
 .wx-tally-n { font-family: var(--font-display); font-weight: 800; color: var(--text); }
@@ -221,7 +221,7 @@ body {
 .wx-row {
   display: flex; align-items: center; gap: 10px;
   padding: 6px 2px;
-  border-top: 1px dashed rgba(255,255,255,0.06);
+  border-top: 1px dashed #e6e6ee;
   font-size: 0.82rem; font-weight: 600;
 }
 .wx-row:first-child { border-top: none; }

--- a/css/little-maestro.css
+++ b/css/little-maestro.css
@@ -12,36 +12,36 @@
     }
 
     :root {
-      /* — Color Palette — */
-      --color-bg:             #0F0F1A;
-      --color-surface:        #1A1A2E;
-      --color-surface-2:      #22223C;
-      --color-border:         #2A2A4A;
-      --color-border-soft:    #1E1E38;
+      /* — Color Palette — (LIGHT theme: surfaces/text/borders light, accents deep) */
+      --color-bg:             #f1f1f4;
+      --color-surface:        #ffffff;
+      --color-surface-2:      #ece9f5;
+      --color-border:         #e6e6ee;
+      --color-border-soft:    #ece9f5;
 
-      --color-purple:         #7C3AED;
-      --color-purple-light:   #9D6EFF;
+      --color-purple:         #6D28D9;
+      --color-purple-light:   #7C3AED;
       --color-purple-dark:    #5B21B6;
       --color-purple-glow:    rgba(124, 58, 237, 0.35);
       --color-purple-subtle:  rgba(124, 58, 237, 0.12);
 
-      --color-gold:           #F59E0B;
-      --color-gold-light:     #FBBF24;
+      --color-gold:           #B45309;
+      --color-gold-light:     #D97706;
       --color-gold-glow:      rgba(245, 158, 11, 0.35);
       --color-gold-subtle:    rgba(245, 158, 11, 0.12);
 
-      --color-green:          #10B981;
-      --color-green-light:    #34D399;
+      --color-green:          #059669;
+      --color-green-light:    #10B981;
       --color-green-glow:     rgba(16, 185, 129, 0.35);
       --color-green-subtle:   rgba(16, 185, 129, 0.12);
 
-      --color-red:            #EF4444;
+      --color-red:            #B91C1C;
       --color-red-glow:       rgba(239, 68, 68, 0.30);
       --color-red-subtle:     rgba(239, 68, 68, 0.10);
 
-      --color-text:           #F8FAFC;
-      --color-text-muted:     #94A3B8;
-      --color-text-dim:       #4A5568;
+      --color-text:           #1c1b29;
+      --color-text-muted:     #6b6878;
+      --color-text-dim:       #9CA3AF;
 
       /* Per-user accent — overridden via inline style on .app-shell */
       --color-user-accent:    #7C3AED;
@@ -203,14 +203,14 @@
       outline-offset: 3px;
     }
 
-    /* Primary — purple fill */
+    /* Primary — indigo fill */
     .btn-primary {
-      background: var(--color-purple);
+      background: linear-gradient(135deg,#4338CA,#6366F1);
       color: #fff;
       box-shadow: 0 4px 16px var(--color-purple-glow);
     }
     .btn-primary:hover {
-      background: var(--color-purple-light);
+      background: linear-gradient(135deg,#3730A3,#4F46E5);
       box-shadow: 0 6px 24px var(--color-purple-glow);
       transform: translateY(-1px);
     }
@@ -234,13 +234,13 @@
     }
     .btn-ghost:hover {
       color: var(--color-text);
-      background: rgba(255,255,255,0.05);
+      background: rgba(0,0,0,0.05);
     }
 
     /* Gold — achievement / next-step */
     .btn-gold {
       background: var(--color-gold);
-      color: #1A1005;
+      color: #fff;
       box-shadow: 0 4px 16px var(--color-gold-glow);
       font-size: 17px;
     }
@@ -253,7 +253,7 @@
     /* Green — success / confirm */
     .btn-green {
       background: var(--color-green);
-      color: #062B1E;
+      color: #fff;
       box-shadow: 0 4px 16px var(--color-green-glow);
     }
     .btn-green:hover {
@@ -592,8 +592,8 @@
       font-weight: 800;
       font-size: 15px;
     }
-    .hdr-stat.streak { color: #FF9500; }
-    .hdr-stat.notes  { color: var(--color-purple-light); }
+    .hdr-stat.streak { color: #C2410C; }
+    .hdr-stat.notes  { color: var(--color-purple); }
 
     .hdr-lock-btn {
       background: none;
@@ -665,7 +665,7 @@
       transform: scale(1.12);
     }
     .nav-item:not(.active):hover {
-      background: rgba(255,255,255,0.04);
+      background: rgba(0,0,0,0.04);
     }
     .nav-item:not(.active):hover .nav-label {
       color: var(--color-text);
@@ -932,7 +932,7 @@
     }
     .login-parent-btn:hover {
       color: var(--color-text-muted);
-      background: rgba(255,255,255,0.04);
+      background: rgba(0,0,0,0.04);
     }
 
 
@@ -1049,12 +1049,11 @@
     /* Unsupported — blue info */
     .midi-pill--info {
       background: rgba(14, 165, 233, 0.10);
-      color: #38BDF8;
+      color: #2563EB;
       border-color: rgba(14, 165, 233, 0.25);
     }
     .midi-pill--info:hover {
       background: rgba(14, 165, 233, 0.18);
-    }
 
     /* Permission denied — red-ish */
     .midi-pill--warn {
@@ -1339,7 +1338,7 @@
     .midi-log-entry {
       color: var(--color-green);
       padding: 2px 0;
-      border-bottom: 1px solid rgba(255,255,255,0.03);
+      border-bottom: 1px solid rgba(0,0,0,0.06);
       white-space: nowrap;
     }
     .midi-log-entry:first-child {
@@ -1547,7 +1546,7 @@
     .color-swatch:hover { transform: scale(1.12); }
     .color-swatch.selected {
       border-color: #fff;
-      box-shadow: 0 0 0 3px rgba(255,255,255,0.35);
+      box-shadow: 0 0 0 3px rgba(49,46,129,0.45);
       transform: scale(1.12);
     }
 
@@ -1587,7 +1586,7 @@
     .btn-create {
       padding: 10px 24px;
       border-radius: var(--radius-md);
-      background: var(--color-purple);
+      background: linear-gradient(135deg,#4338CA,#6366F1);
       border: none;
       color: #fff;
       font-family: var(--font-heading);
@@ -2759,23 +2758,23 @@
       z-index: 1;
       box-shadow: 0 2px 8px rgba(0,0,0,0.3);
     }
-    .world-banner--1 { background: linear-gradient(135deg, #3D5A3E, #2A3F2B); border: 1px solid #5A7C5B; }
-    .world-banner--2 { background: linear-gradient(135deg, #4A3D1E, #352A12); border: 1px solid #7A6230; }
-    .world-banner--3 { background: linear-gradient(135deg, #1E2E4A, #0F1A2E); border: 1px solid #2D4A7A; }
-    .world-banner--4 { background: linear-gradient(135deg, #3D1E3D, #261226); border: 1px solid #6B2D6B; }
-    .world-banner--5 { background: linear-gradient(135deg, #1E3D3D, #0F2626); border: 1px solid #2D7A7A; }
-    .world-banner--6 { background: linear-gradient(135deg, #3A2200, #201200); border: 1px solid #7A5000; }
-    .world-banner--7 { background: linear-gradient(135deg, #1A1A40, #0D0D26); border: 1px solid #5050CC; }
-    .world-banner--8 { background: linear-gradient(135deg, #3A1A00, #240F00); border: 1px solid #CC5500; }
-    .world-banner--9 { background: linear-gradient(135deg, #0A2A1A, #051510); border: 1px solid #00AA66; }
-    .world-banner--10 { background: linear-gradient(135deg, #2A0033, #160019); border: 1px solid #CC00FF; }
-    .world-banner--11 { background: linear-gradient(135deg, #1A3D2E, #0D2619); border: 1px solid #2E8C5A; }
-    .world-banner--12 { background: linear-gradient(135deg, #2E1A3D, #1A0D26); border: 1px solid #6B3DAA; }
-    .world-banner--13 { background: linear-gradient(135deg, #3D2E1A, #261E0D); border: 1px solid #AA8030; }
-    .world-banner--bonus { background: linear-gradient(135deg, #2A2000, #161000); border: 2px solid #FFD700; box-shadow: 0 0 12px rgba(255,215,0,0.3); }
+    .world-banner--1 { background: #ffffff; border: 1px solid #5A7C5B; }
+    .world-banner--2 { background: #ffffff; border: 1px solid #7A6230; }
+    .world-banner--3 { background: #ffffff; border: 1px solid #2D4A7A; }
+    .world-banner--4 { background: #ffffff; border: 1px solid #6B2D6B; }
+    .world-banner--5 { background: #ffffff; border: 1px solid #2D7A7A; }
+    .world-banner--6 { background: #ffffff; border: 1px solid #7A5000; }
+    .world-banner--7 { background: #ffffff; border: 1px solid #5050CC; }
+    .world-banner--8 { background: #ffffff; border: 1px solid #CC5500; }
+    .world-banner--9 { background: #ffffff; border: 1px solid #00AA66; }
+    .world-banner--10 { background: #ffffff; border: 1px solid #CC00FF; }
+    .world-banner--11 { background: #ffffff; border: 1px solid #2E8C5A; }
+    .world-banner--12 { background: #ffffff; border: 1px solid #6B3DAA; }
+    .world-banner--13 { background: #ffffff; border: 1px solid #AA8030; }
+    .world-banner--bonus { background: #ffffff; border: 2px solid #B45309; box-shadow: 0 0 12px rgba(180,83,9,0.2); }
 
     .questmap-bonus-section { margin: 24px 0 8px; }
-    .qm-node--bonus { border: 2px solid #FFD700 !important; background: linear-gradient(135deg, #2A2000, #161000) !important; box-shadow: 0 0 14px rgba(255,215,0,0.4) !important; }
+    .qm-node--bonus { border: 2px solid #FFD700 !important; background: #ffffff !important; box-shadow: 0 0 14px rgba(255,215,0,0.4) !important; }
     .qm-node--bonus .qm-node-circle { background: linear-gradient(135deg, #FFD700, #FF8C00) !important; }
 
     .world-banner-icon { font-size: 20px; }
@@ -3010,7 +3009,7 @@
     .celebration-btn {
       margin-top: var(--space-sm);
       padding: 12px 32px;
-      background: linear-gradient(135deg, #7C3AED, #5B21B6);
+      background: linear-gradient(135deg, #4338CA, #6366F1);
       border: none;
       border-radius: var(--radius-full);
       font-family: var(--font-heading);
@@ -3054,13 +3053,13 @@
       align-items: center;
       gap: 6px;
       padding: 6px 12px;
-      background: linear-gradient(135deg, rgba(245,158,11,0.2), rgba(245,158,11,0.05));
-      border: 1px solid rgba(245,158,11,0.4);
+      background: #B45309;
+      border: 1px solid #B45309;
       border-radius: var(--radius-full);
       font-family: var(--font-heading);
       font-size: 12px;
       font-weight: 700;
-      color: #F59E0B;
+      color: #fff;
     }
 
 
@@ -3091,8 +3090,8 @@
 
     /* Greeting banner */
     .home-greeting {
-      background: linear-gradient(135deg, #1A0A3A 0%, #2D1060 60%, #1A0040 100%);
-      border-bottom: 1px solid rgba(124,58,237,0.25);
+      background: #ffffff;
+      border-bottom: 1px solid var(--color-border);
       padding: 20px 20px 16px;
       display: flex;
       align-items: center;
@@ -3111,37 +3110,37 @@
     .home-greeting-hi {
       font-family: var(--font-heading);
       font-size: 15px; font-weight: 700;
-      color: rgba(255,255,255,0.7);
+      color: var(--color-text-muted);
       margin-bottom: 2px;
     }
     .home-greeting-name {
       font-family: var(--font-heading);
       font-size: 22px; font-weight: 900;
-      color: #fff;
+      color: var(--ink-title, #312e81);
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
     }
     .home-streak-badge {
       display: flex; flex-direction: column; align-items: center;
-      background: rgba(245,158,11,0.15);
-      border: 1px solid rgba(245,158,11,0.4);
+      background: #B45309;
+      border: 1px solid #B45309;
       border-radius: 12px;
       padding: 6px 12px;
       flex-shrink: 0;
     }
     .home-streak-num {
       font-family: var(--font-heading);
-      font-size: 22px; font-weight: 900; color: #F59E0B;
+      font-size: 22px; font-weight: 900; color: #fff;
       line-height: 1;
     }
     .home-streak-label {
-      font-size: 9px; font-weight: 700; color: rgba(245,158,11,0.8);
+      font-size: 9px; font-weight: 700; color: rgba(255,255,255,0.85);
       text-transform: uppercase; letter-spacing: 0.5px;
     }
 
     /* Continue CTA */
     .home-continue {
       margin: 16px 16px 0;
-      background: linear-gradient(135deg, #6D28D9, #7C3AED);
+      background: linear-gradient(135deg, #4338CA, #6366F1);
       border-radius: 16px;
       padding: 16px 18px;
       display: flex; align-items: center; gap: 14px;
@@ -3181,7 +3180,7 @@
     }
     .home-stat-card {
       background: var(--color-surface);
-      border: 1px solid rgba(255,255,255,0.06);
+      border: 1px solid var(--color-border);
       border-radius: 12px;
       padding: 10px 6px;
       display: flex; flex-direction: column; align-items: center; gap: 4px;
@@ -3215,7 +3214,7 @@
     }
     .home-nav-card {
       background: var(--color-surface);
-      border: 1px solid rgba(255,255,255,0.07);
+      border: 1px solid var(--color-border);
       border-radius: 14px;
       padding: 14px 14px 12px;
       display: flex; flex-direction: column; align-items: flex-start; gap: 6px;
@@ -3240,7 +3239,7 @@
     }
     .home-song-row {
       background: var(--color-surface);
-      border: 1px solid rgba(255,255,255,0.06);
+      border: 1px solid var(--color-border);
       border-radius: 12px;
       padding: 12px 14px;
       display: flex; align-items: center; gap: 12px;
@@ -3497,7 +3496,7 @@
     .lesson-btn--primary:hover { background: #6D28D9; box-shadow: 0 4px 16px rgba(124,58,237,0.45); }
     .lesson-btn--danger {
       border-color: rgba(239,68,68,0.4);
-      color: #EF4444;
+      color: #B91C1C;
     }
 
     /* ── Back-to-home button ──────────────────────────────────── */
@@ -3519,7 +3518,7 @@
     }
     .lesson-back-home-btn:hover {
       border-color: rgba(239,68,68,0.4);
-      color: #EF4444;
+      color: #B91C1C;
       background: rgba(239,68,68,0.08);
     }
 
@@ -3659,9 +3658,9 @@
     }
     .accuracy-label { color: var(--color-text-muted); }
     .accuracy-value { color: var(--color-text); }
-    .accuracy-value--great  { color: #10B981; }
-    .accuracy-value--good   { color: #F59E0B; }
-    .accuracy-value--keep   { color: #EF4444; }
+    .accuracy-value--great  { color: #059669; }
+    .accuracy-value--good   { color: #B45309; }
+    .accuracy-value--keep   { color: #B91C1C; }
 
     /* ── Metronome ── */
     .metro-btn {
@@ -4392,7 +4391,7 @@
       font-family: var(--font-heading);
       font-size: 16px;
       font-weight: 800;
-      color: #F59E0B;
+      color: #B45309;
     }
 
 
@@ -4724,7 +4723,7 @@
       font-family: var(--font-heading);
       font-size: 10px;
       font-weight: 800;
-      color: #F59E0B;
+      color: #B45309;
       text-align: center;
       white-space: nowrap;
     }
@@ -4837,7 +4836,7 @@
       font-family: var(--font-heading);
       font-size: 12px;
       font-weight: 700;
-      color: #EF4444;
+      color: #B91C1C;
       min-height: 18px;
       transition: opacity 0.3s ease;
     }
@@ -4853,7 +4852,7 @@
       font-family: var(--font-heading);
       font-size: 13px;
       font-weight: 700;
-      color: #F59E0B;
+      color: #B45309;
     }
 
     /* Dashboard shell */
@@ -5211,11 +5210,11 @@
       font-family: var(--font-heading);
       font-size: 12px;
       font-weight: 700;
-      color: #EF4444;
+      color: #B91C1C;
       cursor: pointer;
       transition: background 0.12s, border-color 0.12s;
     }
-    .pm-danger-btn:hover { background: rgba(239,68,68,0.08); border-color: #EF4444; }
+    .pm-danger-btn:hover { background: rgba(239,68,68,0.08); border-color: #B91C1C; }
 
     /* PIN change form */
     .pm-pin-change-form {
@@ -5468,13 +5467,13 @@
     .midi-test-log {
       max-height: 80px;
       overflow-y: auto;
-      background: rgba(0,0,0,0.2);
+      background: #ece9f5;
       border-radius: 6px;
       padding: 6px 8px;
       margin-top: 6px;
       font-size: 10px;
       font-family: monospace;
-      color: #A78BFA;
+      color: #6D28D9;
       line-height: 1.6;
     }
 
@@ -5557,7 +5556,7 @@
     }
     .freeplay-timer.timer--ending {
       border-color: rgba(239,68,68,0.5);
-      color: #EF4444;
+      color: #B91C1C;
       animation: timer-pulse 0.8s ease-in-out infinite;
     }
     @keyframes timer-pulse {
@@ -5672,7 +5671,7 @@ button:focus:not(:focus-visible),
 .btn-secondary {
   transition: background 0.15s, transform 0.12s;
 }
-.btn-secondary:hover  { background: #4B3F72; transform: translateY(-1px); }
+.btn-secondary:hover  { background: var(--color-purple-subtle); transform: translateY(-1px); }
 .btn-secondary:active { transform: translateY(0); }
 
 /* Nav items */
@@ -5703,9 +5702,9 @@ button:focus:not(:focus-visible),
 .settings-opt, .tempo-btn {
   transition: background 0.14s, color 0.14s, border-color 0.14s, transform 0.12s;
 }
-.settings-opt:hover:not(.opt--on)  { background: #2A2040; transform: translateY(-1px); }
+.settings-opt:hover:not(.opt--on)  { background: #ece9f5; transform: translateY(-1px); }
 .settings-opt:active               { transform: translateY(0); }
-.tempo-btn:hover:not(.tempo-btn--active) { background: #2A2040; }
+.tempo-btn:hover:not(.tempo-btn--active) { background: #ece9f5; }
 
 /* ── TROPHY CARD HOVER ────────────────────────────────────── */
 .trophy-card {
@@ -5780,18 +5779,18 @@ button:focus:not(:focus-visible),
 }
 .recital-change-btn {
   padding: 7px 14px;
-  border: 1px solid rgba(255,165,0,0.4);
+  border: 1px solid #C2410C;
   border-radius: 20px;
-  background: rgba(255,165,0,0.1);
+  background: #C2410C;
   font-family: var(--font-heading);
   font-size: 11px;
   font-weight: 700;
-  color: #FFA500;
+  color: #fff;
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;
 }
-.recital-change-btn:hover { background: rgba(255,165,0,0.2); }
+.recital-change-btn:hover { background: #9a3209; }
 
 /* Practice button */
 .recital-practice-btn {
@@ -5799,7 +5798,7 @@ button:focus:not(:focus-visible),
   padding: 16px;
   border: none;
   border-radius: 16px;
-  background: linear-gradient(135deg, #7C3AED, #6D28D9);
+  background: linear-gradient(135deg, #4338CA, #6366F1);
   font-family: var(--font-heading);
   font-size: 16px;
   font-weight: 900;
@@ -5960,7 +5959,7 @@ button:focus:not(:focus-visible),
   position: fixed;
   inset: 0;
   z-index: 2000;
-  background: rgba(10,5,20,0.97);
+  background: #f1f1f4;
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -5973,13 +5972,13 @@ button:focus:not(:focus-visible),
   padding: 14px 20px;
   border-bottom: 1px solid rgba(255,165,0,0.2);
   flex-shrink: 0;
-  background: rgba(20,10,5,0.6);
+  background: #ffffff;
 }
 .recital-session-title {
   font-family: var(--font-heading);
   font-size: 14px;
   font-weight: 900;
-  color: #FFA500;
+  color: #C2410C;
 }
 .recital-session-stats {
   display: flex;
@@ -5988,8 +5987,8 @@ button:focus:not(:focus-visible),
   font-size: 12px;
   font-weight: 700;
 }
-.recital-stat-hit { color: #10B981; }
-.recital-stat-miss { color: #EF4444; }
+.recital-stat-hit { color: #059669; }
+.recital-stat-miss { color: #B91C1C; }
 .recital-stat-acc { color: var(--color-text); }
 .recital-session-body {
   flex: 1;
@@ -6014,10 +6013,10 @@ button:focus:not(:focus-visible),
   border: 1px solid transparent;
   transition: all 0.15s;
 }
-.recital-note-chip.chip-pending { background: rgba(255,255,255,0.05); border-color: rgba(255,255,255,0.1); color: var(--color-text-dim); }
-.recital-note-chip.chip-active { background: rgba(255,165,0,0.2); border-color: #FFA500; color: #FFA500; animation: chip-pulse 0.4s ease infinite alternate; }
-.recital-note-chip.chip-hit { background: rgba(16,185,129,0.15); border-color: #10B981; color: #10B981; }
-.recital-note-chip.chip-miss { background: rgba(239,68,68,0.15); border-color: #EF4444; color: #EF4444; }
+.recital-note-chip.chip-pending { background: #ece9f5; border-color: #e6e6ee; color: var(--color-text-muted); }
+.recital-note-chip.chip-active { background: #C2410C; border-color: #C2410C; color: #fff; animation: chip-pulse 0.4s ease infinite alternate; }
+.recital-note-chip.chip-hit { background: #059669; border-color: #059669; color: #fff; }
+.recital-note-chip.chip-miss { background: #B91C1C; border-color: #B91C1C; color: #fff; }
 @keyframes chip-pulse { from { opacity: 0.7; } to { opacity: 1; } }
 
 .recital-session-result {
@@ -6028,7 +6027,7 @@ button:focus:not(:focus-visible),
   align-items: center;
   justify-content: center;
   gap: 16px;
-  background: rgba(10,5,20,0.95);
+  background: rgba(241,241,244,0.97);
   padding: 20px;
   text-align: center;
 }
@@ -6073,7 +6072,7 @@ button:focus:not(:focus-visible),
 
 /* ── FLASHCARD HOVER ──────────────────────────────────────── */
 .fc-option:hover {
-  background: #2A2040;
+  background: #ece9f5;
   border-color: var(--color-purple);
   transform: scale(1.03);
   transition: all 0.15s;
@@ -6084,7 +6083,7 @@ button:focus:not(:focus-visible),
 #midi-loading-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(13,10,25,0.85);
+  background: rgba(241,241,244,0.9);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -6101,7 +6100,7 @@ button:focus:not(:focus-visible),
 }
 .midi-spinner {
   width: 52px; height: 52px;
-  border: 4px solid #2A2040;
+  border: 4px solid #ece9f5;
   border-top-color: var(--color-purple);
   border-radius: 50%;
   animation: spin 0.9s linear infinite;
@@ -6114,7 +6113,7 @@ button:focus:not(:focus-visible),
   bottom: calc(var(--nav-height) + 10px);
   left: 50%;
   transform: translateX(-50%) translateY(80px);
-  background: #1E1B2E;
+  background: #ffffff;
   border: 1px solid var(--color-purple);
   color: var(--color-text);
   border-radius: 28px;
@@ -6140,7 +6139,7 @@ button:focus:not(:focus-visible),
   top: calc(var(--header-height) + 10px);
   left: 50%;
   transform: translateX(-50%) translateY(-80px);
-  background: #1E1B2E;
+  background: #ffffff;
   border: 1px solid var(--color-gold);
   color: var(--color-text);
   border-radius: 16px;
@@ -6179,7 +6178,7 @@ button:focus:not(:focus-visible),
 #resume-lesson-banner .resume-no {
   flex: 1;
   padding: 8px;
-  background: #2A2040;
+  background: #ece9f5;
   border: none;
   border-radius: 10px;
   color: var(--color-text-muted);
@@ -6207,8 +6206,8 @@ button:focus:not(:focus-visible),
   position: fixed;
   bottom: calc(var(--nav-height) + 12px);
   right: 16px;
-  background: #2A1515;
-  border: 1px solid #EF4444;
+  background: #ffffff;
+  border: 1px solid #B91C1C;
   color: var(--color-text);
   border-radius: 14px;
   padding: 14px 18px;
@@ -6222,7 +6221,7 @@ button:focus:not(:focus-visible),
 #storage-warning-toast.visible { transform: translateY(0); }
 #storage-warning-toast .toast-title {
   font-weight: 700;
-  color: #EF4444;
+  color: #B91C1C;
   margin-bottom: 6px;
   font-size: 14px;
 }
@@ -6243,7 +6242,7 @@ button:focus:not(:focus-visible),
   position: fixed;
   bottom: calc(var(--nav-height) + 12px);
   left: 16px;
-  background: #1E1B2E;
+  background: #ffffff;
   border: 1px solid #F59E0B;
   border-radius: 14px;
   padding: 14px 18px;
@@ -6258,7 +6257,7 @@ button:focus:not(:focus-visible),
 #import-error-toast.visible { transform: translateY(0); }
 #import-error-toast .toast-title {
   font-weight: 700;
-  color: #F59E0B;
+  color: #B45309;
   margin-bottom: 4px;
 }
 
@@ -6266,8 +6265,8 @@ button:focus:not(:focus-visible),
 .sfx-mute-btn {
   width: 36px; height: 36px;
   border-radius: 50%;
-  background: #1E1B2E;
-  border: 1px solid #2A2040;
+  background: #ffffff;
+  border: 1px solid var(--color-border);
   color: var(--color-text-muted);
   display: flex;
   align-items: center;
@@ -6277,8 +6276,8 @@ button:focus:not(:focus-visible),
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
 }
-.sfx-mute-btn:hover    { background: #2A2040; color: var(--color-text); }
-.sfx-mute-btn.muted    { color: #EF4444; }
+.sfx-mute-btn:hover    { background: #ece9f5; color: var(--color-text); }
+.sfx-mute-btn.muted    { color: #B91C1C; }
 
 /* ── CONSISTENT SPACING POLISH ────────────────────────────── */
 .screen-content {
@@ -6290,14 +6289,14 @@ button:focus:not(:focus-visible),
 .lesson-ctrl-btn {
   transition: background 0.12s, transform 0.1s;
 }
-.lesson-ctrl-btn:hover  { background: #2A2040; transform: scale(1.07); }
+.lesson-ctrl-btn:hover  { background: #ece9f5; transform: scale(1.07); }
 .lesson-ctrl-btn:active { transform: scale(0.96); }
 
 /* Pin numpad key polish */
 .pm-pin-key {
   transition: background 0.12s, transform 0.1s;
 }
-.pm-pin-key:hover  { background: #3D3555; }
+.pm-pin-key:hover  { background: #ece9f5; }
 .pm-pin-key:active { transform: scale(0.92); }
 
 /* Precurriculum card hover */

--- a/css/math-galaxy.css
+++ b/css/math-galaxy.css
@@ -141,10 +141,10 @@
     .level-header h1 {
       font-family: var(--font-display);
       font-size: clamp(2rem, 6vw, 2.8rem); font-weight: 800;
-      background: linear-gradient(135deg, var(--blue), var(--cyan), var(--gold));
+      background: none;
       background-size: 200% 200%;
-      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-      background-clip: text; animation: gradShift 5s ease-in-out infinite;
+      -webkit-background-clip: border-box; -webkit-text-fill-color: #312e81;
+      background-clip: border-box; color: #312e81; animation: gradShift 5s ease-in-out infinite;
     }
     @keyframes gradShift { 0%,100% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } }
     .level-header p { color: var(--text-muted); font-weight: 600; margin-top: 6px; font-size: 1rem; }
@@ -180,7 +180,7 @@
       font-family: var(--font-display); font-size: 0.72rem; font-weight: 700;
       background: rgba(251,191,36,0.12); color: var(--gold);
     }
-    .best-badge.empty { opacity: 0.4; color: var(--text-muted); background: rgba(255,255,255,0.04); }
+    .best-badge.empty { opacity: 0.4; color: var(--text-muted); background: #ece9f5; }
 
     /* Recommended level highlight */
     .level-card.recommended { border-color: var(--card-color); box-shadow: 0 0 30px -8px var(--card-glow); }
@@ -321,11 +321,11 @@
        ============================================================ */
     .card-sprint { background: linear-gradient(135deg, rgba(251,191,36,0.08), rgba(239,68,68,0.08)); border-color: rgba(251,191,36,0.3); }
     .card-sprint .rank-icon { animation: pulseIcon 1.4s ease-in-out infinite; }
-    .card-sprint .rank-name { color: #FBBF24; }
+    .card-sprint .rank-name { color: #B45309; }
     .card-words  { background: linear-gradient(135deg, rgba(167,139,250,0.08), rgba(96,165,250,0.08)); border-color: rgba(167,139,250,0.3); }
-    .card-words .rank-name { color: #A78BFA; }
+    .card-words .rank-name { color: #6D28D9; }
     .card-duel  { background: linear-gradient(135deg, rgba(52,211,153,0.10), rgba(96,165,250,0.10)); border-color: rgba(52,211,153,0.3); }
-    .card-duel .rank-name { color: #34D399; }
+    .card-duel .rank-name { color: #059669; }
     @keyframes pulseIcon { 0%,100% { transform: scale(1); } 50% { transform: scale(1.12); } }
 
     .sprint-wrap, .words-wrap, .duel-wrap { display: flex; flex-direction: column; gap: 16px; }
@@ -334,24 +334,24 @@
     .duel-picker { display: grid; grid-template-columns: 1fr auto 1fr; gap: 14px; align-items: center; }
     .duel-side { display: flex; flex-direction: column; gap: 8px; }
     .duel-side-label { font-family: var(--font-display); font-weight: 800; color: var(--text-muted); text-align: center; }
-    .duel-vs { font-family: var(--font-display); font-weight: 800; font-size: 1.4rem; color: #FBBF24; text-align: center; }
+    .duel-vs { font-family: var(--font-display); font-weight: 800; font-size: 1.4rem; color: #B45309; text-align: center; }
     .duel-tiles { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; }
     .duel-tile {
       display: flex; flex-direction: column; align-items: center; gap: 4px;
       padding: 10px 12px; min-width: 78px;
-      background: rgba(255,255,255,0.04);
-      border: 2px solid rgba(255,255,255,0.08);
+      background: #ffffff;
+      border: 2px solid #e6e6ee;
       border-radius: 14px;
       cursor: pointer;
       font-family: var(--font-display);
       transition: transform 0.12s, border-color 0.15s, background 0.15s;
-      color: #F0EDFF;
+      color: #1c1b29;
     }
     .duel-tile:hover { transform: translateY(-2px); }
     .duel-tile.active {
-      border-color: var(--accent, #34D399);
-      background: rgba(52,211,153,0.12);
-      box-shadow: 0 4px 16px -8px var(--accent, #34D399);
+      border-color: var(--accent, #059669);
+      background: #ece9f5;
+      box-shadow: 0 4px 16px -8px var(--accent, #059669);
     }
     .duel-avatar { font-size: 1.5rem; }
     .duel-pname { font-weight: 700; font-size: 0.85rem; }
@@ -361,18 +361,18 @@
     .duel-tables-row { display: flex; flex-wrap: wrap; gap: 6px; justify-content: center; }
     .duel-table-btn {
       padding: 8px 14px; min-width: 52px;
-      background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.1);
+      background: #ffffff;
+      border: 1.5px solid #e6e6ee;
       border-radius: 10px;
-      color: #F0EDFF;
+      color: #1c1b29;
       font-family: var(--font-display);
       font-weight: 800;
       cursor: pointer;
     }
     .duel-table-btn.active {
-      background: rgba(251,191,36,0.18);
-      border-color: #FBBF24;
-      color: #FBBF24;
+      background: #B45309;
+      border-color: #B45309;
+      color: #fff;
     }
 
     .duel-last { text-align: center; color: var(--text-muted); font-weight: 700; font-size: 0.85rem; }
@@ -387,14 +387,14 @@
     .duel-handoff-name {
       font-family: var(--font-display);
       font-weight: 800; font-size: 1.6rem;
-      color: var(--accent, #A78BFA);
+      color: var(--accent, #6D28D9);
       margin-bottom: 4px;
     }
     .duel-handoff-sub { color: var(--text-muted); font-weight: 700; margin-bottom: 22px; }
 
     .duel-winner-line {
       text-align: center; font-family: var(--font-display);
-      font-weight: 800; font-size: 1.4rem; color: #FBBF24;
+      font-weight: 800; font-size: 1.4rem; color: #B45309;
       margin: 8px 0 18px;
     }
     .duel-scoreboard {
@@ -403,13 +403,13 @@
     }
     .duel-score-card {
       padding: 18px 12px; text-align: center;
-      background: rgba(255,255,255,0.03);
-      border: 2px solid var(--accent, #A78BFA);
+      background: #ffffff;
+      border: 2px solid var(--accent, #6D28D9);
       border-radius: 18px;
     }
     .duel-score-emoji { font-size: 2.6rem; }
-    .duel-score-name { font-family: var(--font-display); font-weight: 800; color: var(--accent, #A78BFA); }
-    .duel-score-num { font-family: var(--font-display); font-weight: 800; font-size: 2.6rem; color: #F0EDFF; }
+    .duel-score-name { font-family: var(--font-display); font-weight: 800; color: var(--accent, #6D28D9); }
+    .duel-score-num { font-family: var(--font-display); font-weight: 800; font-size: 2.6rem; color: #1c1b29; }
     .duel-score-sub { color: var(--text-muted); font-weight: 700; font-size: 0.8rem; }
 
     @media (max-width: 480px) {
@@ -429,21 +429,21 @@
     .sprint-header p { color: var(--text-muted); font-weight: 700; width: 100%; text-align: center; margin-top: 4px; }
     .sprint-chip {
       padding: 6px 12px; border-radius: 99px;
-      background: rgba(255,255,255,0.08); font-weight: 800; font-size: 0.85rem;
+      background: #ece9f5; font-weight: 800; font-size: 0.85rem;
       font-family: var(--font-display); color: var(--text);
     }
-    .sprint-chip.correct { background: rgba(52,211,153,0.15); color: #34D399; }
+    .sprint-chip.correct { background: rgba(52,211,153,0.15); color: #059669; }
     .back-btn {
       width: 40px; height: 40px; border-radius: 50%;
-      border: 1.5px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.04);
+      border: 1.5px solid #e6e6ee; background: #ffffff;
       color: var(--text); font-size: 1.2rem; cursor: pointer; transition: all 0.2s;
     }
-    .back-btn:hover { background: rgba(255,255,255,0.1); border-color: rgba(255,255,255,0.25); }
+    .back-btn:hover { background: #ece9f5; border-color: #d6d2ea; }
 
     .sprint-picker { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 10px; }
     .sprint-pick {
-      padding: 16px 10px; background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08); border-radius: 16px;
+      padding: 16px 10px; background: #ffffff;
+      border: 1.5px solid #e6e6ee; border-radius: 16px;
       color: var(--text); cursor: pointer; transition: all 0.2s;
       font-family: var(--font-body);
     }
@@ -452,9 +452,9 @@
     .sprint-pick-best { font-size: 0.75rem; color: var(--text-muted); margin-top: 4px; font-weight: 700; }
 
     .sprint-mixed {
-      padding: 14px 16px; background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(239,68,68,0.08));
+      padding: 14px 16px; background: #ffffff;
       border: 1.5px solid rgba(251,191,36,0.35); border-radius: 16px;
-      text-align: center; font-weight: 800; color: #FBBF24; font-size: 1rem;
+      text-align: center; font-weight: 800; color: #B45309; font-size: 1rem;
       transition: all 0.2s;
     }
     .sprint-mixed:hover { transform: translateY(-2px); }
@@ -462,15 +462,15 @@
 
     .sprint-question {
       padding: 36px 20px;
-      background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08); border-radius: 24px;
+      background: #ffffff;
+      border: 1.5px solid #e6e6ee; border-radius: 24px;
       text-align: center;
     }
     .sprint-q-text { font-family: var(--font-display); font-size: 3rem; font-weight: 800; margin-bottom: 20px; }
     .sprint-input {
       width: 160px; padding: 14px 12px; border-radius: 16px;
-      border: 2px solid rgba(255,255,255,0.15); background: rgba(0,0,0,0.3);
-      color: #fff; font-family: var(--font-display); font-size: 2rem; font-weight: 800;
+      border: 2px solid #d6d2ea; background: #ece9f5;
+      color: #1c1b29; font-family: var(--font-display); font-size: 2rem; font-weight: 800;
       text-align: center; outline: none; transition: border-color 0.2s;
     }
     .sprint-input:focus { border-color: #FBBF24; }
@@ -498,10 +498,10 @@
 
     .sprint-result {
       padding: 32px 20px; text-align: center;
-      background: rgba(255,255,255,0.04);
+      background: #ffffff;
       border: 1.5px solid rgba(251,191,36,0.3); border-radius: 24px;
     }
-    .sprint-result-num { font-family: var(--font-display); font-size: 4rem; font-weight: 800; color: #FBBF24; line-height: 1; }
+    .sprint-result-num { font-family: var(--font-display); font-size: 4rem; font-weight: 800; color: #B45309; line-height: 1; }
     .sprint-result-label { color: var(--text); font-weight: 700; margin-top: 8px; }
     .sprint-result-sub  { color: var(--text-muted); font-size: 0.85rem; font-weight: 700; margin-top: 6px; }
     .sprint-result-best { margin-top: 12px; font-size: 0.85rem; color: var(--text-muted); font-weight: 700; }
@@ -509,8 +509,8 @@
 
     .words-tiers { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; }
     .words-tier {
-      padding: 20px 14px; background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08); border-radius: 18px;
+      padding: 20px 14px; background: #ffffff;
+      border: 1.5px solid #e6e6ee; border-radius: 18px;
       text-align: center; cursor: pointer; transition: all 0.2s;
       color: var(--text); font-family: var(--font-body);
     }
@@ -518,30 +518,30 @@
     .words-tier-icon { font-size: 1.8rem; }
     .words-tier-name { font-family: var(--font-display); font-size: 1.05rem; font-weight: 800; margin-top: 4px; }
     .words-tier-ages { font-size: 0.72rem; color: var(--text-muted); font-weight: 700; }
-    .words-tier-best { font-size: 0.78rem; color: #FBBF24; margin-top: 6px; font-weight: 700; }
+    .words-tier-best { font-size: 0.78rem; color: #B45309; margin-top: 6px; font-weight: 700; }
     .words-lang {
       position: absolute; right: 0; top: 8px;
       padding: 4px 12px; border-radius: 99px;
-      background: rgba(255,255,255,0.06); border: 1px solid rgba(255,255,255,0.1);
+      background: #ece9f5; border: 1px solid #e6e6ee;
       font-size: 0.75rem; font-weight: 700; cursor: pointer;
     }
 
     .words-q {
-      padding: 22px 18px; background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.08); border-radius: 16px;
+      padding: 22px 18px; background: #ffffff;
+      border: 1.5px solid #e6e6ee; border-radius: 16px;
       font-size: 1.1rem; line-height: 1.5; font-weight: 700;
     }
     .words-options { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
     .words-opt {
       padding: 16px 12px; border-radius: 14px;
-      background: rgba(255,255,255,0.05); border: 1.5px solid rgba(255,255,255,0.1);
+      background: #ffffff; border: 1.5px solid #e6e6ee;
       color: var(--text); font-family: var(--font-display); font-size: 1.1rem; font-weight: 800;
       cursor: pointer; transition: all 0.15s;
     }
-    .words-opt:hover:not(:disabled) { transform: translateY(-2px); border-color: #A78BFA; }
+    .words-opt:hover:not(:disabled) { transform: translateY(-2px); border-color: #6D28D9; }
     .words-opt:disabled { opacity: 0.6; cursor: default; }
-    .words-opt.right { background: rgba(52,211,153,0.18); border-color: #34D399; color: #D1FAE5; }
-    .words-opt.wrong { background: rgba(248,113,113,0.15); border-color: #F87171; color: #FECACA; }
+    .words-opt.right { background: rgba(52,211,153,0.18); border-color: #059669; color: #065F46; }
+    .words-opt.wrong { background: rgba(248,113,113,0.15); border-color: #B91C1C; color: #991B1B; }
 
     @media (max-width: 480px) {
       .words-options { grid-template-columns: 1fr; }

--- a/css/menu.css
+++ b/css/menu.css
@@ -11,11 +11,8 @@
   font-family: var(--font-display);
   font-size: clamp(1.8rem, 5vw, 2.4rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #F87171, #FBBF24, #34D399);
+  background:none; -webkit-text-fill-color:#312e81; background-clip:border-box; -webkit-background-clip:border-box; color:#312e81;
   background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
   animation: gradShift 6s ease-in-out infinite;
 }
 .mn-header p {
@@ -35,26 +32,25 @@
 .mn-toolbar button {
   padding: 8px 14px;
   border-radius: 99px;
-  border: 1.5px solid rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.04);
+  border: 1.5px solid #e6e6ee;
+  background: #ffffff;
   color: var(--text);
   font-weight: 700;
   font-size: 0.82rem;
   cursor: pointer;
   transition: all 0.15s;
 }
-.mn-toolbar button:hover { border-color: #FBBF24; color: #FBBF24; }
+.mn-toolbar button:hover { border-color: #B45309; color: #B45309; }
 .mn-toolbar .mn-tb-lock {
-  background: linear-gradient(135deg, rgba(167,139,250,0.15), rgba(96,165,250,0.12));
-  border-color: rgba(167,139,250,0.3);
-  color: #A78BFA;
+  color:#fff; background:#6D28D9;
+  border-color: #6D28D9;
 }
 
 .mn-today {
   padding: 16px;
   margin-bottom: 20px;
-  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(239,68,68,0.08));
-  border: 1.5px solid rgba(251,191,36,0.3);
+  background: #ffffff;
+  border: 1.5px solid #B45309;
   border-radius: 16px;
   text-align: center;
   animation: fadeUp 0.5s ease-out both;
@@ -62,7 +58,7 @@
 .mn-today-label {
   font-size: 0.75rem;
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   margin-bottom: 4px;
@@ -91,12 +87,12 @@
 .mn-day {
   padding: 12px 14px;
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.06);
+  border: 1.5px solid #e6e6ee;
   border-radius: 14px;
 }
 .mn-day.today {
-  border-color: rgba(251,191,36,0.35);
-  background: linear-gradient(180deg, rgba(251,191,36,0.06), rgba(255,255,255,0.02));
+  border-color: #B45309;
+  background: #ffffff;
 }
 .mn-day-head {
   display: flex;
@@ -114,7 +110,7 @@
   color: var(--text-muted);
   font-weight: 700;
 }
-.mn-day.today .mn-day-name { color: #FBBF24; }
+.mn-day.today .mn-day-name { color: #B45309; }
 
 .mn-meals {
   display: grid;
@@ -123,8 +119,8 @@
 }
 .mn-meal {
   padding: 8px 10px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.05);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 10px;
 }
 .mn-meal-label {
@@ -150,7 +146,7 @@
 }
 .mn-meal input::placeholder { color: var(--text-muted); font-weight: 500; opacity: 0.6; }
 .mn-meal input:focus {
-  background: rgba(251,191,36,0.05);
+  background: #ece9f5;
   border-radius: 6px;
 }
 .mn-meal.read-only input {
@@ -171,7 +167,7 @@
 .mn-modal-panel {
   max-width: 420px; width: 100%;
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.1);
+  border: 1.5px solid #e6e6ee;
   border-radius: 18px;
   padding: 20px 22px;
 }
@@ -186,8 +182,8 @@
   min-height: 160px;
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid rgba(255,255,255,0.1);
-  background: rgba(0,0,0,0.2);
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
   color: var(--text);
   font-family: var(--font-body);
   font-size: 0.9rem;
@@ -209,8 +205,8 @@
   font-size: 0.85rem;
   cursor: pointer;
 }
-.mn-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
-.mn-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); }
+.mn-btn-primary { background:linear-gradient(135deg,#4338CA,#6366F1); color:#fff; }
+.mn-btn-secondary { background: #ffffff; color: var(--text); }
 
 @media (max-width: 640px) {
   .mn-meals { grid-template-columns: 1fr; }

--- a/css/money-master.css
+++ b/css/money-master.css
@@ -18,13 +18,10 @@
   font-family: var(--font-display);
   font-size: clamp(1.8rem, 4.5vw, 2.4rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #34D399, #FBBF24);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background:none; -webkit-text-fill-color:#312e81; background-clip:border-box; -webkit-background-clip:border-box; color:#312e81;
 }
 .mm-header p {
-  color: var(--text-muted, #8B86B0);
+  color: var(--text-muted, #6b6878);
   font-weight: 600;
   margin-top: 4px;
 }
@@ -39,9 +36,9 @@
 .mm-currency button {
   min-width: 130px;
   padding: 12px 18px;
-  background: rgba(255,255,255,0.04);
-  border: 2px solid rgba(255,255,255,0.08);
-  color: #F0EDFF;
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
+  color: #1c1b29;
   border-radius: 14px;
   font-family: var(--font-display);
   font-weight: 800;
@@ -51,8 +48,8 @@
 }
 .mm-currency button:hover { transform: translateY(-2px); }
 .mm-currency button.active {
-  background: rgba(16,185,129,0.18);
-  border-color: #34D399;
+  background: #059669;
+  border-color: #059669;
   color: #fff;
 }
 
@@ -65,8 +62,8 @@
 .mm-mode-card {
   position: relative;
   padding: 22px 18px;
-  background: rgba(255,255,255,0.03);
-  border: 2px solid rgba(16,185,129,0.18);
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
   border-radius: 20px;
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
@@ -86,20 +83,20 @@
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 1.1rem;
-  color: #F0EDFF;
+  color: #1c1b29;
   margin-bottom: 4px;
 }
 .mm-mode-desc {
   font-size: 0.82rem;
   font-weight: 600;
-  color: var(--text-muted, #8B86B0);
+  color: var(--text-muted, #6b6878);
   line-height: 1.35;
 }
 .mm-mode-best {
   margin-top: 10px;
   font-size: 0.78rem;
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
 }
 
 /* Game screen */
@@ -115,9 +112,9 @@
   gap: 10px;
 }
 .mm-back-btn {
-  background: rgba(255,255,255,0.06);
-  border: 1px solid rgba(255,255,255,0.1);
-  color: #F0EDFF;
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
+  color: #1c1b29;
   width: 38px; height: 38px;
   border-radius: 50%;
   font-size: 1.2rem;
@@ -126,7 +123,7 @@
 .mm-progress {
   flex: 1;
   height: 8px;
-  background: rgba(255,255,255,0.06);
+  background: #ece9f5;
   border-radius: 99px;
   overflow: hidden;
 }
@@ -138,12 +135,12 @@
 .mm-score {
   font-family: var(--font-display);
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
 }
 
 .mm-question-card {
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.08);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 22px;
   padding: 24px 18px;
   text-align: center;
@@ -152,7 +149,7 @@
 .mm-q-prompt {
   font-size: 0.85rem;
   font-weight: 700;
-  color: var(--text-muted, #8B86B0);
+  color: var(--text-muted, #6b6878);
   margin-bottom: 10px;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -169,7 +166,7 @@
   font-family: var(--font-display);
   font-size: clamp(1.4rem, 4vw, 2rem);
   font-weight: 800;
-  color: #F0EDFF;
+  color: #1c1b29;
 }
 
 .mm-coin {
@@ -238,9 +235,9 @@
 }
 .mm-option {
   padding: 16px 12px;
-  background: rgba(255,255,255,0.04);
-  border: 2px solid rgba(255,255,255,0.08);
-  color: #F0EDFF;
+  background: #ffffff;
+  border: 2px solid #e6e6ee;
+  color: #1c1b29;
   border-radius: 14px;
   font-family: var(--font-display);
   font-weight: 800;
@@ -250,8 +247,8 @@
   text-align: center;
 }
 .mm-option:hover { transform: translateY(-2px); border-color: #34D399; }
-.mm-option.correct { background: rgba(16,185,129,0.22); border-color: #10B981; }
-.mm-option.wrong   { background: rgba(239,68,68,0.18); border-color: #EF4444; }
+.mm-option.correct { background: #059669; border-color: #059669; color: #fff; }
+.mm-option.wrong   { background: #B91C1C; border-color: #B91C1C; color: #fff; }
 .mm-option:disabled { cursor: default; }
 
 .mm-hint {
@@ -278,10 +275,7 @@
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 1.8rem;
-  background: linear-gradient(135deg, #34D399, #FBBF24);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background:none; -webkit-text-fill-color:#312e81; background-clip:border-box; -webkit-background-clip:border-box; color:#312e81;
   margin-bottom: 6px;
 }
 .mm-results-sub {
@@ -313,14 +307,14 @@
 }
 .mm-btn:hover { transform: translateY(-2px); }
 .mm-btn-primary {
-  background: linear-gradient(135deg, #10B981, #34D399);
+  background: linear-gradient(135deg,#4338CA,#6366F1);
   color: #fff;
-  box-shadow: 0 6px 20px -6px rgba(16,185,129,0.5);
+  box-shadow: 0 6px 20px -6px rgba(67,56,202,0.5);
 }
 .mm-btn-secondary {
-  background: rgba(255,255,255,0.05);
-  border: 1px solid rgba(255,255,255,0.1);
-  color: #F0EDFF;
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
+  color: #1c1b29;
 }
 
 @media (max-width: 480px) {

--- a/css/quest-adventure.css
+++ b/css/quest-adventure.css
@@ -6,8 +6,8 @@
 :root {
   --quest-accent: #F59E0B;
   --quest-glow: rgba(245, 158, 11, 0.3);
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -66,7 +66,7 @@ body {
   padding: 16px; margin-bottom: 40px; text-align: center;
 }
 .quest-ep-label { font-weight: 800; font-size: 1.1rem; margin-bottom: 10px; color: var(--quest-accent); }
-.quest-ep-track { height: 10px; background: rgba(255,255,255,0.06); border-radius: 99px; overflow: hidden; }
+.quest-ep-track { height: 10px; background: #ece9f5; border-radius: 99px; overflow: hidden; }
 .quest-ep-fill { height: 100%; background: linear-gradient(90deg, #F59E0B, #FBBF24); border-radius: 99px; transition: width 1s ease-out; }
 
 /* Nodes & Connectors */
@@ -77,14 +77,14 @@ body {
   position: relative; cursor: pointer; transition: all 0.3s ease;
   z-index: 2; margin: 20px 0;
 }
-.quest-node.unlocked { background: rgba(245, 158, 11, 0.1); border-color: var(--quest-accent); box-shadow: 0 0 20px var(--quest-glow); }
+.quest-node.unlocked { background: #B45309; color: #fff; border-color: var(--quest-accent); box-shadow: 0 0 20px var(--quest-glow); }
 .quest-node.locked { opacity: 0.6; cursor: not-allowed; }
-.quest-node.current { border-color: #fff; animation: pulse 2s infinite; }
+.quest-node.current { border-color: #4338CA; animation: pulse 2s infinite; }
 
 @keyframes pulse {
-  0% { box-shadow: 0 0 0 0 rgba(255,255,255,0.4); }
-  70% { box-shadow: 0 0 0 15px rgba(255,255,255,0); }
-  100% { box-shadow: 0 0 0 0 rgba(255,255,255,0); }
+  0% { box-shadow: 0 0 0 0 rgba(67,56,202,0.45); }
+  70% { box-shadow: 0 0 0 15px rgba(67,56,202,0); }
+  100% { box-shadow: 0 0 0 0 rgba(67,56,202,0); }
 }
 
 .quest-node-icon { font-size: 2rem; }
@@ -115,46 +115,46 @@ body {
 .quest-detail-card h2 { font-family: var(--font-display); font-size: 2rem; font-weight: 800; margin-bottom: 12px; color: var(--quest-accent); }
 .quest-detail-card p { font-size: 1.1rem; font-weight: 600; line-height: 1.5; color: var(--text-primary); margin-bottom: 24px; }
 
-.quest-reward { background: rgba(245, 158, 11, 0.1); border-radius: 20px; padding: 20px; margin-bottom: 32px; text-align: left; border: 1px dashed var(--quest-accent); }
-.reward-label { font-size: 0.8rem; font-weight: 800; text-transform: uppercase; color: var(--quest-accent); margin-bottom: 6px; }
-.reward-text { font-size: 1rem; font-weight: 700; line-height: 1.4; color: var(--text-primary); }
+.quest-reward { background: #B45309; border-radius: 20px; padding: 20px; margin-bottom: 32px; text-align: left; border: 1px dashed var(--quest-accent); }
+.reward-label { font-size: 0.8rem; font-weight: 800; text-transform: uppercase; color: #fff; margin-bottom: 6px; }
+.reward-text { font-size: 1rem; font-weight: 700; line-height: 1.4; color: #fff; }
 
 .action-btn {
   padding: 16px 32px; border-radius: var(--radius-sm); font-family: var(--font-body);
   font-weight: 800; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease;
   border: none; width: 100%;
 }
-.btn-secondary { background: rgba(255,255,255,0.08); color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
+.btn-secondary { background: #ffffff; color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
 
 /* ============================================================
    SEASONAL GRAND TOURS
    ============================================================ */
 .quest-tour {
-  background: rgba(255,255,255,0.03);
-  border: 1.5px solid rgba(255,255,255,0.08);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   border-radius: 16px;
   padding: 16px 18px;
   margin: 18px 0;
 }
 .quest-tour.current {
-  background: linear-gradient(135deg, rgba(251,191,36,0.1), rgba(167,139,250,0.06));
-  border-color: rgba(251,191,36,0.35);
+  background: linear-gradient(135deg, rgba(180,83,9,0.08), rgba(109,40,217,0.05));
+  border-color: #B45309;
 }
 .quest-tour.done {
-  background: linear-gradient(135deg, rgba(52,211,153,0.1), rgba(251,191,36,0.06));
-  border-color: rgba(52,211,153,0.35);
+  background: linear-gradient(135deg, rgba(5,150,105,0.08), rgba(180,83,9,0.05));
+  border-color: #059669;
 }
 .quest-tour-head {
   font-family: var(--font-display, 'Baloo 2');
   font-weight: 800;
   font-size: 1.15rem;
-  color: var(--text-primary, #F0EDFF);
+  color: var(--text-primary, #1c1b29);
   margin-bottom: 6px;
 }
-.quest-tour.current .quest-tour-head { color: #FBBF24; }
+.quest-tour.current .quest-tour-head { color: #B45309; }
 .quest-tour-desc {
   font-size: 0.85rem;
-  color: var(--text-muted, #8B86B0);
+  color: var(--text-muted, #6b6878);
   font-weight: 600;
   line-height: 1.4;
   margin-bottom: 12px;
@@ -166,7 +166,7 @@ body {
 }
 .quest-goal {
   padding: 10px 12px;
-  background: rgba(0,0,0,0.18);
+  background: #ece9f5;
   border-radius: 10px;
 }
 .quest-goal-head {
@@ -176,19 +176,19 @@ body {
   gap: 10px;
   font-weight: 700;
   font-size: 0.85rem;
-  color: var(--text-primary, #F0EDFF);
+  color: var(--text-primary, #1c1b29);
 }
 .quest-goal-num {
   font-family: var(--font-display, 'Baloo 2');
   font-weight: 800;
-  color: #FBBF24;
+  color: #B45309;
   font-size: 0.9rem;
   white-space: nowrap;
 }
 .quest-goal-bar {
   margin-top: 6px;
   height: 6px;
-  background: rgba(255,255,255,0.06);
+  background: #ece9f5;
   border-radius: 99px;
   overflow: hidden;
 }
@@ -201,24 +201,24 @@ body {
 .quest-tour-done {
   margin-top: 10px;
   padding: 8px 12px;
-  background: rgba(52,211,153,0.1);
-  border: 1px solid rgba(52,211,153,0.28);
+  background: #059669;
+  border: 1px solid #059669;
   border-radius: 10px;
   font-weight: 700;
   font-size: 0.82rem;
-  color: #34D399;
+  color: #fff;
   text-align: center;
 }
 .quest-tours-browse {
   margin-top: 20px;
   padding-top: 16px;
-  border-top: 1px dashed rgba(255,255,255,0.08);
+  border-top: 1px dashed #e6e6ee;
 }
 .quest-tours-head {
   font-family: var(--font-display, 'Baloo 2');
   font-weight: 800;
   font-size: 1rem;
-  color: var(--text-muted, #8B86B0);
+  color: var(--text-muted, #6b6878);
   margin-bottom: 4px;
   letter-spacing: 0.04em;
   text-transform: uppercase;

--- a/css/redesign.css
+++ b/css/redesign.css
@@ -1,0 +1,345 @@
+/* ================================================================
+   ZAVALA SERRA — LIGHT REDESIGN (2026)
+   Layered LAST on index.html + family.html only, so the 25 sub-apps
+   keep their dark theme untouched. Light-grey screen, white modules,
+   solid saturated pills, option-C app cards, no rainbow gradients.
+   ================================================================ */
+
+/* ---------- Tokens (scoped to these two pages) ---------- */
+:root {
+  --bg-deep:    #f1f1f4;   /* screen / grey backdrop */
+  --bg-surface: #ffffff;   /* modules */
+  --bg-card:    #ffffff;
+  --border-subtle: #e6e6ee;
+  --text-primary: #1c1b29;
+  --text:         #1c1b29;
+  --text-muted:   #6b6878;
+  --ink-title:    #312e81;  /* solid title color (replaces rainbow) */
+  --mod-shadow: 0 4px 14px rgba(15,15,25,0.08);
+}
+
+/* ---------- Background: kill dark starfield + aurora ---------- */
+body { background: var(--bg-deep) !important; color: var(--text-primary) !important; }
+body::before { display: none !important; }
+.aurora { display: none !important; }
+
+/* ================================================================
+   HEADERS / HERO  — solid ink titles, no gradient
+   ================================================================ */
+.header h1,
+.login-hero h1 {
+  background: none !important;
+  -webkit-text-fill-color: var(--ink-title) !important;
+  background-clip: border-box !important;
+  -webkit-background-clip: border-box !important;
+  color: var(--ink-title) !important;
+  animation: none !important;
+}
+.header p, .login-hero p { color: var(--text-muted); }
+
+/* ================================================================
+   USER BAR  — white module + solid status pills
+   ================================================================ */
+.user-bar {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--mod-shadow);
+}
+.user-bar-name { color: var(--text-primary); }
+.user-bar-greeting { color: var(--text-muted); }
+
+#timer-display {
+  background: #2563EB !important;
+  color: #ffffff !important;
+}
+#timer-display.timer-low { background: #DC2626 !important; color:#fff !important; }
+#token-balance {
+  background: #B45309 !important;
+  color: #ffffff !important;
+}
+.switch-btn {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+}
+.switch-btn:hover {
+  border-color: #c9c5e0;
+  color: var(--text-primary);
+  background: #faf9fd;
+}
+
+/* ================================================================
+   SCHEDULE BANNER + WIDGETS  — white modules
+   ================================================================ */
+#schedule-banner {
+  background: #ffffff !important;
+  border: 1px solid var(--border-subtle) !important;
+  box-shadow: var(--mod-shadow);
+}
+#schedule-day { color: var(--ink-title) !important; }
+#schedule-theme { color: var(--text-muted) !important; }
+
+.fcal-widget {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--mod-shadow);
+}
+.fcal-w-empty, .fcal-w-when { color: var(--text-muted); }
+
+/* ================================================================
+   APP GRID  — option C: bold colored header + white body
+   ================================================================ */
+.app-card {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  border-radius: 20px;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  box-shadow: var(--mod-shadow);
+}
+.app-card::before { display: none !important; }
+.app-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--border-subtle);
+  box-shadow: 0 18px 40px -16px var(--card-glow, rgba(20,18,40,0.25));
+}
+
+/* icon tile -> full-width colored header band (keeps per-card --card-icon-bg) */
+.card-icon {
+  width: 100%;
+  height: 94px;
+  border-radius: 0;
+  font-size: 44px;
+  box-shadow: none;
+}
+.app-card:hover .card-icon { transform: none; }
+
+.card-title { padding: 15px 20px 0; color: var(--text-primary); }
+.card-desc  { padding: 6px 20px 0; color: var(--text-muted); }
+.card-stats { padding: 10px 20px 0; color: var(--text-muted); }
+.card-stats:empty { display: none; }
+.card-stats .cs-item { background: #f0eef7; color: var(--text-muted); }
+.card-stats .cs-item.active { background: rgba(180,83,9,0.12); color: #B45309; }
+
+/* tag -> solid saturated chip using the card's own gradient */
+.card-tag {
+  margin: 14px 20px 18px;
+  background: var(--card-icon-bg) !important;
+  color: #ffffff !important;
+}
+
+/* ================================================================
+   LOGIN  — white profile cards on grey, solid stat chips
+   ================================================================ */
+.profile-card {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--mod-shadow);
+}
+.profile-card:hover {
+  border-color: #d6d2ea;
+  box-shadow: 0 18px 44px -18px rgba(67,56,202,0.30);
+}
+.profile-name { color: var(--text-primary); }
+.profile-age  { color: var(--text-muted); }
+
+.profile-card.add-card {
+  background: #f7f6fc;
+  border: 1.5px dashed #cfcbe2;
+}
+.profile-card.add-card:hover { background:#f1eff9; border-color:#a99fe0; box-shadow:none; }
+.add-icon {
+  background: #f0eef7;
+  color: var(--text-muted);
+  border: 2px dashed #cfcbe2;
+}
+.add-label { color: var(--text-muted); }
+.guest-card { background:#eef4ff !important; border-color:#bcd4ff !important; }
+
+.profile-edit-btn {
+  background: #f0eef7;
+  border: 1.5px solid #ddd8ee;
+}
+.profile-edit-btn:hover { background:#e6e1f6; border-color:#c4bce6; }
+
+/* ================================================================
+   PARENT ACCESS BUTTONS  — clean light pills
+   ================================================================ */
+.parent-btn {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  color: #3a3850;
+  box-shadow: 0 2px 6px rgba(15,15,25,0.05);
+}
+.parent-btn:hover {
+  border-color: #c9c5e0;
+  color: var(--text-primary);
+  background: #faf9fd;
+}
+
+/* ================================================================
+   MODALS  — white sheets, light inputs
+   ================================================================ */
+.modal { background: #ffffff; border: 1px solid var(--border-subtle); }
+.modal h2 { color: var(--text-primary); }
+.modal-field label { color: var(--text-muted); }
+.modal-field input,
+#pin-input {
+  background: #f4f3f8;
+  border: 2px solid #e2def0;
+  color: var(--text-primary);
+}
+.modal-field input:focus, #pin-input:focus { border-color: #6D28D9; }
+.emoji-option, .age-option, .color-option {
+  background: #f4f3f8;
+  border-color: #e2def0;
+}
+.age-option { color: var(--text-muted); }
+.age-option.selected, .emoji-option.selected {
+  border-color: #6D28D9; background:#efeafb; color:#6D28D9;
+  box-shadow: 0 0 0 3px rgba(109,40,217,0.12);
+}
+.btn-cancel { background:#eceaf3; color:#3a3850; }
+.btn-cancel:hover { background:#e2dff0; color:var(--text-primary); }
+.btn-create {
+  background: linear-gradient(135deg,#4338CA,#6366F1);
+  box-shadow: 0 4px 16px -4px rgba(67,56,202,0.5);
+}
+.hub-action-btn {
+  background: linear-gradient(135deg,#4338CA,#6366F1);
+  box-shadow: 0 4px 16px -4px rgba(67,56,202,0.5);
+}
+.hub-action-btn.secondary {
+  background:#eceaf3; color:#3a3850; border:1px solid var(--border-subtle);
+}
+.hub-action-btn.secondary:hover { background:#e2dff0; color:var(--text-primary); border-color:#c9c5e0; }
+.edit-preview { border-bottom-color: var(--border-subtle); }
+.edit-preview-name { color: var(--text-primary); }
+.edit-actions { border-top-color: var(--border-subtle); }
+
+/* ================================================================
+   DASHBOARD / PARENTS CORNER SHELL  — grey panel, white modules
+   (chart widgets are added in Phase 2 via JS)
+   ================================================================ */
+.dash-panel {
+  background: #f1f1f4;
+  border: 1px solid #e2e2e6;
+}
+.dash-panel h2 { color: var(--text-primary); }
+.dash-close { background:#ffffff; border:1px solid var(--border-subtle); color:var(--text-muted); }
+.dash-close:hover { color:var(--text-primary); border-color:#c9c5e0; }
+
+.dash-kid, .dash-profile {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--mod-shadow);
+}
+.dash-kid-name, .dash-name { color: var(--text-primary); }
+.dash-kid-age, .dash-age { color: var(--text-muted); }
+.dash-app-row { border-top-color: #eceaf3; }
+.dash-app-stat { color: var(--text-muted); }
+.dash-bar-wrap { background: #ece9f5; }
+
+.ins-card { background:#ffffff; border:1px solid var(--border-subtle); box-shadow:var(--mod-shadow); }
+.ins-name { color: var(--text-primary); }
+.ins-bar { background:#ece9f5; }
+.ins-legend { color: var(--text-muted); }
+.ins-stats { color: var(--text-muted); border-top-color:#eceaf3; }
+.ins-nudges { border-top-color:#eceaf3; }
+.ins-nudge {
+  background: rgba(67,56,202,0.06);
+  border: 1px solid rgba(67,56,202,0.18);
+  color: #2a2840;
+}
+
+.tokens-summary { background:#ffffff; border:1px solid rgba(180,83,9,0.25); }
+.chore-item { background:#ffffff; border:1px solid var(--border-subtle); }
+.chore-item:hover { background:#faf9fd; border-color:#d6d2ea; }
+.chore-label { color: var(--text-primary); }
+.parent-kid-card { background:#ffffff; border:1px solid var(--border-subtle); box-shadow:var(--mod-shadow); }
+.pk-name { color: var(--text-primary); }
+.pk-setting label { color: var(--text-muted); }
+.a11y-scale-btn { background:#f4f3f8; border:1px solid #e2def0; color:var(--text-primary); }
+.a11y-scale-btn.active { background:rgba(109,40,217,0.14); border-color:#6D28D9; color:#6D28D9; }
+
+/* ================================================================
+   FAMILY WALL  (family.html) — light bento
+   ================================================================ */
+:root {
+  --fw-bg: #f1f1f4;
+  --fw-card: #ffffff;
+  --fw-card-strong: #f4f3f8;
+  --fw-border: #e6e6ee;
+  --fw-text: #1c1b29;
+  --fw-muted: #6b6878;
+}
+body { background: var(--fw-bg) !important; }
+#fw-root { color: var(--fw-text); }
+
+.fw-back { background:#ffffff; border:1px solid var(--fw-border); color:var(--fw-text); box-shadow:0 2px 6px rgba(15,15,25,0.05); }
+.fw-back:hover { background:#faf9fd; }
+.fw-avatar { background:#ffffff; }
+.fw-avatar-name { color: var(--fw-muted); }
+.fw-date {
+  background: none !important;
+  -webkit-text-fill-color: var(--ink-title) !important;
+  -webkit-background-clip: border-box !important;
+  background-clip: border-box !important;
+  color: var(--ink-title) !important;
+}
+.fw-greeting { color: var(--fw-muted); }
+
+.fw-card {
+  background: #ffffff;
+  border: 1px solid var(--fw-border);
+  box-shadow: var(--mod-shadow);
+}
+.fw-card-empty { color: var(--fw-muted); }
+.fw-weather-meta { color: var(--fw-muted); }
+.fw-weather-cta { color: var(--fw-muted); }
+
+.fw-routines-head > div { color: var(--fw-muted); border-bottom-color: var(--fw-border); }
+.fw-r-kid-avatar { background:#f4f3f8; }
+.fw-r-section { background:#f6f5fb; }
+.fw-r-section-label { color: var(--fw-muted); }
+.fw-r-task {
+  background:#f4f3f8;
+  border:1px solid var(--fw-border);
+  color: var(--fw-text);
+}
+.fw-r-task:hover { background:#ece9f5; }
+.fw-r-task.done {
+  background:#0D9488;          /* solid teal "done" */
+  border-color:#0D9488;
+  color:#ffffff;
+  text-decoration-color: rgba(255,255,255,0.6);
+}
+.fw-r-task.done .fw-r-check { background:#ffffff; border-color:#ffffff; color:#0D9488; }
+.fw-r-check { border-color: var(--fw-muted); }
+.fw-r-empty, .fw-week-empty, .fw-week-day-date { color: var(--fw-muted); }
+
+.fw-event-row, .fw-menu-row, .fw-shop-row, .fw-week-day { border-bottom-color: var(--fw-border); }
+.fw-when, .fw-menu-meal { color: var(--fw-muted); }
+.fw-menu-text.empty { color: var(--fw-muted); }
+.fw-shop-row .fw-shop-cat { color: var(--fw-muted); }
+.fw-shop-more { color: var(--fw-muted); }
+
+.fw-quick a {
+  background:#f4f3f8;
+  border:1px solid var(--fw-border);
+  color: var(--fw-text);
+}
+.fw-quick a:hover { transform:translateY(-2px); border-color:#c9c5e0; }
+
+.fw-weather-suggest { background:#eef4ff; border-left-color:#2563EB; }
+.fw-weather-suggest.warm { background:#fff7e6; border-left-color:#B45309; }
+.fw-weather-suggest .when { color: var(--fw-muted); }
+
+.fw-modal-card { background:#ffffff; border:1px solid var(--fw-border); }
+.fw-modal-card p, .fw-or, .fw-loc-empty { color: var(--fw-muted); }
+.fw-loc-search input, .fw-loc-result, .fw-loc-city { background:#f4f3f8; border:1px solid var(--fw-border); color:var(--fw-text); }
+.fw-btn { border:1px solid var(--fw-border); }
+.fw-btn-primary { background:linear-gradient(135deg,#4338CA,#6366F1); border-color:transparent; }
+.fw-btn-ghost { background:transparent; color:var(--fw-text); }
+.fw-week-body::-webkit-scrollbar-thumb { background: rgba(0,0,0,0.18); }

--- a/css/shopping-list.css
+++ b/css/shopping-list.css
@@ -16,11 +16,12 @@
   font-family: var(--font-display);
   font-size: clamp(1.8rem, 5vw, 2.4rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #34D399, #FBBF24, #60A5FA);
+  background: none;
+  -webkit-text-fill-color: #312e81;
+  background-clip: border-box;
+  -webkit-background-clip: border-box;
+  color: #312e81;
   background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
   animation: gradShift 6s ease-in-out infinite;
 }
 .sl-header p {
@@ -41,7 +42,7 @@
   min-width: 0;
   padding: 12px 14px;
   border-radius: var(--radius-xs);
-  border: 2px solid rgba(255,255,255,0.08);
+  border: 2px solid #e6e6ee;
   background: var(--bg-deep);
   color: var(--text);
   font-family: var(--font-body);
@@ -54,7 +55,7 @@
 .sl-add select {
   padding: 12px 10px;
   border-radius: var(--radius-xs);
-  border: 2px solid rgba(255,255,255,0.08);
+  border: 2px solid #e6e6ee;
   background: var(--bg-deep);
   color: var(--text);
   font-family: var(--font-body);
@@ -88,8 +89,8 @@
 .sl-action-btn {
   padding: 8px 14px;
   border-radius: 99px;
-  border: 1.5px solid rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.04);
+  border: 1.5px solid #e6e6ee;
+  background: #ffffff;
   color: var(--text);
   font-family: var(--font-body);
   font-size: 0.8rem;
@@ -137,12 +138,12 @@
   gap: 12px;
   padding: 12px 14px;
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.06);
+  border: 1.5px solid #e6e6ee;
   border-radius: var(--radius-xs);
   transition: all 0.2s;
   animation: fadeUp 0.25s ease-out both;
 }
-.sl-item:hover { border-color: rgba(255,255,255,0.15); }
+.sl-item:hover { border-color: #d6d2ea; }
 .sl-item.checked {
   opacity: 0.5;
 }
@@ -155,7 +156,7 @@
   width: 26px;
   height: 26px;
   border-radius: 50%;
-  border: 2px solid rgba(255,255,255,0.2);
+  border: 2px solid #d6d2ea;
   background: transparent;
   cursor: pointer;
   display: flex;

--- a/css/sports-arena.css
+++ b/css/sports-arena.css
@@ -3,18 +3,18 @@
    ================================================================ */
 
     :root {
-      --bg: #0B0B1A;
-      --bg-card: rgba(255,255,255,0.04);
-      --border-subtle: rgba(255,255,255,0.08);
-      --text: #F0EDFF;
-      --text-muted: rgba(240,237,255,0.55);
-      --green: #10B981;
-      --green-light: #34D399;
-      --orange: #F59E0B;
-      --red: #EF4444;
-      --purple: #A78BFA;
-      --blue: #60A5FA;
-      --gold: #FBBF24;
+      --bg: #f1f1f4;
+      --bg-card: #ffffff;
+      --border-subtle: #e6e6ee;
+      --text: #1c1b29;
+      --text-muted: #6b6878;
+      --green: #059669;
+      --green-light: #059669;
+      --orange: #C2410C;
+      --red: #B91C1C;
+      --purple: #6D28D9;
+      --blue: #2563EB;
+      --gold: #B45309;
       --font-display: 'Baloo 2', cursive;
       --font-body: 'Nunito', sans-serif;
       --radius: 20px;
@@ -83,10 +83,10 @@
     .arena-header h1 {
       font-family: var(--font-display);
       font-size: clamp(2rem, 6vw, 2.8rem); font-weight: 800;
-      background: linear-gradient(135deg, var(--green), var(--gold), var(--orange));
-      background-size: 200% 200%;
-      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
-      background-clip: text; animation: gradShift 5s ease-in-out infinite;
+      background: none;
+      -webkit-text-fill-color: #312e81;
+      background-clip: border-box; -webkit-background-clip: border-box;
+      color: #312e81;
     }
     @keyframes gradShift { 0%,100% { background-position: 0% 50%; } 50% { background-position: 100% 50%; } }
     .arena-header p { color: var(--text-muted); font-weight: 600; margin-top: 6px; font-size: 1rem; }
@@ -138,7 +138,7 @@
       align-items: center; gap: 6px;
     }
     .sport-btn:hover { border-color: var(--green); }
-    .sport-btn.selected { border-color: var(--green); background: rgba(16,185,129,0.12); color: var(--green-light); }
+    .sport-btn.selected { border-color: var(--green); background: #059669; color: #fff; }
     .sport-btn .sport-icon { font-size: 1.5rem; }
 
     /* ---- Form elements ---- */
@@ -162,7 +162,7 @@
       background-repeat: no-repeat; background-position: right 14px center;
       padding-right: 36px;
     }
-    select.form-input option { background: #1a1a3a; color: var(--text); }
+    select.form-input option { background: #ffffff; color: var(--text); }
 
     /* ---- Player chips ---- */
     .player-chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 8px 0; }
@@ -172,7 +172,7 @@
       cursor: pointer; transition: all 0.2s;
     }
     .player-chip:hover { border-color: var(--green); }
-    .player-chip.selected { border-color: var(--green); background: rgba(16,185,129,0.15); color: var(--green-light); }
+    .player-chip.selected { border-color: var(--green); background: #059669; color: #fff; }
 
     /* ---- Score inputs ---- */
     .score-row {
@@ -184,7 +184,7 @@
     .score-name { flex: 1; font-weight: 700; font-size: 0.95rem; }
     .score-input {
       width: 70px; padding: 8px; text-align: center;
-      background: rgba(0,0,0,0.3); border: 1.5px solid var(--border-subtle);
+      background: #ece9f5; border: 1.5px solid var(--border-subtle);
       border-radius: 10px; color: var(--text); font-weight: 800; font-size: 1.1rem;
       font-family: var(--font-body);
     }
@@ -193,12 +193,12 @@
     /* ---- Action buttons ---- */
     .btn-primary {
       padding: 14px 28px; border-radius: var(--radius-sm); border: none;
-      background: linear-gradient(135deg, var(--green), var(--green-light));
+      background: linear-gradient(135deg, #4338CA, #6366F1);
       color: #fff; font-weight: 800; font-size: 1rem; cursor: pointer;
       font-family: var(--font-body); transition: all 0.2s; width: 100%;
     }
-    .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(16,185,129,0.3); }
-    .btn-primary:disabled { background: #333; color: #666; cursor: not-allowed; transform: none; box-shadow: none; }
+    .btn-primary:hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(67,56,202,0.3); }
+    .btn-primary:disabled { background: #ece9f5; color: #6b6878; cursor: not-allowed; transform: none; box-shadow: none; }
 
     .btn-secondary {
       padding: 12px 24px; border-radius: var(--radius-sm);
@@ -243,7 +243,7 @@
     .match-actions { display: flex; gap: 4px; align-items: center; margin-left: 8px; }
     .match-edit, .match-delete {
       width: 32px; height: 32px;
-      background: rgba(255,255,255,0.04);
+      background: #ffffff;
       border: 1px solid var(--border-subtle);
       border-radius: 8px;
       cursor: pointer;
@@ -252,8 +252,8 @@
       display: inline-flex; align-items: center; justify-content: center;
       transition: background 0.15s, border-color 0.15s, transform 0.12s;
     }
-    .match-edit:hover { background: rgba(96,165,250,0.15); border-color: var(--blue); }
-    .match-delete:hover { background: rgba(248,113,113,0.15); border-color: var(--red); }
+    .match-edit:hover { background: #ece9f5; border-color: var(--blue); }
+    .match-delete:hover { background: #ece9f5; border-color: var(--red); }
     .match-edit:active, .match-delete:active { transform: scale(0.92); }
 
     /* ---- Tournament bracket ---- */

--- a/css/story-explorer.css
+++ b/css/story-explorer.css
@@ -5,8 +5,8 @@
 :root {
   --story-accent: #8B5CF6;
   --story-glow: rgba(139, 92, 246, 0.3);
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -105,19 +105,19 @@ body {
   color: var(--purple); border-bottom: 2px dashed var(--purple);
   cursor: pointer; transition: all 0.2s;
 }
-.vocab-link:hover { background: rgba(167, 139, 250, 0.1); }
+.vocab-link:hover { background: #ece9f5; }
 
 /* Read-aloud word highlighting (word at a time) */
 .rw-word { transition: background 0.15s ease, color 0.15s ease; padding: 0 1px; border-radius: 4px; }
 .rw-word.speaking {
   background: rgba(251, 191, 36, 0.25);
-  color: #FBBF24;
+  color: #B45309;
   box-shadow: 0 0 0 2px rgba(251, 191, 36, 0.35);
 }
 
 .page-controls { display: flex; align-items: center; gap: 24px; margin-bottom: 24px; width: 100%; justify-content: center; }
 .nav-btn {
-  padding: 10px 20px; border-radius: 12px; background: rgba(255,255,255,0.05);
+  padding: 10px 20px; border-radius: 12px; background: #ffffff;
   border: 1.5px solid var(--border-subtle); color: var(--text-primary);
   font-weight: 800; cursor: pointer; transition: all 0.2s;
 }
@@ -147,8 +147,8 @@ body {
   font-weight: 800; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease;
   border: none; width: 100%; max-width: 280px; margin-bottom: 12px;
 }
-.btn-primary { background: linear-gradient(135deg, var(--story-accent), #A78BFA); color: #fff; }
-.btn-secondary { background: rgba(255,255,255,0.08); color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
+.btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; }
+.btn-secondary { background: #ffffff; color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
 
 .feedback {
   position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%) scale(0.5);

--- a/css/sunday-report.css
+++ b/css/sunday-report.css
@@ -3,7 +3,7 @@
    ============================================================ */
 
 .sr-body {
-  background: #2a2040;
+  background: #f1f1f4;
   min-height: 100vh;
   padding: 24px;
   font-family: var(--font-body, 'Nunito', sans-serif);
@@ -22,9 +22,9 @@
 .sr-tb-btn {
   padding: 10px 18px;
   border-radius: 12px;
-  background: rgba(255,255,255,0.08);
-  border: 1.5px solid rgba(255,255,255,0.12);
-  color: #F0EDFF;
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
+  color: #1c1b29;
   font-weight: 700;
   font-size: 0.9rem;
   text-decoration: none;
@@ -34,9 +34,9 @@
   gap: 6px;
   transition: all 0.2s;
 }
-.sr-tb-btn:hover { background: rgba(255,255,255,0.14); }
+.sr-tb-btn:hover { background: #ece9f5; }
 .sr-tb-btn.primary {
-  background: linear-gradient(135deg, #7C3AED, #A78BFA);
+  background: linear-gradient(135deg, #4338CA, #6366F1);
   border-color: transparent;
   color: #fff;
 }

--- a/css/trophy-room.css
+++ b/css/trophy-room.css
@@ -17,11 +17,11 @@
   font-family: var(--font-display);
   font-size: clamp(2rem, 5vw, 2.6rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #FBBF24, #F472B6, #A78BFA);
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: none;
+  -webkit-text-fill-color: #312e81;
+  background-clip: border-box;
+  -webkit-background-clip: border-box;
+  color: #312e81;
   animation: gradShift 6s ease-in-out infinite;
 }
 .tr-header p {
@@ -35,8 +35,8 @@
 .tr-rank-banner {
   padding: 20px;
   border-radius: var(--radius);
-  background: linear-gradient(135deg, rgba(251,191,36,0.12), rgba(167,139,250,0.08));
-  border: 1.5px solid rgba(251,191,36,0.2);
+  background: #ffffff;
+  border: 1.5px solid #e6e6ee;
   margin-bottom: 20px;
   display: flex;
   align-items: center;
@@ -73,7 +73,7 @@
   margin-bottom: 28px;
   padding: 16px;
   background: var(--bg-surface);
-  border: 1px solid rgba(255,255,255,0.06);
+  border: 1px solid #e6e6ee;
   border-radius: var(--radius-sm);
 }
 .tr-ps-label {
@@ -86,7 +86,7 @@
 }
 .tr-ps-bar {
   height: 10px;
-  background: rgba(255,255,255,0.06);
+  background: #ece9f5;
   border-radius: 99px;
   overflow: hidden;
 }
@@ -133,7 +133,7 @@
 .tr-badge {
   padding: 16px 12px;
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.06);
+  border: 1.5px solid #e6e6ee;
   border-radius: var(--radius-xs);
   text-align: center;
   transition: all 0.3s cubic-bezier(0.34,1.56,0.64,1);
@@ -182,8 +182,8 @@
 /* Next up */
 .tr-next {
   padding: 16px;
-  background: rgba(96,165,250,0.06);
-  border: 1.5px dashed rgba(96,165,250,0.25);
+  background: #ffffff;
+  border: 1.5px dashed #d6d2ea;
   border-radius: var(--radius-sm);
   display: flex;
   align-items: center;

--- a/css/vacation.css
+++ b/css/vacation.css
@@ -8,11 +8,11 @@
   font-family: var(--font-display);
   font-size: clamp(1.8rem, 5vw, 2.4rem);
   font-weight: 800;
-  background: linear-gradient(135deg, #60A5FA, #FBBF24, #F472B6);
-  background-size: 200% 200%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  background: none;
+  -webkit-text-fill-color: #312e81;
+  background-clip: border-box;
+  -webkit-background-clip: border-box;
+  color: #312e81;
   animation: gradShift 6s ease-in-out infinite;
 }
 .vc-header p {
@@ -32,17 +32,17 @@
 .vc-toolbar button {
   padding: 8px 14px;
   border-radius: 99px;
-  border: 1.5px solid rgba(255,255,255,0.1);
-  background: rgba(255,255,255,0.04);
+  border: 1.5px solid #e6e6ee;
+  background: #ffffff;
   color: var(--text);
   font-weight: 700;
   font-size: 0.82rem;
   cursor: pointer;
   transition: all 0.15s;
 }
-.vc-toolbar button:hover { border-color: #60A5FA; color: #60A5FA; }
+.vc-toolbar button:hover { border-color: #2563EB; color: #2563EB; }
 .vc-toolbar .vc-tb-primary {
-  background: linear-gradient(135deg, #7C3AED, #A78BFA);
+  background: linear-gradient(135deg, #4338CA, #6366F1);
   border-color: transparent;
   color: #fff;
 }
@@ -56,7 +56,7 @@
 .vc-trip {
   padding: 16px 18px;
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.06);
+  border: 1.5px solid #e6e6ee;
   border-radius: 16px;
   cursor: pointer;
   transition: all 0.2s;
@@ -92,14 +92,14 @@
   display: inline-block;
   padding: 4px 12px;
   border-radius: 99px;
-  background: rgba(251,191,36,0.12);
-  color: #FBBF24;
+  color: #fff;
+  background: #B45309;
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 0.85rem;
 }
-.vc-countdown.now { background: rgba(52,211,153,0.15); color: #34D399; }
-.vc-countdown.past { background: rgba(255,255,255,0.05); color: var(--text-muted); }
+.vc-countdown.now { color: #fff; background: #059669; }
+.vc-countdown.past { background: #ffffff; color: var(--text-muted); }
 
 .vc-empty {
   text-align: center;
@@ -111,7 +111,7 @@
 /* Trip detail */
 .vc-detail {
   background: var(--bg-surface);
-  border: 1.5px solid rgba(255,255,255,0.06);
+  border: 1.5px solid #e6e6ee;
   border-radius: 18px;
   padding: 20px;
 }
@@ -141,7 +141,7 @@
 .vc-detail-meta span {
   padding: 4px 10px;
   border-radius: 99px;
-  background: rgba(255,255,255,0.04);
+  background: #ffffff;
 }
 
 .vc-section { margin-bottom: 20px; }
@@ -155,7 +155,7 @@
 .vc-section-head a {
   font-size: 0.78rem;
   font-weight: 700;
-  color: #60A5FA;
+  color: #2563EB;
   text-decoration: none;
   margin-left: 8px;
 }
@@ -168,8 +168,8 @@
 }
 .vc-pack-col {
   padding: 10px 12px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 12px;
 }
 .vc-pack-col h4 {
@@ -214,8 +214,8 @@
   flex: 1;
   padding: 6px 8px;
   border-radius: 6px;
-  border: 1px solid rgba(255,255,255,0.1);
-  background: rgba(0,0,0,0.2);
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
   color: var(--text);
   font-size: 0.8rem;
   outline: none;
@@ -224,8 +224,8 @@
   padding: 6px 10px;
   border-radius: 6px;
   border: none;
-  background: rgba(52,211,153,0.15);
-  color: #34D399;
+  color: #fff;
+  background: #059669;
   font-weight: 800;
   font-size: 0.78rem;
   cursor: pointer;
@@ -234,8 +234,8 @@
 /* Itinerary */
 .vc-day {
   padding: 10px 14px;
-  background: rgba(255,255,255,0.03);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
   border-radius: 12px;
   margin-bottom: 8px;
 }
@@ -260,8 +260,8 @@
   min-height: 50px;
   padding: 6px 10px;
   border-radius: 8px;
-  border: 1px solid rgba(255,255,255,0.08);
-  background: rgba(0,0,0,0.2);
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
   color: var(--text);
   font-family: var(--font-body);
   font-size: 0.85rem;
@@ -269,7 +269,7 @@
   outline: none;
   resize: vertical;
 }
-.vc-day textarea:focus { border-color: #60A5FA; }
+.vc-day textarea:focus { border-color: #2563EB; }
 
 /* Form */
 .vc-form .vc-field {
@@ -288,15 +288,15 @@
   width: 100%;
   padding: 10px 12px;
   border-radius: 10px;
-  border: 1px solid rgba(255,255,255,0.1);
-  background: rgba(0,0,0,0.2);
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
   color: var(--text);
   font-family: var(--font-body);
   font-size: 0.95rem;
   font-weight: 700;
   outline: none;
 }
-.vc-form input:focus, .vc-form select:focus { border-color: #60A5FA; }
+.vc-form input:focus, .vc-form select:focus { border-color: #2563EB; }
 .vc-form-actions {
   display: flex;
   gap: 8px;
@@ -312,9 +312,9 @@
   font-size: 0.9rem;
   cursor: pointer;
 }
-.vc-btn-primary { background: linear-gradient(135deg, #7C3AED, #A78BFA); color: #fff; }
-.vc-btn-secondary { background: rgba(255,255,255,0.08); color: var(--text); }
-.vc-btn-danger { background: rgba(248,113,113,0.12); color: #F87171; }
+.vc-btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; }
+.vc-btn-secondary { background: #ffffff; color: var(--text); }
+.vc-btn-danger { color: #fff; background: #B91C1C; }
 
 @media (max-width: 480px) {
   .vc-pack-cols { grid-template-columns: 1fr; }

--- a/css/vocabulario-vivo.css
+++ b/css/vocabulario-vivo.css
@@ -4,9 +4,9 @@
    ============================================================ */
 
 :root {
-  --vv-accent: #F472B6;       /* rose-400 */
+  --vv-accent: #BE185D;       /* rose, deep for text/borders on light */
   --vv-accent-deep: #BE185D;  /* rose-700 */
-  --vv-terra: #F97316;        /* orange-500, terracotta */
+  --vv-terra: #C2410C;        /* deep terracotta for text/borders on light */
   --vv-terra-deep: #9A3412;
 }
 
@@ -199,8 +199,8 @@
 .vv-root-big-origin {
   display: inline-block;
   margin-top: 4px;
-  background: rgba(244,114,182,0.18);
-  color: var(--vv-accent);
+  background: #BE185D;
+  color: #fff;
   border-radius: 999px;
   padding: 4px 12px;
   font-size: 0.85rem;
@@ -233,7 +233,7 @@
   align-items: center;
   gap: 12px;
   padding: 8px 10px;
-  border-bottom: 1px solid rgba(255,255,255,0.05);
+  border-bottom: 1px solid #e6e6ee;
   font-weight: 700;
 }
 .vv-word-pair:last-child { border-bottom: 0; }
@@ -284,8 +284,8 @@
 }
 .vv-match-word {
   display: inline-block;
-  background: rgba(244,114,182,0.18);
-  color: var(--vv-accent);
+  background: #BE185D;
+  color: #fff;
   border-radius: 8px;
   padding: 2px 10px;
   font-family: var(--font-display);

--- a/css/world-cup.css
+++ b/css/world-cup.css
@@ -9,11 +9,11 @@
   --wc-blue-soft:  rgba(37, 99, 235, 0.18);
   --wc-red:    #DC2626;
   --wc-red-soft:   rgba(220, 38, 38, 0.18);
-  --wc-gold:   #F59E0B;
+  --wc-gold:   #B45309;
   --wc-gold-soft:  rgba(245, 158, 11, 0.20);
-  --wc-card:   rgba(255,255,255,0.04);
-  --wc-card-strong: rgba(255,255,255,0.06);
-  --wc-line:   rgba(255,255,255,0.08);
+  --wc-card:   #ffffff;
+  --wc-card-strong: #ece9f5;
+  --wc-line:   #e6e6ee;
 }
 
 body {
@@ -56,10 +56,11 @@ body {
   font-weight: 800;
   margin: 6px 0 4px;
   letter-spacing: -0.01em;
-  background: linear-gradient(120deg, #FBBF24, #DC2626 50%, #2563EB);
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
+  background: none;
+  -webkit-background-clip: border-box;
+  background-clip: border-box;
+  -webkit-text-fill-color: #312e81;
+  color: #312e81;
 }
 .wc-header .sub {
   color: var(--text-muted);
@@ -316,8 +317,8 @@ body {
   font-size: 0.7rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  background: var(--wc-blue-soft);
-  color: #93C5FD;
+  background: #2563EB;
+  color: #fff;
   border-radius: 6px;
   padding: 2px 6px;
 }
@@ -696,7 +697,7 @@ body {
   gap: 8px;
   padding: 6px 0;
   font-size: 0.86rem;
-  border-bottom: 1px solid rgba(255,255,255,0.04);
+  border-bottom: 1px solid #e6e6ee;
 }
 .pool-pick:last-child { border-bottom: none; }
 .pool-pick-val {

--- a/css/world-explorer.css
+++ b/css/world-explorer.css
@@ -5,8 +5,8 @@
 :root {
   --world-accent: #3B82F6;
   --world-glow: rgba(59, 130, 246, 0.3);
-  --bg-card: rgba(255, 255, 255, 0.04);
-  --border-subtle: rgba(255, 255, 255, 0.08);
+  --bg-card: #ffffff;
+  --border-subtle: #e6e6ee;
 }
 
 body {
@@ -94,7 +94,7 @@ body {
 .exp-stars { font-weight: 800; color: var(--gold); }
 
 .map-wrap {
-  background: rgba(0,0,0,0.2); border-radius: var(--radius);
+  background: #ece9f5; border-radius: var(--radius);
   padding: 20px; border: 1.5px solid var(--border-subtle);
   margin-top: 12px; min-height: 300px; display: flex; align-items: center; justify-content: center;
 }
@@ -121,11 +121,11 @@ path.country.visited { fill: #10B981; fill-opacity: 0.3; stroke: #34D399; }
 .country-capital { font-size: 1.1rem; color: var(--text-muted); font-weight: 700; margin-bottom: 24px; }
 
 .country-info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
-.info-box { background: rgba(255,255,255,0.03); border-radius: 16px; padding: 16px; border: 1px solid var(--border-subtle); }
+.info-box { background: #ffffff; border-radius: 16px; padding: 16px; border: 1px solid var(--border-subtle); }
 .info-label { font-size: 0.75rem; text-transform: uppercase; font-weight: 800; color: var(--text-muted); margin-bottom: 4px; }
 .info-value { font-size: 1.1rem; font-weight: 800; }
 
-.country-facts { text-align: left; background: rgba(0,0,0,0.1); border-radius: 16px; padding: 20px; margin-bottom: 24px; }
+.country-facts { text-align: left; background: #ece9f5; border-radius: 16px; padding: 20px; margin-bottom: 24px; }
 .fact-item { margin-bottom: 12px; font-size: 0.95rem; line-height: 1.5; font-weight: 600; display: flex; gap: 10px; }
 .fact-item:last-child { margin-bottom: 0; }
 
@@ -133,7 +133,7 @@ path.country.visited { fill: #10B981; fill-opacity: 0.3; stroke: #34D399; }
 @media (min-width: 560px) { .we-extras { grid-template-columns: 1fr 1fr; } }
 .we-extra-card {
   text-align: left;
-  background: rgba(255,255,255,0.04);
+  background: #ffffff;
   border: 1px solid var(--border-subtle);
   border-radius: 16px;
   padding: 16px;
@@ -153,7 +153,7 @@ path.country.visited { fill: #10B981; fill-opacity: 0.3; stroke: #34D399; }
   font-family: var(--font-display);
   font-weight: 800;
   font-size: 2.2rem;
-  color: #FBBF24;
+  color: #B45309;
   min-width: 44px;
   text-align: center;
 }
@@ -168,8 +168,8 @@ path.country.visited { fill: #10B981; fill-opacity: 0.3; stroke: #34D399; }
   font-weight: 600;
   line-height: 1.4;
   padding: 8px 12px;
-  background: rgba(96,165,250,0.08);
-  border-left: 3px solid #60A5FA;
+  background: #ece9f5;
+  border-left: 3px solid #2563EB;
   border-radius: 6px;
 }
 
@@ -178,8 +178,8 @@ path.country.visited { fill: #10B981; fill-opacity: 0.3; stroke: #34D399; }
   font-weight: 800; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease;
   border: none; width: 100%; margin-bottom: 12px;
 }
-.btn-primary { background: linear-gradient(135deg, var(--world-accent), #60A5FA); color: #fff; }
-.btn-secondary { background: rgba(255,255,255,0.08); color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
+.btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; }
+.btn-secondary { background: #ffffff; color: var(--text-primary); border: 1.5px solid var(--border-subtle); }
 
 /* Results & Feedback same as lab */
 .feedback {

--- a/css/zs-theme.css
+++ b/css/zs-theme.css
@@ -1,0 +1,128 @@
+/* ================================================================
+   ZAVALA SERRA — LIGHT THEME (global)  ·  css/zs-theme.css
+   ----------------------------------------------------------------
+   The single source of truth for the 2026 light redesign.
+   Link AFTER css/common.css (and the app's own stylesheet) on every
+   page so it wins on source order:
+
+     <link rel="stylesheet" href="css/common.css">
+     <link rel="stylesheet" href="css/<app>.css">
+     <link rel="stylesheet" href="css/zs-theme.css">   <-- last
+
+   This file re-themes the SHARED tokens + shared chrome (body, home
+   button, user badge, modals, feedback) for ALL apps. Per-app
+   bespoke surfaces (custom panels, game boards, etc.) still use the
+   tokens below — convert their hardcoded dark values using the
+   dark→light map in the redesign handoff README.
+   ================================================================ */
+
+/* ---------------- DESIGN TOKENS ---------------- */
+:root {
+  /* Surfaces — light grey screen, white modules */
+  --bg-deep:    #f1f1f4;   /* screen / app background */
+  --bg-surface: #ffffff;   /* cards / modules */
+  --bg-card:    #ffffff;
+  --bg-sunken:  #ece9f5;   /* tracks, wells, inset bars */
+  --border-subtle: #e6e6ee;
+  --border-strong: #d6d2ea;
+
+  /* Text */
+  --text:         #1c1b29;
+  --text-primary: #1c1b29;
+  --text-muted:   #6b6878;
+  --ink-title:    #312e81;   /* solid display-title color (NO gradient) */
+
+  /* Brand + accents (deep enough for white text on solid fills) */
+  --purple: #6D28D9;
+  --indigo: #4338CA;
+  --blue:   #2563EB;
+  --green:  #059669;
+  --teal:   #0D9488;
+  --gold:   #B45309;
+  --pink:   #BE185D;
+  --red:    #B91C1C;
+  --cyan:   #0E7490;
+  --orange: #C2410C;
+
+  /* Effects */
+  --radius:    20px;
+  --radius-sm: 16px;
+  --radius-xs: 12px;
+  --mod-shadow:    0 4px 14px rgba(15,15,25,0.08);
+  --mod-shadow-sm: 0 2px 6px rgba(15,15,25,0.05);
+
+  --font-display: 'Baloo 2', 'Nunito', cursive;
+  --font-body: 'Nunito', system-ui, sans-serif;
+}
+
+/* ---------------- BACKGROUND ---------------- */
+/* Light screen, no dark starfield / aurora. */
+body { background: var(--bg-deep) !important; color: var(--text-primary) !important; }
+body::before { display: none !important; }
+.aurora, .atmo, .nebula { display: none !important; }
+
+/* ---------------- SHARED CHROME (common.css) ---------------- */
+.home-btn {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-muted);
+  box-shadow: var(--mod-shadow-sm);
+}
+.home-btn:hover { border-color: var(--purple); color: var(--purple); }
+
+.user-badge {
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-primary);
+  box-shadow: var(--mod-shadow-sm);
+}
+.star-counter { background: rgba(180,83,9,0.12); color: var(--gold); }
+
+/* ---------------- COMPONENT RECIPES ----------------
+   Reusable classes apps can adopt. (See DESIGN_SYSTEM.md for the
+   full conversion playbook + dark->light value map.) */
+
+/* Module / card — white surface on the grey screen */
+.zs-module {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--mod-shadow);
+}
+
+/* Solid, saturated pill — NOT a chalky pastel tint.
+   Set --pill to any accent token, e.g. style="--pill:var(--blue)". */
+.zs-pill {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 4px 11px; border-radius: 99px;
+  font-weight: 800; font-size: 0.72rem;
+  background: var(--pill, var(--indigo));
+  color: #ffffff;
+}
+
+/* Solid title — replaces rainbow gradient text */
+.zs-title { color: var(--ink-title); font-family: var(--font-display); font-weight: 800; }
+
+/* Option-C app card — colored header band + white body.
+   Markup: <a class="zs-card" style="--accent:var(--blue)">
+             <div class="zs-card-head">🧮</div>
+             <div class="zs-card-body"> … </div>
+           </a> */
+.zs-card {
+  display: block; text-decoration: none; color: var(--text-primary);
+  background: #ffffff; border: 1px solid var(--border-subtle);
+  border-radius: var(--radius); overflow: hidden;
+  box-shadow: var(--mod-shadow);
+  transition: transform .3s, box-shadow .3s;
+}
+.zs-card:hover { transform: translateY(-5px); box-shadow: 0 18px 40px -16px rgba(20,18,40,0.25); }
+.zs-card-head {
+  height: 94px; display: flex; align-items: center; justify-content: center;
+  font-size: 44px; color: #fff;
+  background: var(--accent, var(--indigo));
+}
+.zs-card-body { padding: 15px 20px 18px; }
+
+/* Inset bar / progress track */
+.zs-track { height: 9px; border-radius: 99px; background: var(--bg-sunken); overflow: hidden; }
+.zs-track > .zs-fill { height: 100%; border-radius: 99px; background: var(--accent, var(--indigo)); }

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/descubre-chile.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/family.html
+++ b/family.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/family-wall.css">
+  <link rel="stylesheet" href="css/redesign.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -8,14 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <style>
     :root {
       --faith-gold: #F59E0B;
       --faith-gold-light: #FBBF24;
-      --faith-bg: #1A1005;
-      --faith-surface: #2D1B0A;
+      --faith-gold-ink: #B45309;
+      --faith-bg: #f1f1f4;
+      --faith-surface: #ffffff;
     }
-    body { background-color: var(--faith-bg); color: #FFFBEB; }
+    body { background-color: var(--faith-bg); color: #1c1b29; }
     
     .header {
       background: var(--faith-surface);
@@ -25,75 +27,75 @@
     }
     .header-left { display: flex; align-items: center; gap: 12px; }
     .back-btn {
-      background: rgba(255,255,255,0.1); border: none; border-radius: 50%;
+      background: #ece9f5; border: none; border-radius: 50%;
       width: 40px; height: 40px; display: flex; align-items: center; justify-content: center;
-      color: white; font-size: 20px; cursor: pointer; text-decoration: none;
+      color: #1c1b29; font-size: 20px; cursor: pointer; text-decoration: none;
     }
-    .back-btn:hover { background: rgba(255,255,255,0.2); }
+    .back-btn:hover { background: #d6d2ea; }
     .title { font-family: 'Baloo 2', cursive; font-weight: 800; font-size: 1.4rem; }
-    .stars-badge { background: rgba(245,158,11,0.2); border: 1px solid var(--faith-gold); padding: 4px 12px; border-radius: 99px; font-weight: 800; color: var(--faith-gold-light); }
+    .stars-badge { color:#fff; background:#B45309; border: 1px solid #B45309; padding: 4px 12px; border-radius: 99px; font-weight: 800; }
 
     .nav-tabs {
       display: flex; gap: 8px; padding: 12px; overflow-x: auto;
-      background: rgba(0,0,0,0.2);
+      background: #ece9f5;
     }
     .tab {
-      padding: 10px 20px; border-radius: 12px; background: rgba(255,255,255,0.05);
+      padding: 10px 20px; border-radius: 12px; background: #ffffff;
       font-weight: 700; font-size: 0.9rem; cursor: pointer; white-space: nowrap; transition: all 0.2s;
     }
     .tab.active { background: var(--faith-gold); color: #000; }
 
     .content-area { padding: 24px; max-width: 600px; margin: 0 auto; min-height: 70vh; }
-    .card { background: var(--faith-surface); border-radius: 20px; border: 1.5px solid rgba(245,158,11,0.2); padding: 24px; animation: fadeIn 0.4s ease-out; }
+    .card { background: var(--faith-surface); border-radius: 20px; border: 1.5px solid #e6e6ee; padding: 24px; animation: fadeIn 0.4s ease-out; }
     @keyframes fadeIn { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
 
     /* Prayer Section */
     .prayer-line { font-size: 1.2rem; font-weight: 700; margin-bottom: 12px; line-height: 1.4; opacity: 0.4; transition: opacity 0.3s; }
-    .prayer-line.active { opacity: 1; color: var(--faith-gold-light); transform: scale(1.05); transform-origin: left; }
+    .prayer-line.active { opacity: 1; color: var(--faith-gold-ink); transform: scale(1.05); transform-origin: left; }
     .bead-counter { display: flex; gap: 8px; justify-content: center; margin-top: 24px; }
-    .bead { width: 12px; height: 12px; border-radius: 50%; background: rgba(255,255,255,0.2); border: 1px solid rgba(255,255,255,0.1); transition: all 0.3s; }
+    .bead { width: 12px; height: 12px; border-radius: 50%; background: #ece9f5; border: 1px solid #e6e6ee; transition: all 0.3s; }
     .bead.active { background: var(--faith-gold); box-shadow: 0 0 10px var(--faith-gold); }
 
     /* Saint/Heritage Section */
     .item-header { display: flex; align-items: center; gap: 16px; margin-bottom: 16px; }
-    .item-icon { font-size: 3rem; background: rgba(255,255,255,0.05); width: 80px; height: 80px; border-radius: 20px; display: flex; align-items: center; justify-content: center; }
+    .item-icon { font-size: 3rem; background: #ece9f5; width: 80px; height: 80px; border-radius: 20px; display: flex; align-items: center; justify-content: center; }
     .item-title { font-family: 'Baloo 2', cursive; font-size: 1.6rem; font-weight: 800; line-height: 1.1; }
-    .item-meta { font-size: 0.85rem; color: var(--faith-gold-light); font-weight: 700; }
+    .item-meta { font-size: 0.85rem; color: var(--faith-gold-ink); font-weight: 700; }
     .item-bio { font-size: 1.1rem; line-height: 1.6; margin-bottom: 24px; }
 
     .quiz-options { display: grid; gap: 12px; }
     .quiz-btn {
-      padding: 16px; background: rgba(255,255,255,0.05); border: 1.5px solid rgba(255,255,255,0.1);
-      border-radius: 12px; color: white; font-weight: 700; text-align: left; cursor: pointer; transition: all 0.2s;
+      padding: 16px; background: #ffffff; border: 1.5px solid #e6e6ee;
+      border-radius: 12px; color: #1c1b29; font-weight: 700; text-align: left; cursor: pointer; transition: all 0.2s;
     }
-    .quiz-btn:hover { background: rgba(255,255,255,0.1); border-color: var(--faith-gold); }
+    .quiz-btn:hover { background: #ece9f5; border-color: var(--faith-gold); }
     .quiz-btn.correct { background: #10B981; border-color: #10B981; }
     .quiz-btn.wrong { background: #EF4444; border-color: #EF4444; }
 
     /* Rosary Section */
     .rosary-today { text-align: center; font-size: 0.95rem; opacity: 0.85; margin: 8px 0 16px; }
-    .rosary-today strong { color: var(--faith-gold-light); }
+    .rosary-today strong { color: var(--faith-gold-ink); }
 
     .set-tabs { display: flex; flex-wrap: wrap; gap: 8px; justify-content: center; margin-bottom: 16px; }
     .set-tab {
-      padding: 8px 14px; border-radius: 99px; background: rgba(255,255,255,0.05);
-      border: 1.5px solid rgba(255,255,255,0.12); color: #FFFBEB; font-weight: 700;
+      padding: 8px 14px; border-radius: 99px; background: #ffffff;
+      border: 1.5px solid #d6d2ea; color: #1c1b29; font-weight: 700;
       font-size: 0.85rem; cursor: pointer; transition: all 0.2s; white-space: nowrap;
     }
     .set-tab:hover { border-color: var(--faith-gold); }
     .set-tab.active { background: var(--faith-gold); color: #000; border-color: var(--faith-gold); }
     .set-tab.is-today { box-shadow: 0 0 0 2px rgba(245,158,11,0.35); }
 
-    .set-days { text-align: center; font-size: 0.85rem; color: var(--faith-gold-light); font-weight: 700; margin-bottom: 16px; }
+    .set-days { text-align: center; font-size: 0.85rem; color: var(--faith-gold-ink); font-weight: 700; margin-bottom: 16px; }
 
     .mystery-list { display: grid; gap: 8px; margin-bottom: 8px; }
     .mystery-item {
       display: flex; align-items: center; gap: 12px; width: 100%; text-align: left;
-      padding: 12px 14px; border-radius: 12px; background: rgba(255,255,255,0.04);
-      border: 1.5px solid rgba(255,255,255,0.1); color: #FFFBEB; cursor: pointer; transition: all 0.2s;
+      padding: 12px 14px; border-radius: 12px; background: #ffffff;
+      border: 1.5px solid #e6e6ee; color: #1c1b29; cursor: pointer; transition: all 0.2s;
     }
-    .mystery-item:hover { border-color: var(--faith-gold); background: rgba(255,255,255,0.08); }
-    .mystery-item.active { border-color: var(--faith-gold); background: rgba(245,158,11,0.12); }
+    .mystery-item:hover { border-color: var(--faith-gold); background: #ece9f5; }
+    .mystery-item.active { border-color: var(--faith-gold); background: #fdf6e7; }
     .mystery-num {
       flex: 0 0 28px; width: 28px; height: 28px; border-radius: 50%;
       background: var(--faith-gold); color: #000; font-weight: 800;
@@ -105,17 +107,17 @@
     .mystery-item-desc { font-size: 0.82rem; opacity: 0.75; line-height: 1.35; }
 
     .rosary-beads { display: flex; flex-wrap: wrap; gap: 12px; justify-content: center; margin: 32px 0; }
-    .rosary-bead { width: 44px; height: 44px; border-radius: 50%; background: #2D1B0A; border: 3px solid #4D2B1A; cursor: pointer; transition: all 0.3s; display: flex; align-items: center; justify-content: center; font-weight: 800; color: rgba(255,255,255,0.2); }
+    .rosary-bead { width: 44px; height: 44px; border-radius: 50%; background: #ece9f5; border: 3px solid #d6d2ea; cursor: pointer; transition: all 0.3s; display: flex; align-items: center; justify-content: center; font-weight: 800; color: #6b6878; }
     .rosary-bead.active { background: var(--faith-gold); border-color: #FFF; color: #000; box-shadow: 0 0 20px var(--faith-gold); transform: scale(1.15); }
-    .rosary-bead.done { background: #4D2B1A; border-color: var(--faith-gold); color: var(--faith-gold); }
+    .rosary-bead.done { background: #fdf6e7; border-color: var(--faith-gold); color: var(--faith-gold-ink); }
 
-    .mystery-card { background: rgba(0,0,0,0.3); padding: 20px; border-radius: 16px; text-align: center; margin-top: 24px; }
-    .mystery-title { font-weight: 800; font-size: 1.2rem; color: var(--faith-gold-light); margin-bottom: 4px; }
+    .mystery-card { background: #ece9f5; padding: 20px; border-radius: 16px; text-align: center; margin-top: 24px; }
+    .mystery-title { font-weight: 800; font-size: 1.2rem; color: var(--faith-gold-ink); margin-bottom: 4px; }
     .mystery-desc { font-size: 0.95rem; opacity: 0.8; }
 
     .bottom-actions { margin-top: 32px; display: flex; justify-content: center; }
     .next-btn {
-      padding: 14px 32px; border-radius: 12px; background: var(--faith-gold); color: #000;
+      padding: 14px 32px; border-radius: 12px; background: linear-gradient(135deg,#4338CA,#6366F1); color: #fff;
       border: none; font-weight: 800; font-family: 'Baloo 2', cursive; font-size: 1.1rem; cursor: pointer;
     }
     .next-btn:hover { transform: scale(1.05); }
@@ -333,7 +335,7 @@
             <div class="mystery-title">🎉 ¡Rosario completo!</div>
             <div class="mystery-desc">Para terminar, recemos juntos la Salve.</div>
           </div>
-          <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-light);">${salve.title}</h3>
+          <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-ink);">${salve.title}</h3>
           <div id="prayer-lines">
             ${salve.lines.map(l => `<div class="prayer-line active">${l}</div>`).join('')}
           </div>
@@ -384,7 +386,7 @@
           }).join('')}
         </div>
 
-        <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-light);">${prayerLabel}</h3>
+        <h3 style="font-family:'Baloo 2';text-align:center;margin:16px 0 8px;color:var(--faith-gold-ink);">${prayerLabel}</h3>
         <div id="prayer-lines">
           ${prayer.lines.map(l => `<div class="prayer-line active">${l}</div>`).join('')}
         </div>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/guess-quest.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -7,6 +7,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@400;500;600;700;800&family=Nunito:wght@400;600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/guitar-jam.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/home-timer.html
+++ b/home-timer.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/home-timer.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/index.css">
   <link rel="stylesheet" href="css/routines.css">
+  <link rel="stylesheet" href="css/redesign.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/js/index.js
+++ b/js/index.js
@@ -691,6 +691,231 @@
     } catch(err) {}
   }
 
+  // ════════════════════════════════════════════════════════════════
+  //  REDESIGN — Dashboard "Overview" (charts from real local data)
+  //  All values are derived from data the suite already stores:
+  //    • totalStars / rank  → getPlayerStats / getExplorerRank
+  //    • screen time today  → TimerManager (per-kid minutesUsed/max)
+  //    • tokens             → zs_chores_<kid>.totalTokens
+  //    • activity trend +   → ActivityLog timestamped events
+  //      app usage + streak
+  // ════════════════════════════════════════════════════════════════
+  var _DASH_RANKS = [
+    { n: 'Cadet', s: 0, i: '🛸' }, { n: 'Apprentice', s: 15, i: '🌟' },
+    { n: 'Veteran', s: 30, i: '🛡️' }, { n: 'Explorer', s: 60, i: '🌍' },
+    { n: 'Pilot', s: 100, i: '🚀' }, { n: 'Astronaut', s: 150, i: '🌌' },
+    { n: 'Elite', s: 250, i: '💎' }, { n: 'Grand Master', s: 500, i: '👑' }
+  ];
+  var _APP_COLOR = {
+    'Math Galaxy': '#1D4ED8', 'Little Maestro': '#6D28D9', 'Chess Quest': '#B45309',
+    'Art Studio': '#BE185D', 'Descubre Chile': '#B91C1C', 'Lab Explorer': '#047857',
+    'World Explorer': '#1D4ED8', 'Story Explorer': '#6D28D9', 'Guitar Jam': '#047857',
+    'Fe Explorador': '#B45309', 'Sports Arena': '#0D9488', 'Guess Quest': '#B45309',
+    'Quest Adventure': '#B45309', 'Book & Movie Check': '#1D4ED8', 'Routines': '#0D9488'
+  };
+  function _appColor(name) { return _APP_COLOR[name] || '#4338CA'; }
+  function _slug(s) { return String(s || '').toLowerCase().replace(/\s+/g, '_'); }
+  function _nextRank(stars) {
+    for (var i = 0; i < _DASH_RANKS.length; i++) {
+      if (stars < _DASH_RANKS[i].s) return { next: _DASH_RANKS[i], prev: _DASH_RANKS[i - 1] || _DASH_RANKS[0] };
+    }
+    return { next: null, prev: _DASH_RANKS[_DASH_RANKS.length - 1] };
+  }
+
+  // Weekly STARS history — one snapshot per ISO week (Monday key), last 12 weeks.
+  function _starsWeekKey(ts) { var d = new Date(ts); var dow = (d.getDay() + 6) % 7; d.setDate(d.getDate() - dow); return d.toISOString().split('T')[0]; }
+  function _readStarsHistory() { try { return JSON.parse(localStorage.getItem('zs_stars_history')) || {}; } catch (e) { return {}; } }
+  function _recordStarsSnapshot(profiles) {
+    var h = _readStarsHistory();
+    try {
+      var total = 0;
+      (profiles || []).forEach(function(p) { try { var s = (typeof getPlayerStats === 'function') ? getPlayerStats(p.name) : {}; total += (s.totalStars || 0); } catch (e) {} });
+      h[_starsWeekKey(Date.now())] = total;
+      var keys = Object.keys(h).sort();
+      while (keys.length > 12) { delete h[keys.shift()]; }
+      localStorage.setItem('zs_stars_history', JSON.stringify(h));
+    } catch (e) {}
+    return h;
+  }
+  function _seriesSvg(vals, color) {
+    var n = vals.length; if (n < 2) return '';
+    var max = Math.max.apply(null, vals), min = Math.min.apply(null, vals), span = (max - min) || 1;
+    var pts = vals.map(function(v, i) { return [i * (520 / (n - 1)), 80 - ((v - min) / span) * 62]; });
+    var line = pts.map(function(pt, i) { return (i ? 'L' : 'M') + pt[0].toFixed(0) + ',' + pt[1].toFixed(0); }).join(' ');
+    var last = pts[n - 1];
+    return '<svg viewBox="0 0 520 96" width="100%" height="120" preserveAspectRatio="none" style="display:block;">' +
+      '<defs><linearGradient id="ovTrend" x1="0" y1="0" x2="0" y2="1"><stop offset="0%" stop-color="' + color + '" stop-opacity="0.22"></stop><stop offset="100%" stop-color="' + color + '" stop-opacity="0"></stop></linearGradient></defs>' +
+      '<path d="' + line + ' L520,90 L0,90 Z" fill="url(#ovTrend)"></path>' +
+      '<path d="' + line + '" fill="none" stroke="' + color + '" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"></path>' +
+      '<circle cx="' + last[0].toFixed(0) + '" cy="' + last[1].toFixed(0) + '" r="4.5" fill="' + color + '" stroke="#ffffff" stroke-width="2"></circle>' +
+    '</svg>';
+  }
+  // Accrue a weekly snapshot on every hub load (so the trend fills even if the dashboard is rarely opened).
+  try { document.addEventListener('DOMContentLoaded', function() { try { if (typeof getProfiles === 'function') _recordStarsSnapshot(getProfiles()); } catch (e) {} }); } catch (e) {}
+
+  function _renderOverview(profiles) {
+    if (!profiles || !profiles.length) return '';
+    var DAY = 86400000, now = Date.now();
+    var totalStars = 0, tokens = 0, usedMin = 0, maxMin = 0;
+    var activeDays = {}, weekBuckets = [0,0,0,0,0,0,0,0];
+    var appCount = {}, appIcon = {};
+    var perKid = [];
+
+    profiles.forEach(function(p) {
+      var stats = {}, ts = 0, rank = { icon: '🛸', name: 'Cadet' };
+      try { stats = (typeof getPlayerStats === 'function') ? getPlayerStats(p.name) : {}; ts = stats.totalStars || 0; } catch (e) {}
+      try { rank = (typeof getExplorerRank === 'function') ? getExplorerRank(p.name, stats) : rank; } catch (e) {}
+      totalStars += ts;
+      try { var ch = JSON.parse(localStorage.getItem('zs_chores_' + _slug(p.name))); if (ch && ch.totalTokens) tokens += ch.totalTokens; } catch (e) {}
+      try { var td = (typeof TimerManager !== 'undefined' && TimerManager.getDataForKid) ? TimerManager.getDataForKid(p.name) : null; if (td) { usedMin += (td.minutesUsed || 0); maxMin += (td.maxMinutes || 0); } } catch (e) {}
+
+      var ev = [];
+      try { ev = (typeof ActivityLog !== 'undefined') ? (ActivityLog.getForUser(p.name) || []) : []; } catch (e) {}
+      var kidDays = {}, kidWeek = 0, kidApps = {};
+      ev.forEach(function(e) {
+        if (!e || !e.ts) return;
+        var age = now - e.ts;
+        var wk = Math.floor(age / (7 * DAY));
+        if (wk >= 0 && wk < 8) weekBuckets[7 - wk]++;
+        if (age <= 7 * DAY) {
+          var d = new Date(e.ts).toISOString().split('T')[0];
+          activeDays[d] = true; kidDays[d] = true; kidWeek++;
+          if (e.app) { appCount[e.app] = (appCount[e.app] || 0) + 1; if (e.icon) appIcon[e.app] = e.icon; }
+        }
+      });
+      // streak: consecutive days ending today (or yesterday) with activity
+      var streak = 0;
+      for (var i = 0; i < 60; i++) {
+        var dk = new Date(now - i * DAY).toISOString().split('T')[0];
+        if (kidDays[dk]) streak++;
+        else if (i > 0) break;
+      }
+      var topApps = Object.keys(kidApps).sort(function(a, b) { return kidApps[b] - kidApps[a]; }).slice(0, 2);
+      perKid.push({ p: p, stars: ts, rank: rank, week: kidWeek, streak: streak, top: topApps, used: 0, max: 0 });
+    });
+
+    var activeDayCount = Object.keys(activeDays).length;
+    var hasActivity = weekBuckets.some(function(v) { return v > 0; });
+
+    // ---------- summary tiles ----------
+    function tile(accent, icon, big, sub) {
+      return '<div style="padding:16px 16px 14px;border-radius:16px;background:linear-gradient(180deg,' + accent + '14,' + accent + '05);border:1px solid ' + accent + '55;">' +
+        '<div style="display:flex;align-items:center;justify-content:space-between;">' +
+          '<div style="width:34px;height:34px;border-radius:10px;background:' + accent + '22;display:flex;align-items:center;justify-content:center;font-size:18px;">' + icon + '</div>' +
+        '</div>' +
+        '<div style="font-family:var(--font-display);font-weight:800;font-size:1.85rem;line-height:1;margin-top:12px;color:#1c1b29;">' + big + '</div>' +
+        '<div style="font-size:0.78rem;font-weight:700;color:#6b6878;margin-top:3px;">' + sub + '</div>' +
+      '</div>';
+    }
+    var tiles = '<div style="display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:18px;">' +
+      tile('#B45309', '⭐', totalStars, 'Total stars · family') +
+      tile('#0D9488', '🔥', activeDayCount + '<span style="font-size:0.95rem;color:#6b6878;">/7</span>', 'Active days this week') +
+      tile('#2563EB', '⏱', (maxMin ? usedMin : 0) + '<span style="font-size:0.95rem;color:#6b6878;">m</span>', 'Screen time today' + (maxMin ? ' · ' + maxMin + 'm limit' : '')) +
+      tile('#6D28D9', '🪙', tokens, 'Adventure tokens') +
+    '</div>';
+
+    // ---------- trend: prefer real weekly STARS history, else activity sessions ----------
+    var starsHist = _recordStarsSnapshot(profiles);
+    var histKeys = Object.keys(starsHist).sort();
+    var trend, trendTitle, trendBadge, axisL = '', trendAxis = '';
+    if (histKeys.length >= 2) {
+      trend = _seriesSvg(histKeys.map(function(k) { return starsHist[k]; }), '#B45309');
+      trendTitle = 'Stars earned · last ' + histKeys.length + ' weeks';
+      trendBadge = totalStars + ' total';
+      axisL = histKeys.length + ' wks ago';
+    } else if (hasActivity) {
+      trend = _seriesSvg(weekBuckets, '#4338CA');
+      trendTitle = 'Activity · last 8 weeks';
+      trendBadge = weekBuckets.reduce(function(a, b) { return a + b; }, 0) + ' this week';
+      axisL = '8 wks ago';
+    } else {
+      trend = '<div style="padding:28px 8px;text-align:center;color:#9a97a8;font-weight:700;font-size:0.85rem;">Trend builds up one snapshot per week — check back soon.</div>';
+      trendTitle = 'Stars earned · trend';
+      trendBadge = totalStars + ' total';
+    }
+    if (trend.indexOf('<svg') === 0) {
+      trendAxis = '<div style="display:flex;justify-content:space-between;font-size:0.66rem;font-weight:700;color:#9a97a8;margin-top:2px;"><span>' + axisL + '</span><span>now</span></div>';
+    }
+
+    // ---------- screen-time donut (today) ----------
+    var pct = maxMin ? Math.min(1, usedMin / maxMin) : 0;
+    var donutColor = pct < 0.8 ? '#0D9488' : (pct < 1 ? '#B45309' : '#DC2626');
+    var off = (314 * (1 - pct)).toFixed(0);
+    var donut = '<div style="display:flex;align-items:center;gap:16px;">' +
+      '<div style="position:relative;width:104px;height:104px;flex:none;">' +
+        '<svg viewBox="0 0 120 120" width="104" height="104">' +
+          '<circle cx="60" cy="60" r="50" fill="none" stroke="#ece9f5" stroke-width="13"></circle>' +
+          '<circle cx="60" cy="60" r="50" fill="none" stroke="' + donutColor + '" stroke-width="13" stroke-linecap="round" stroke-dasharray="314" stroke-dashoffset="' + off + '" transform="rotate(-90 60 60)"></circle>' +
+        '</svg>' +
+        '<div style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;">' +
+          '<div style="font-family:var(--font-display);font-weight:800;font-size:1.3rem;line-height:1;color:#1c1b29;">' + Math.round(pct * 100) + '%</div>' +
+          '<div style="font-size:0.62rem;font-weight:700;color:#6b6878;">of limit</div>' +
+        '</div>' +
+      '</div>' +
+      '<div style="flex:1;font-size:0.8rem;font-weight:700;color:#3a3850;line-height:1.7;">' +
+        '<div>Used <b style="float:right;">' + usedMin + ' min</b></div>' +
+        '<div>Left <b style="float:right;">' + Math.max(0, maxMin - usedMin) + ' min</b></div>' +
+        '<div style="border-top:1px solid #eceaf3;margin-top:6px;padding-top:6px;color:#6b6878;">Daily limit <b style="color:#1c1b29;">' + maxMin + ' min</b></div>' +
+      '</div>' +
+    '</div>';
+
+    // ---------- charts row ----------
+    var charts = '<div style="display:grid;grid-template-columns:1.7fr 1fr;gap:14px;margin-bottom:18px;">' +
+      '<div style="padding:18px 20px 14px;border-radius:16px;background:#ffffff;border:1px solid #e6e6ee;box-shadow:0 4px 14px rgba(15,15,25,0.08);">' +
+        '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:6px;"><div style="font-weight:800;font-size:0.9rem;color:#1c1b29;">' + trendTitle + '</div><div style="font-size:0.78rem;font-weight:800;color:#4338CA;">' + trendBadge + '</div></div>' +
+        trend + trendAxis +
+      '</div>' +
+      '<div style="padding:18px 20px;border-radius:16px;background:#ffffff;border:1px solid #e6e6ee;box-shadow:0 4px 14px rgba(15,15,25,0.08);">' +
+        '<div style="font-weight:800;font-size:0.9rem;color:#1c1b29;margin-bottom:12px;">Screen time today</div>' + donut +
+      '</div>' +
+    '</div>';
+
+    // ---------- per-kid snapshot cards ----------
+    var kidCards = perKid.map(function(k) {
+      var col = safeColor(k.p.color);
+      var nr = _nextRank(k.stars);
+      var pPct = 100;
+      if (nr.next) { var span = nr.next.s - nr.prev.s; pPct = span > 0 ? Math.round(((k.stars - nr.prev.s) / span) * 100) : 0; }
+      var chips = k.top.map(function(a) {
+        return '<span style="font-size:0.62rem;font-weight:800;color:#fff;background:' + _appColor(a) + ';padding:3px 8px;border-radius:99px;">' + escHtml((appIcon[a] || '') + ' ' + a) + '</span>';
+      }).join('');
+      return '<div style="padding:15px;border-radius:16px;background:#ffffff;border:1px solid #e6e6ee;box-shadow:0 4px 14px rgba(15,15,25,0.08);">' +
+        '<div style="display:flex;align-items:center;gap:10px;margin-bottom:11px;">' +
+          '<div style="width:40px;height:40px;border-radius:50%;border:2.5px solid ' + col + ';background:' + col + '1a;display:flex;align-items:center;justify-content:center;font-size:20px;">' + escHtml(k.p.avatar) + '</div>' +
+          '<div style="min-width:0;"><div style="font-family:var(--font-display);font-weight:800;font-size:0.98rem;color:#1c1b29;">' + escHtml(k.p.name) + '</div>' +
+          '<div style="font-size:0.7rem;font-weight:800;color:' + col + ';">' + k.rank.icon + ' ' + escHtml(k.rank.name) + ' · ' + k.stars + ' ★</div></div>' +
+          (k.streak > 1 ? '<div style="margin-left:auto;font-size:0.7rem;font-weight:800;color:#C2410C;">🔥 ' + k.streak + 'd</div>' : '') +
+        '</div>' +
+        '<div style="height:7px;border-radius:99px;background:#ece9f5;overflow:hidden;margin-bottom:6px;"><div style="width:' + Math.max(3, Math.min(100, pPct)) + '%;height:100%;border-radius:99px;background:' + col + ';"></div></div>' +
+        '<div style="font-size:0.68rem;font-weight:700;color:#6b6878;margin-bottom:' + (chips ? '10' : '0') + 'px;">' + (nr.next ? (nr.next.s - k.stars) + ' ★ to ' + nr.next.i + ' ' + nr.next.n : 'Top rank reached! 👑') + '</div>' +
+        (chips ? '<div style="display:flex;gap:6px;flex-wrap:wrap;">' + chips + '</div>' : '') +
+      '</div>';
+    }).join('');
+    var kids = '<div style="font-weight:800;font-size:0.9rem;color:#1c1b29;margin:4px 0 12px;">Explorers</div>' +
+      '<div style="display:grid;grid-template-columns:repeat(' + Math.min(3, perKid.length) + ',1fr);gap:14px;margin-bottom:18px;">' + kidCards + '</div>';
+
+    // ---------- most-used apps (last 7 days) ----------
+    var apps = '';
+    var appList = Object.keys(appCount).sort(function(a, b) { return appCount[b] - appCount[a]; }).slice(0, 5);
+    if (appList.length) {
+      var amax = Math.max.apply(null, appList.map(function(a) { return appCount[a]; }).concat([1]));
+      var rows = appList.map(function(a) {
+        var w = Math.round((appCount[a] / amax) * 100);
+        return '<div style="display:flex;align-items:center;gap:10px;margin-bottom:10px;">' +
+          '<span style="font-size:15px;width:20px;text-align:center;">' + escHtml(appIcon[a] || '📦') + '</span>' +
+          '<span style="font-size:0.8rem;font-weight:700;width:110px;color:#1c1b29;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">' + escHtml(a) + '</span>' +
+          '<div style="flex:1;height:9px;border-radius:99px;background:#ece9f5;overflow:hidden;"><div style="width:' + w + '%;height:100%;border-radius:99px;background:' + _appColor(a) + ';"></div></div>' +
+          '<span style="font-size:0.72rem;font-weight:800;color:#6b6878;width:34px;text-align:right;">' + appCount[a] + '×</span>' +
+        '</div>';
+      }).join('');
+      apps = '<div style="padding:18px 20px;border-radius:16px;background:#ffffff;border:1px solid #e6e6ee;box-shadow:0 4px 14px rgba(15,15,25,0.08);margin-bottom:24px;">' +
+        '<div style="font-weight:800;font-size:0.9rem;color:#1c1b29;margin-bottom:14px;">Most-used apps · this week</div>' + rows +
+      '</div>';
+    }
+
+    return '<div style="margin-bottom:8px;">' + tiles + charts + kids + apps + '</div>';
+  }
+
   function _openDashboard() {
     if (typeof Debug !== 'undefined') Debug.log('Opening Dashboard...');
     var content = document.getElementById('dash-content');
@@ -706,6 +931,9 @@
       }
 
       var html = '';
+
+      // ── Redesign: at-a-glance overview (charts wired to real data) ──
+      try { html += _renderOverview(profiles); } catch (e) { if (typeof Debug !== 'undefined') Debug.error('overview render failed', e.message); }
 
       // Diagnostics flush row — small utility for parents / dev
       if (typeof ZsDiag !== 'undefined') {
@@ -754,7 +982,7 @@
           html += '<div style="display:flex; flex-direction:column; gap:8px;">';
           allRecent.forEach(function(e) {
             var when = _timeAgo(e.ts);
-            html += '<div style="display:flex; align-items:center; gap:10px; padding:10px; background:rgba(255,255,255,0.02); border:1px solid rgba(255,255,255,0.05); border-radius:12px;">' +
+            html += '<div style="display:flex; align-items:center; gap:10px; padding:10px; background:#ffffff; border:1px solid #e6e6ee; box-shadow:0 2px 6px rgba(15,15,25,0.05); border-radius:12px;">' +
               '<span style="font-size:1.2rem;">' + escHtml(e.icon) + '</span>' +
               '<div style="flex:1; min-width:0;">' +
                 '<div style="font-weight:700; font-size:0.85rem;">' + escHtml(e.kidName) + ' · ' + escHtml(e.app) + '</div>' +
@@ -899,16 +1127,16 @@
   //     suggest Sports Arena?") when the balance is skewed
   // No writes, no push notifications — nudges live inside this panel.
   var _INSIGHT_CATEGORIES = {
-    physical:       { label: 'Physical', color: '#34D399', apps: ['Sports Arena'] },
-    math:           { label: 'Math',     color: '#60A5FA', apps: ['Math Galaxy'] },
-    music:          { label: 'Music',    color: '#A78BFA', apps: ['Little Maestro', 'Guitar Jam'] },
-    creative:       { label: 'Creative', color: '#F472B6', apps: ['Art Studio'] },
-    language:       { label: 'Language', color: '#F59E0B', apps: ['Story Explorer', 'Guess Quest'] },
-    culture:        { label: 'Culture',  color: '#F87171', apps: ['Descubre Chile', 'Fe Explorador', 'World Explorer'] },
-    science:        { label: 'Science',  color: '#22D3EE', apps: ['Lab Explorer'] },
-    strategy:       { label: 'Strategy', color: '#FBBF24', apps: ['Chess Quest'] },
-    adventure:      { label: 'Quests',   color: '#8B5CF6', apps: ['Quest Adventure', 'Book & Movie Check'] },
-    habit:          { label: 'Habits',   color: '#10B981', apps: ['Routines'] }
+    physical:       { label: 'Physical', color: '#0D9488', apps: ['Sports Arena'] },
+    math:           { label: 'Math',     color: '#1D4ED8', apps: ['Math Galaxy'] },
+    music:          { label: 'Music',    color: '#6D28D9', apps: ['Little Maestro', 'Guitar Jam'] },
+    creative:       { label: 'Creative', color: '#BE185D', apps: ['Art Studio'] },
+    language:       { label: 'Language', color: '#C2410C', apps: ['Story Explorer', 'Guess Quest'] },
+    culture:        { label: 'Culture',  color: '#B91C1C', apps: ['Descubre Chile', 'Fe Explorador', 'World Explorer'] },
+    science:        { label: 'Science',  color: '#0E7490', apps: ['Lab Explorer'] },
+    strategy:       { label: 'Strategy', color: '#B45309', apps: ['Chess Quest'] },
+    adventure:      { label: 'Quests',   color: '#4338CA', apps: ['Quest Adventure', 'Book & Movie Check'] },
+    habit:          { label: 'Habits',   color: '#047857', apps: ['Routines'] }
   };
 
   function _classifyApp(appName) {

--- a/js/timer.js
+++ b/js/timer.js
@@ -171,16 +171,16 @@ var TimerManager = (function() {
     var style = document.createElement('style');
     style.id = 'timer-lock-styles';
     style.textContent = 
-      '#timer-lock-overlay { position:fixed; inset:0; background:rgba(11,11,26,0.98); z-index:10000; display:flex; align-items:center; justify-content:center; color:#fff; text-align:center; font-family:var(--font-display); }' +
+      '#timer-lock-overlay { position:fixed; inset:0; background:rgba(241,241,244,0.98); z-index:10000; display:flex; align-items:center; justify-content:center; color:#1c1b29; text-align:center; font-family:var(--font-display); }' +
       '.lock-panel { max-width:400px; padding:40px 20px; }' +
       '.lock-emoji { font-size:80px; margin-bottom:20px; }' +
-      '.lock-msg { font-size:1.2rem; margin-bottom:30px; line-height:1.5; color:var(--text-muted); }' +
+      '.lock-msg { font-size:1.2rem; margin-bottom:30px; line-height:1.5; color:#6b6878; }' +
       '.lock-actions { display:flex; flex-direction:column; gap:12px; }' +
       '.lock-btn { padding:14px; border-radius:12px; border:none; font-weight:800; font-family:var(--font-display); cursor:pointer; }' +
-      '.btn-switch { background:var(--purple); color:#fff; }' +
-      '.btn-parent { background:#333; color:var(--text-muted); }' +
+      '.btn-switch { background:linear-gradient(135deg,#4338CA,#6366F1); color:#fff; }' +
+      '.btn-parent { background:#ffffff; border:1px solid #e6e6ee; color:#6b6878; }' +
       '.lock-pin-area { margin-top:20px; display:none; flex-direction:column; gap:10px; }' +
-      '.lock-pin-input { background:rgba(0,0,0,0.3); border:1px solid rgba(255,255,255,0.1); padding:12px; border-radius:8px; color:#fff; text-align:center; font-size:1.5rem; letter-spacing:8px; }';
+      '.lock-pin-input { background:#f4f3f8; border:2px solid #e2def0; padding:12px; border-radius:8px; color:#1c1b29; text-align:center; font-size:1.5rem; letter-spacing:8px; }';
     document.head.appendChild(style);
 
     var paused = isPaused();

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/lab-explorer.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -19,6 +19,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700;800;900&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="css/little-maestro.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <script src="js/debug.js?v=2"></script>
 
   <script src="js/vexflow-min.js"></script>
@@ -15561,28 +15562,28 @@ document.addEventListener('DOMContentLoaded', () => {
     * { box-sizing: border-box; margin: 0; padding: 0; }
     body {
       font-family: 'Nunito', sans-serif;
-      background: linear-gradient(135deg, #0A0514 0%, #150B30 100%);
-      color: #EDE9FE;
+      background: #f1f1f4;
+      color: #1c1b29;
       min-height: 100vh;
       padding: 40px 20px;
     }
     .card {
-      background: rgba(255,255,255,0.05);
-      border: 1px solid rgba(124,58,237,0.3);
+      background: #ffffff;
+      border: 1px solid #e6e6ee;
       border-radius: 20px;
       padding: 40px;
       max-width: 640px;
       margin: 0 auto;
     }
-    h1 { font-size: 32px; font-weight: 900; color: #EDE9FE; margin-bottom: 4px; }
-    .subtitle { color: #A78BFA; font-size: 15px; font-weight: 600; margin-bottom: 32px; }
+    h1 { font-size: 32px; font-weight: 900; color: #1c1b29; margin-bottom: 4px; }
+    .subtitle { color: #6D28D9; font-size: 15px; font-weight: 600; margin-bottom: 32px; }
     .stats-grid { display: grid; grid-template-columns: repeat(4,1fr); gap: 12px; margin-bottom: 32px; }
-    .stat { background: rgba(124,58,237,0.1); border: 1px solid rgba(124,58,237,0.2); border-radius: 12px; padding: 14px 8px; text-align: center; }
+    .stat { background: #ece9f5; border: 1px solid #e6e6ee; border-radius: 12px; padding: 14px 8px; text-align: center; }
     .stat-val { font-size: 26px; font-weight: 900; }
-    .stat-lbl { font-size: 10px; font-weight: 700; color: #A78BFA; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 2px; }
-    h2 { font-size: 16px; font-weight: 800; color: #A78BFA; letter-spacing: 0.5px; margin-bottom: 12px; }
-    table { width: 100%; border-collapse: collapse; background: rgba(255,255,255,0.03); border-radius: 10px; overflow: hidden; }
-    tr { border-bottom: 1px solid rgba(124,58,237,0.15); }
+    .stat-lbl { font-size: 10px; font-weight: 700; color: #6D28D9; text-transform: uppercase; letter-spacing: 0.5px; margin-top: 2px; }
+    h2 { font-size: 16px; font-weight: 800; color: #6D28D9; letter-spacing: 0.5px; margin-bottom: 12px; }
+    table { width: 100%; border-collapse: collapse; background: #ffffff; border-radius: 10px; overflow: hidden; }
+    tr { border-bottom: 1px solid #e6e6ee; }
     tr:last-child { border-bottom: none; }
     .footer { text-align: center; margin-top: 32px; color: #6D28D9; font-size: 13px; font-weight: 700; }
     @media print {

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/math-galaxy.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/menu.html
+++ b/menu.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/menu.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/money-master.html
+++ b/money-master.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/money-master.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/quest-adventure.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/shopping-list.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/sports-arena.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">
@@ -248,7 +249,7 @@
 
   <!-- ============ TOURNAMENT SCORE MODAL ============ -->
   <div id="score-modal" style="display:none; position:fixed; inset:0; z-index:9999; background:rgba(11,11,26,0.92); backdrop-filter:blur(10px); align-items:center; justify-content:center;">
-    <div style="background:rgba(30,30,60,0.95); border:1.5px solid rgba(16,185,129,0.3); border-radius:24px; padding:32px 28px; max-width:380px; width:90%; text-align:center;">
+    <div style="background:#ffffff; border:1.5px solid #e6e6ee; border-radius:24px; padding:32px 28px; max-width:380px; width:90%; text-align:center;">
       <div style="font-size:2rem; margin-bottom:8px;">🏓</div>
       <div style="font-family:var(--font-display); font-size:1.2rem; font-weight:800; margin-bottom:16px;" id="score-modal-title">Enter Score</div>
       <div id="score-modal-inputs"></div>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/story-explorer.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/sunday-report.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/trophy-room.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/vacation.html
+++ b/vacation.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/vacation.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/vocabulario-vivo.html
+++ b/vocabulario-vivo.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/vocabulario-vivo.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#F472B6">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/world-cup.html
+++ b/world-cup.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/world-cup.css?v=21">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#16A34A">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
   <link rel="stylesheet" href="css/world-explorer.css">
+  <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
   <link rel="icon" type="image/svg+xml" href="icons/icon.svg">


### PR DESCRIPTION
## Overview
Rolls the 2026 **light theme** across the whole suite per the redesign handoff: neutral light-grey screen (`#f1f1f4`), crisp white modules, solid saturated pills, solid ink titles (`#312e81`, no gradients), and indigo CTAs — replacing the original dark "space" theme.

## What's included

**Foundation (reference install + shared chrome)**
- Add `css/zs-theme.css` — global light tokens + shared chrome + component recipes (linked **last** on every page so it wins on source order).
- Add `css/redesign.css` and link it last in `index.html` + `family.html` (hub, login, dashboard shell, Family Wall).
- Update `js/index.js` with the data-wired Parent Dashboard overview (summary tiles, stars trend, screen-time donut, most-used apps, per-kid snapshots) and the deepened insight palette.
- Relight `#timer-lock-overlay` in `js/timer.js` → `rgba(241,241,244,0.98)` scrim, dark text, indigo switch CTA, light pin input.

**26 sub-apps converted** — each links `zs-theme.css` last and has its own CSS converted dark→light (white modules, sunken `#ece9f5` tracks, solid pills, solid `#312e81` titles, indigo `linear-gradient(135deg,#4338CA,#6366F1)` CTAs):

little-maestro · math-galaxy · chess-quest · world-cup · descubre-chile · guess-quest · guitar-jam · vocabulario-vivo · book-movie-check · bible-explorer · lab-explorer · sports-arena · art-studio · world-explorer · story-explorer · quest-adventure · civics-lab · code-cadet · money-master · menu · vacation · home-timer · shopping-list · trophy-room · sunday-report · fe-explorador

**Design-identity fills deliberately preserved:** piano keys, chess board squares, World Cup team/bracket cards, currency cards, lab color-mixing swatches, art palette/brush colors, code blocks, trophy tier metals, guitar fretboard greens, the falling-notes gameplay stage, and modal scrims.

## Verification
- All 26 sub-app pages link `zs-theme.css` exactly once.
- Zero residual dark surface literals (`#0B0B1A` / `#131328` / `#1A1A3E`) and zero gradient-text (transparent-fill) titles across sub-app CSS.
- Remaining dark literals exist only in `css/index.css` + `css/family-wall.css`, which `redesign.css` overrides by design (reference files, untouched).

> **Note:** verification was **static** (residual-dark grep + CSS-cascade analysis), not visual screenshots — the environment's network policy blocks Playwright's Chromium download and no system browser is available. For true screenshots, whitelist `cdn.playwright.dev` or run `npx playwright test` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5ZY2DCXhN3623UPR2J5BE

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5ZY2DCXhN3623UPR2J5BE)_