### PR TITLE
Family Wall: add Summer Quest shared kids' summer to-do card

### DIFF
--- a/css/family-wall.css
+++ b/css/family-wall.css
@@ -106,12 +106,14 @@ body {
     grid-auto-flow: dense;
   }
   .fw-card-routines { grid-column: span 2; }
+  .fw-card-summer { grid-column: span 2; }
 }
 @media (min-width: 1100px) {
   .fw-grid {
     grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) minmax(0, 1fr);
   }
   .fw-card-routines { grid-column: span 3; }
+  .fw-card-summer { grid-column: span 2; }
   .fw-card-weather { grid-column: span 1; }
   .fw-card-calendar { grid-column: span 1; }
   .fw-card-week { grid-column: span 1; }
@@ -269,6 +271,166 @@ body {
   font-style: italic;
   padding: 4px 0;
 }
+
+/* ---- Summer Quest card ---- */
+.fw-sq-bar {
+  height: 8px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 99px;
+  overflow: hidden;
+  margin-bottom: 14px;
+}
+.fw-sq-bar-fill {
+  height: 100%;
+  border-radius: 99px;
+  background: linear-gradient(90deg, var(--fw-orange), var(--fw-gold));
+  transition: width 0.4s ease;
+}
+
+.fw-sq-kids {
+  display: flex; flex-wrap: wrap; gap: 8px;
+  margin-bottom: 8px;
+}
+.fw-sq-kid {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 6px;
+  background: rgba(255,255,255,0.04);
+  border: 1.5px solid var(--fw-border);
+  border-radius: 99px;
+  cursor: pointer;
+  color: var(--fw-text);
+  font-family: inherit;
+  transition: border-color 0.15s, background 0.15s, transform 0.15s;
+}
+.fw-sq-kid:hover { transform: translateY(-1px); }
+.fw-sq-kid.active {
+  border-color: var(--avatar-color, var(--fw-accent));
+  background: rgba(167,139,250,0.12);
+  box-shadow: 0 0 0 2px var(--avatar-color, var(--fw-accent));
+}
+.fw-sq-kid-av {
+  width: 30px; height: 30px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 16px;
+  background: var(--fw-card-strong);
+  border: 2px solid var(--avatar-color, var(--fw-accent));
+  flex-shrink: 0;
+}
+.fw-sq-kid-meta { display: flex; flex-direction: column; line-height: 1.1; text-align: left; }
+.fw-sq-kid-name { font-weight: 800; font-size: 0.85rem; }
+.fw-sq-kid-stat { font-size: 0.7rem; color: var(--fw-muted); font-weight: 800; }
+.fw-sq-kid.active .fw-sq-kid-stat { color: var(--fw-gold); }
+
+.fw-sq-hint {
+  font-size: 0.74rem; color: var(--fw-muted); font-weight: 700;
+  margin-bottom: 12px;
+}
+.fw-sq-hint b { color: var(--fw-text); }
+
+.fw-sq-add { display: flex; gap: 8px; margin-bottom: 12px; }
+.fw-sq-add input {
+  flex: 1; min-width: 0;
+  padding: 10px 12px;
+  background: var(--fw-card);
+  border: 1px solid var(--fw-border);
+  border-radius: 12px;
+  color: var(--fw-text);
+  font-family: var(--font-body, sans-serif);
+  font-size: 0.9rem;
+}
+.fw-sq-add input:focus { outline: none; border-color: var(--fw-accent); }
+.fw-sq-add-btn {
+  flex-shrink: 0;
+  width: 42px;
+  background: linear-gradient(135deg, var(--fw-orange), var(--fw-gold));
+  border: none;
+  border-radius: 12px;
+  color: #2b1a00;
+  font-size: 1.3rem; font-weight: 800;
+  cursor: pointer;
+}
+.fw-sq-add-btn:hover { filter: brightness(1.05); }
+
+.fw-sq-empty { padding: 6px 0 14px; }
+
+.fw-sq-list {
+  display: flex; flex-direction: column;
+  max-height: 280px; overflow-y: auto;
+  margin-bottom: 12px;
+  padding-right: 4px;
+}
+.fw-sq-list::-webkit-scrollbar { width: 8px; }
+.fw-sq-list::-webkit-scrollbar-track { background: transparent; }
+.fw-sq-list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.12); border-radius: 4px; }
+.fw-sq-list::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.22); }
+
+.fw-sq-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--fw-border);
+}
+.fw-sq-item:last-child { border-bottom: none; }
+.fw-sq-check {
+  flex-shrink: 0;
+  width: 24px; height: 24px;
+  border: 2px solid var(--fw-muted);
+  border-radius: 7px;
+  background: transparent;
+  color: #073b27;
+  font-size: 14px; font-weight: 900; line-height: 1;
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  transition: background 0.15s, border-color 0.15s;
+}
+.fw-sq-item.done .fw-sq-check {
+  background: var(--fw-green);
+  border-color: var(--fw-green);
+}
+.fw-sq-label {
+  flex: 1;
+  font-weight: 700; font-size: 0.92rem;
+  display: flex; flex-wrap: wrap; align-items: baseline; gap: 8px;
+}
+.fw-sq-item.done .fw-sq-label {
+  color: var(--fw-muted);
+  text-decoration: line-through;
+  text-decoration-color: rgba(52,211,153,0.6);
+}
+.fw-sq-who {
+  font-size: 0.7rem; font-weight: 800;
+  color: var(--fw-green);
+  text-decoration: none;
+  background: rgba(52,211,153,0.14);
+  padding: 1px 7px; border-radius: 99px;
+}
+.fw-sq-del {
+  flex-shrink: 0;
+  background: transparent; border: none;
+  font-size: 0.85rem; cursor: pointer;
+  opacity: 0.4; transition: opacity 0.15s;
+  padding: 4px;
+}
+.fw-sq-del:hover { opacity: 1; }
+
+.fw-sq-goal {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-top: auto;
+  padding-top: 10px;
+  border-top: 1px solid var(--fw-border);
+  font-size: 0.82rem; font-weight: 700; color: var(--fw-muted);
+}
+.fw-sq-goal b { color: var(--fw-text); }
+.fw-sq-goal-btns { display: flex; gap: 6px; }
+.fw-sq-goal-btns button {
+  width: 28px; height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--fw-border);
+  background: var(--fw-card-strong);
+  color: var(--fw-text);
+  font-size: 1rem; font-weight: 800;
+  cursor: pointer;
+}
+.fw-sq-goal-btns button:hover { border-color: var(--fw-accent); }
 
 /* ---- Calendar / Menu / Shopping rows ---- */
 .fw-event-row, .fw-menu-row, .fw-shop-row {

--- a/family.html
+++ b/family.html
@@ -54,8 +54,9 @@
   <script src="js/activity-log.js?v=2"></script>
   <script src="js/chilean-calendar.js?v=2"></script>
   <script src="js/routines.js?v=3"></script>
+  <script src="js/summer-todos.js?v=1"></script>
   <script src="js/family-calendar.js?v=6"></script>
-  <script src="js/family-wall.js?v=4"></script>
+  <script src="js/family-wall.js?v=5"></script>
   <script src="js/pwa.js?v=2"></script>
 </body>
 </html>

--- a/js/family-wall.js
+++ b/js/family-wall.js
@@ -266,6 +266,7 @@ var FamilyWall = (function() {
       '<div class="fw-grid">' +
         _renderWeatherCard() +
         _renderRoutinesCard(profiles) +
+        _renderSummerCard(profiles) +
         _renderCalendarCard() +
         _renderWeekCard() +
         _renderMenuCard() +
@@ -390,6 +391,149 @@ var FamilyWall = (function() {
         rows +
       '</div>' +
     '</div>';
+  }
+
+  // ---- Summer Quest card ----------------------------------------
+  // Shared family summer bucket list with per-kid credit + streaks.
+  // `_summerKid` is the kid that completions are credited to; it's a
+  // UI selection (not persisted), defaulting to the logged-in kid.
+  var _summerKid = null;
+
+  function _summerKidsList(profiles) {
+    // Same set of profiles the Routines card shows (parents who opt out
+    // of routines don't clutter the wall with a summer chip either).
+    return (profiles || []).filter(function(p) {
+      if (typeof Routines !== 'undefined' && typeof Routines.isEnabledFor === 'function') {
+        return Routines.isEnabledFor(p.name);
+      }
+      return p && p.routinesEnabled !== false;
+    });
+  }
+
+  function _summerActiveKid(profiles) {
+    var kids = _summerKidsList(profiles);
+    if (_summerKid && kids.some(function(p) { return p.name === _summerKid; })) return _summerKid;
+    var active = (typeof getActiveUser === 'function') ? getActiveUser() : null;
+    if (active && kids.some(function(p) { return p.name === active.name; })) return active.name;
+    return kids.length ? kids[0].name : null;
+  }
+
+  function _renderSummerCard(profiles) {
+    if (typeof SummerTodos === 'undefined') return '';
+
+    var prog = SummerTodos.getProgress();
+    var target = SummerTodos.getTarget();
+    var items = SummerTodos.getItems();
+    var kids = _summerKidsList(profiles);
+    var creditKid = _summerActiveKid(profiles);
+
+    var pct = prog.total ? Math.round((prog.done / prog.total) * 100) : 0;
+
+    // Per-kid chips: tap to choose who's checking things off.
+    var chips = kids.map(function(p) {
+      var c = SummerTodos.getCreditFor(p.name);
+      var on = p.name === creditKid;
+      var stat = c.doneToday + '/' + target + (c.reachedTarget ? ' ✓' : '') +
+        (c.streak > 0 ? ' · 🔥' + c.streak : '');
+      return '<button class="fw-sq-kid ' + (on ? 'active' : '') + '" ' +
+               'style="--avatar-color:' + _esc(p.color || '#A78BFA') + '" ' +
+               'onclick="FamilyWall.summerPickKid(\'' + _escAttr(p.name) + '\')">' +
+        '<span class="fw-sq-kid-av">' + _esc(p.avatar || '🦊') + '</span>' +
+        '<span class="fw-sq-kid-meta">' +
+          '<span class="fw-sq-kid-name">' + _esc(p.name) + '</span>' +
+          '<span class="fw-sq-kid-stat">' + _esc(stat) + '</span>' +
+        '</span>' +
+      '</button>';
+    }).join('');
+
+    var chipsBlock = kids.length
+      ? '<div class="fw-sq-kids">' + chips + '</div>' +
+        '<div class="fw-sq-hint">' +
+          (creditKid
+            ? 'Crediting <b>' + _esc(creditKid) + '</b> — tap a name to switch, then tap what you did.'
+            : 'Tap a name, then check off what you did today.') +
+        '</div>'
+      : '';
+
+    var addForm =
+      '<form class="fw-sq-add" onsubmit="return FamilyWall.summerAdd(event)">' +
+        '<input type="text" id="fw-sq-input" maxlength="120" autocomplete="off" ' +
+               'placeholder="Add a summer to-do…" aria-label="New summer to-do" />' +
+        '<button type="submit" class="fw-sq-add-btn" aria-label="Add to-do">＋</button>' +
+      '</form>';
+
+    var listBlock;
+    if (!items.length) {
+      listBlock = '<div class="fw-card-empty fw-sq-empty">No summer to-dos yet — add your first one above ☀️</div>';
+    } else {
+      // Unfinished first, then completed (struck through with who did it).
+      var ordered = items.slice().sort(function(a, b) {
+        if (!!a.done === !!b.done) return (a.createdAt || 0) - (b.createdAt || 0);
+        return a.done ? 1 : -1;
+      });
+      var rows = ordered.map(function(it) {
+        var who = it.done && it.doneBy ? '<span class="fw-sq-who">✓ ' + _esc(it.doneBy) + '</span>' : '';
+        return '<div class="fw-sq-item ' + (it.done ? 'done' : '') + '">' +
+          '<button class="fw-sq-check" aria-label="Toggle done" ' +
+                  'onclick="FamilyWall.summerToggle(\'' + _escAttr(it.id) + '\')">' +
+            (it.done ? '✓' : '') +
+          '</button>' +
+          '<span class="fw-sq-label">' + _esc(it.label) + who + '</span>' +
+          '<button class="fw-sq-del" aria-label="Remove to-do" ' +
+                  'onclick="FamilyWall.summerRemove(\'' + _escAttr(it.id) + '\')">🗑</button>' +
+        '</div>';
+      }).join('');
+      listBlock = '<div class="fw-sq-list">' + rows + '</div>';
+    }
+
+    var goal =
+      '<div class="fw-sq-goal">' +
+        '<span>🎯 Daily goal: <b>' + target + '</b> per kid</span>' +
+        '<span class="fw-sq-goal-btns">' +
+          '<button onclick="FamilyWall.summerTarget(-1)" aria-label="Lower daily goal">−</button>' +
+          '<button onclick="FamilyWall.summerTarget(1)" aria-label="Raise daily goal">＋</button>' +
+        '</span>' +
+      '</div>';
+
+    return '<div class="fw-card fw-card-summer">' +
+      '<div class="fw-card-head"><span class="fw-card-icon">🏖️</span> Summer Quest · ' +
+        prog.done + '/' + prog.total + '</div>' +
+      '<div class="fw-sq-bar"><div class="fw-sq-bar-fill" style="width:' + pct + '%"></div></div>' +
+      chipsBlock +
+      addForm +
+      listBlock +
+      goal +
+    '</div>';
+  }
+
+  // ---- Summer Quest handlers ----
+  function summerPickKid(name) {
+    _summerKid = name;
+    _paint();
+  }
+  function summerAdd(ev) {
+    if (ev && ev.preventDefault) ev.preventDefault();
+    var inp = document.getElementById('fw-sq-input');
+    if (inp && typeof SummerTodos !== 'undefined') SummerTodos.addItem(inp.value);
+    _paint();
+    return false;
+  }
+  function summerToggle(id) {
+    if (typeof SummerTodos === 'undefined') return;
+    var profiles = (typeof getProfiles === 'function') ? getProfiles() : [];
+    SummerTodos.toggleItem(id, _summerActiveKid(profiles));
+    _paint();
+  }
+  function summerRemove(id) {
+    if (typeof SummerTodos === 'undefined') return;
+    if (typeof confirm === 'function' && !confirm('Remove this summer to-do?')) return;
+    SummerTodos.removeItem(id);
+    _paint();
+  }
+  function summerTarget(delta) {
+    if (typeof SummerTodos === 'undefined') return;
+    SummerTodos.setTarget(SummerTodos.getTarget() + delta);
+    _paint();
   }
 
   function _renderCalendarCard() {
@@ -712,6 +856,11 @@ var FamilyWall = (function() {
     paint: _paint,
     loginAs: loginAs,
     toggleRoutine: toggleRoutine,
+    summerPickKid: summerPickKid,
+    summerAdd: summerAdd,
+    summerToggle: summerToggle,
+    summerRemove: summerRemove,
+    summerTarget: summerTarget,
     openLocationModal: openLocationModal,
     closeLocationModal: closeLocationModal,
     requestGeo: requestGeo,

--- a/js/summer-todos.js
+++ b/js/summer-todos.js
@@ -1,0 +1,187 @@
+/* ================================================================
+   SUMMER QUEST — summer-todos.js
+   A shared family "summer bucket list" that lives on the Family Wall.
+   Unlike Routines (which reset every night) or Chores (which earn
+   screen-time tokens), these are one-time things to accomplish over
+   the whole summer — and the goal is to knock out a few PER DAY.
+
+   Design (per parent request):
+     - ONE shared list the whole family works through together.
+     - PER-KID CREDIT: each completed item records who did it + when,
+       so every kid sees their own "done today" count and 🔥 streak.
+     - DAILY TARGET + STREAK: hit `target` items in a day and your
+       streak grows; miss a day and it resets (same rule as Routines).
+     - Starts EMPTY: the kids add their own summer to-dos.
+
+   Storage key (household-shared, syncs via CloudSync HOUSEHOLD_KEYS):
+     zs_summer_todos = {
+       items:  [ { id, label, done, doneBy, doneAt(YYYY-MM-DD), createdAt } ],
+       target: 2,
+       credit: { "<kidkey>": { streak, bestStreak, lastTargetDay } }
+     }
+   ================================================================ */
+
+var SummerTodos = (function() {
+  'use strict';
+
+  var STORAGE_KEY = 'zs_summer_todos';
+  var DEFAULT_TARGET = 2;
+  var MAX_TARGET = 20;
+
+  function _today() {
+    var d = new Date();
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _yesterday() {
+    var d = new Date();
+    d.setDate(d.getDate() - 1);
+    return d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+  }
+
+  function _kidKey(name) {
+    return String(name == null ? '' : name).toLowerCase().replace(/\s+/g, '_');
+  }
+
+  function _genId() {
+    return 's_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 7);
+  }
+
+  function _load() {
+    try {
+      var data = JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}') || {};
+      if (!Array.isArray(data.items)) data.items = [];
+      if (typeof data.target !== 'number' || data.target < 1) data.target = DEFAULT_TARGET;
+      if (!data.credit || typeof data.credit !== 'object') data.credit = {};
+      return data;
+    } catch (e) {
+      return { items: [], target: DEFAULT_TARGET, credit: {} };
+    }
+  }
+
+  function _save(data) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); } catch (e) {}
+    // Mirror to the shared household bucket so every family device
+    // (iPad on the fridge, parents' phones) sees the same list.
+    if (typeof CloudSync !== 'undefined' && CloudSync.push) CloudSync.push(STORAGE_KEY);
+  }
+
+  // ---- Reads ----
+  function getData() { return _load(); }
+  function getItems() { return _load().items; }
+  function getTarget() { return _load().target; }
+
+  function getProgress() {
+    var items = _load().items;
+    var done = items.filter(function(it) { return it.done; }).length;
+    return { done: done, total: items.length };
+  }
+
+  function doneTodayFor(kidName) {
+    var kk = _kidKey(kidName);
+    var today = _today();
+    return _load().items.filter(function(it) {
+      return it.done && it.doneAt === today && _kidKey(it.doneBy) === kk;
+    }).length;
+  }
+
+  // Per-kid status for the Family Wall chips. A streak only stays
+  // "alive" if the kid last hit their target today or yesterday;
+  // otherwise it's lapsed and shows as 0 (bestStreak is preserved).
+  function getCreditFor(kidName) {
+    var data = _load();
+    var c = data.credit[_kidKey(kidName)] || { streak: 0, bestStreak: 0, lastTargetDay: null };
+    var streak = c.streak || 0;
+    if (c.lastTargetDay !== _today() && c.lastTargetDay !== _yesterday()) streak = 0;
+    var doneToday = doneTodayFor(kidName);
+    return {
+      streak: streak,
+      bestStreak: c.bestStreak || 0,
+      doneToday: doneToday,
+      target: data.target,
+      reachedTarget: doneToday >= data.target
+    };
+  }
+
+  // ---- Writes ----
+  function setTarget(n) {
+    n = parseInt(n, 10);
+    if (isNaN(n) || n < 1) n = 1;
+    if (n > MAX_TARGET) n = MAX_TARGET;
+    var data = _load();
+    data.target = n;
+    _save(data);
+    return n;
+  }
+
+  function addItem(label) {
+    label = String(label == null ? '' : label).trim().slice(0, 120);
+    if (!label) return null;
+    var data = _load();
+    data.items.push({
+      id: _genId(), label: label, done: false,
+      doneBy: null, doneAt: null, createdAt: Date.now()
+    });
+    _save(data);
+    return data.items[data.items.length - 1];
+  }
+
+  function removeItem(id) {
+    var data = _load();
+    data.items = data.items.filter(function(it) { return it.id !== id; });
+    _save(data);
+  }
+
+  // Award/advance the crediting kid's streak the moment they reach the
+  // daily target. Mirrors Routines: +1 if they also hit it yesterday,
+  // otherwise the streak (re)starts at 1. Recorded once per day.
+  function _awardStreak(data, kidName) {
+    var kk = _kidKey(kidName);
+    var c = data.credit[kk] || { streak: 0, bestStreak: 0, lastTargetDay: null };
+    var today = _today();
+    if (c.lastTargetDay === today) { data.credit[kk] = c; return; }
+    c.streak = (c.lastTargetDay === _yesterday()) ? (c.streak || 0) + 1 : 1;
+    c.lastTargetDay = today;
+    if (c.streak > (c.bestStreak || 0)) c.bestStreak = c.streak;
+    data.credit[kk] = c;
+  }
+
+  function toggleItem(id, kidName) {
+    var data = _load();
+    var it = data.items.filter(function(x) { return x.id === id; })[0];
+    if (!it) return;
+    var today = _today();
+    if (it.done) {
+      // Un-check. The already-earned streak for the day stands (same
+      // forgiving behaviour as Routines — we don't claw it back).
+      it.done = false; it.doneBy = null; it.doneAt = null;
+    } else {
+      it.done = true;
+      it.doneBy = kidName || null;
+      it.doneAt = today;
+      if (kidName) {
+        var countToday = data.items.filter(function(x) {
+          return x.done && x.doneAt === today && _kidKey(x.doneBy) === _kidKey(kidName);
+        }).length;
+        if (countToday >= data.target) _awardStreak(data, kidName);
+        if (typeof ActivityLog !== 'undefined' && ActivityLog.log) {
+          ActivityLog.log('Summer Quest', '🏖️', kidName + ' did: ' + it.label);
+        }
+      }
+    }
+    _save(data);
+  }
+
+  return {
+    getData: getData,
+    getItems: getItems,
+    getProgress: getProgress,
+    getTarget: getTarget,
+    setTarget: setTarget,
+    doneTodayFor: doneTodayFor,
+    getCreditFor: getCreditFor,
+    addItem: addItem,
+    removeItem: removeItem,
+    toggleItem: toggleItem
+  };
+})();

--- a/js/sync.js
+++ b/js/sync.js
@@ -43,6 +43,7 @@ var CloudSync = (function() {
     'zs_sports_matches_shared': 'sports_matches',
     'zs_home_location':         'home_location',
     'zs_deleted_profiles':      'deleted_profiles',
+    'zs_summer_todos':          'summer',
     'wc2026.v2':                'worldcup'
   };
   var HOUSEHOLD_KID = '_household';


### PR DESCRIPTION
## Summer Quest 🏖️

A go-to hub card for the kids' summer to-dos, living on the **Family Wall** (`family.html`) — the iPad-on-the-fridge screen.

### What it does
- **One shared family bucket list** everyone works through together.
- **Per-kid credit** — each completed to-do records who did it and when, so every kid sees their own "done today" count.
- **Daily target + streak** — hit the per-kid daily goal (default 2/kid, adjustable) and your 🔥 streak grows; miss a day and it resets (same forgiving rule as Routines).
- **Starts empty** — the kids add their own summer to-dos right on the card.
- **Syncs across all family devices** via the household CloudSync bucket (new `zs_summer_todos` household key, alongside the shopping list and menu).

### Files
- `js/summer-todos.js` — new `SummerTodos` module (storage, per-kid credit, streaks)
- `js/family-wall.js` — Summer Quest card + handlers, wired into the grid
- `css/family-wall.css` — card styling matching the existing `fw-card` look
- `js/sync.js` — registered the `zs_summer_todos` household sync key
- `family.html` — loads the new script

### Verification
- `node --check` passes on all changed JS.
- Logic harnesses pass: add/toggle/per-kid credit/remove/target clamps, plus consecutive-day streak continuation and lapse-to-zero (best streak preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpwsHRBzwqSPkvVGNzbDHw

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpwsHRBzwqSPkvVGNzbDHw)_