### PR TITLE
World Cup: fix infinite render loop in tier-2 match-detail hydration

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -4961,6 +4961,12 @@
   function _hydrateMatchDetail(m) {
     const eventId = m && m.result && m.result.eventId;
     if (!eventId) return;
+    // Bail if cache is fresh — m.result already holds the latest
+    // scorers/cards from the previous fetch. Without this gate, the
+    // post-fetch re-render below calls editResult, which calls us
+    // again, which sees the cache as still empty... freeze.
+    const cached = _matchDetailCache.get(eventId);
+    if (cached && Date.now() - cached.fetchedAt < MATCH_DETAIL_TTL_MS) return;
     _fetchMatchDetail(eventId).then(detail => {
       if (!detail) return;
       // Overlay onto local result so the static scorer renderer picks

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=29"></script>
+  <script src="js/world-cup.js?v=30"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Reported on Canada vs Qatar — opening the match modal froze the app. Tier-2 introduced an `editResult ↔ _hydrateMatchDetail` recursion:

1. `editResult` renders the modal and fires `_hydrateMatchDetail`.
2. `_fetchMatchDetail` returns (network first time, cache after).
3. `.then()` mutates `m.result` and calls `editResult(m.id)` to refresh the rendered scorers/cards.
4. `editResult` fires `_hydrateMatchDetail` again.
5. `_hydrateMatchDetail` kicks another `_fetchMatchDetail`. Cache hit returns instantly, `.then()` mutates + `editResult` again... forever.

Each spin happens inside a microtask, so the browser never repaints and the tab feels frozen. The 5-min in-memory cache short-circuited the network round trip but didn't break the loop because hydrate itself didn't check freshness.

### Fix
Gate `_hydrateMatchDetail` on the cache's TTL up front. If the match's `eventId` is already in the cache and fresh, bail before firing a new fetch — `m.result` already has the latest detail from the previous render, so a re-render would no-op anyway.

Loop simulator: `editResult` now fires exactly **twice** per session (initial open + one re-render after the fetch lands), then the gate engages.

Cache bust: `world-cup.js` v29→30.

## Test plan
- [ ] Open Canada vs Qatar (and any other previously-frozen match) → modal opens and stays responsive.
- [ ] Scorers + cards still appear within ~1s of first open.
- [ ] Repeat-open the same match within 5 min → renders instantly from cache, no flash.
- [ ] After 5 min, re-open → cache expires, fetches again, still no loop.
- [ ] Prev/next navigation works without sticking.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_