### PR TITLE
Vacation Planner: surprise (hidden) trips, photos/overview/tips, sync

### DIFF
--- a/css/vacation.css
+++ b/css/vacation.css
@@ -315,6 +315,102 @@
 .vc-btn-primary { background: linear-gradient(135deg, #4338CA, #6366F1); color: #fff; }
 .vc-btn-secondary { background: #ffffff; color: var(--text); }
 .vc-btn-danger { color: #fff; background: #B91C1C; }
+.vc-form textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 600;
+  outline: none;
+  resize: vertical;
+}
+.vc-form textarea:focus { border-color: #2563EB; }
+.vc-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text);
+  cursor: pointer;
+  margin: 4px 0 4px;
+}
+.vc-check input[type="checkbox"] { width: 18px; height: 18px; accent-color: #6366F1; cursor: pointer; }
+
+/* Surprise (hidden) trips */
+.vc-surprise-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 99px;
+  background: linear-gradient(135deg, #DB2777, #9333EA);
+  color: #fff;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 0.72rem;
+  white-space: nowrap;
+}
+.vc-trip.surprise {
+  border-color: rgba(147,51,234,0.4);
+  background: linear-gradient(180deg, rgba(147,51,234,0.06), var(--bg-surface));
+}
+.vc-surprise-note {
+  text-align: center;
+  margin: -8px 0 16px;
+  padding: 8px 14px;
+  border-radius: 12px;
+  background: rgba(147,51,234,0.08);
+  border: 1px dashed rgba(147,51,234,0.35);
+  color: #6B21A8;
+  font-weight: 700;
+  font-size: 0.85rem;
+}
+
+/* Overview */
+.vc-overview { font-size: 0.92rem; font-weight: 600; color: var(--text); line-height: 1.5; }
+.vc-overview p { margin: 0 0 10px; }
+.vc-overview p:last-child { margin-bottom: 0; }
+
+/* Photo gallery */
+.vc-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+}
+.vc-photo {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid #e6e6ee;
+  background: #ece9f5;
+}
+.vc-photo img { display: block; width: 100%; height: 130px; object-fit: cover; }
+.vc-photo-cap {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  padding: 14px 8px 6px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #fff;
+  background: linear-gradient(transparent, rgba(0,0,0,0.7));
+}
+
+/* Suggestions / tips */
+.vc-suggs { display: flex; flex-direction: column; gap: 8px; }
+.vc-sugg {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  background: #ffffff;
+  border: 1px solid #e6e6ee;
+  border-radius: 12px;
+}
+.vc-sugg-icon { font-size: 1.3rem; flex-shrink: 0; line-height: 1.4; }
+.vc-sugg-title { font-family: var(--font-display); font-weight: 800; font-size: 0.9rem; }
+.vc-sugg-text { font-size: 0.85rem; font-weight: 600; color: var(--text-muted); margin-top: 2px; line-height: 1.45; }
 
 @media (max-width: 480px) {
   .vc-pack-cols { grid-template-columns: 1fr; }

--- a/js/sync.js
+++ b/js/sync.js
@@ -44,7 +44,8 @@ var CloudSync = (function() {
     'zs_home_location':         'home_location',
     'zs_deleted_profiles':      'deleted_profiles',
     'zs_summer_todos':          'summer',
-    'wc2026.v2':                'worldcup'
+    'wc2026.v2':                'worldcup',
+    'zs_vacation':              'vacation'
   };
   var HOUSEHOLD_KID = '_household';
 

--- a/js/vacation.js
+++ b/js/vacation.js
@@ -8,6 +8,12 @@
        trips: [
          { id, name, destination, country, icon,
            startDate, endDate, notes,
+           hidden,     // when true, trip is a "surprise": invisible in
+                       // the list and blocked from detail view until a
+                       // parent unlocks with the PIN. Kids never see it.
+           overview,   // free text intro (blank lines separate paragraphs)
+           images: [ { url, caption } ],      // photo gallery
+           suggestions: [ { icon, title, text } ], // things to do / tips
            packing: { shared: [...], <profileName>: [...] },
                        // each item: { id, label, packed: bool }
            itinerary: { "YYYY-MM-DD": "Activities text…" }
@@ -17,7 +23,8 @@
      }
 
    Uses parent PIN to unlock editing (reuses requestPinThen).
-   Read-only browsing by default.
+   Read-only browsing by default. Surprise trips (hidden:true) stay
+   out of sight for kids until a parent unlocks with the PIN.
    ================================================================ */
 
 var Vacation = (function() {
@@ -141,6 +148,8 @@ var Vacation = (function() {
     var start = document.getElementById('vc-new-start').value;
     var end = document.getElementById('vc-new-end').value;
     var icon = document.getElementById('vc-new-icon').value.trim() || '✈️';
+    var overview = document.getElementById('vc-new-overview').value.trim();
+    var hidden = document.getElementById('vc-new-hidden').checked;
 
     if (!name || !start) {
       alert('Pick a trip name and a start date.');
@@ -168,6 +177,10 @@ var Vacation = (function() {
       startDate: start,
       endDate: end || start,
       notes: '',
+      hidden: hidden,
+      overview: overview,
+      images: [],
+      suggestions: [],
       packing: packing,
       itinerary: {}
     });
@@ -254,6 +267,13 @@ var Vacation = (function() {
   function _renderList(wrap) {
     var data = _load();
     var trips = data.trips.slice();
+    // Surprise trips (hidden:true) are kept out of the list entirely
+    // until a parent unlocks with the PIN — that's what keeps a planned
+    // surprise invisible to the kids browsing the planner.
+    var hiddenCount = trips.filter(function(t) { return t.hidden; }).length;
+    if (!_parentUnlocked) {
+      trips = trips.filter(function(t) { return !t.hidden; });
+    }
     // Sort: upcoming/current first by start date, then past
     trips.sort(function(a, b) {
       var aPast = !_isUpcomingOrCurrent(a);
@@ -274,6 +294,11 @@ var Vacation = (function() {
           ? '<button class="vc-tb-primary" onclick="Vacation.newTrip()">＋ New trip</button>'
           : '<button onclick="Vacation.unlockParent()">' + lockTxt + '</button>') +
       '</div>' +
+      (_parentUnlocked && hiddenCount > 0
+        ? '<div class="vc-surprise-note">🤫 ' + hiddenCount + ' surprise trip' +
+          (hiddenCount === 1 ? '' : 's') + ' shown below — hidden from the kids until you reveal ' +
+          (hiddenCount === 1 ? 'it' : 'them') + '.</div>'
+        : '') +
       (trips.length === 0
         ? '<div class="vc-empty">No trips yet. Tap "Unlock to edit" then "New trip" to add one.</div>'
         : '<div class="vc-trips">' + trips.map(_tripCardHtml).join('') + '</div>');
@@ -282,10 +307,11 @@ var Vacation = (function() {
   function _tripCardHtml(trip) {
     var cd = _countdown(trip);
     var cls = cd ? cd.kind : 'upcoming';
-    return '<div class="vc-trip ' + cls + '" onclick="Vacation.openTrip(\'' + trip.id + '\')">' +
+    return '<div class="vc-trip ' + cls + (trip.hidden ? ' surprise' : '') + '" onclick="Vacation.openTrip(\'' + trip.id + '\')">' +
       '<div class="vc-trip-head">' +
         '<span class="vc-trip-icon">' + _esc(trip.icon || '✈️') + '</span>' +
         '<span class="vc-trip-name">' + _esc(trip.name) + '</span>' +
+        (trip.hidden ? '<span class="vc-surprise-badge">🤫 Surprise</span>' : '') +
       '</div>' +
       '<div class="vc-trip-dest">' + _esc(trip.destination || '') +
         (trip.country ? ' · ' + _esc(trip.country) : '') + '</div>' +
@@ -307,6 +333,9 @@ var Vacation = (function() {
           '<div class="vc-field"><label>Icon (one emoji)</label><input type="text" id="vc-new-icon" maxlength="2" placeholder="✈️"></div>' +
           '<div class="vc-field"><label>Start date</label><input type="date" id="vc-new-start"></div>' +
           '<div class="vc-field"><label>End date (optional)</label><input type="date" id="vc-new-end"></div>' +
+          '<div class="vc-field"><label>Overview (optional)</label><textarea id="vc-new-overview" rows="3" placeholder="A short intro to the trip…" maxlength="2000"></textarea></div>' +
+          '<label class="vc-check"><input type="checkbox" id="vc-new-hidden">' +
+            '<span>🤫 Surprise — hide from the kids until I reveal it</span></label>' +
           '<div class="vc-form-actions">' +
             '<button class="vc-btn-secondary" onclick="Vacation.backToList()">Cancel</button>' +
             '<button class="vc-btn-primary" onclick="Vacation.saveNewTrip()">Save trip</button>' +
@@ -319,8 +348,14 @@ var Vacation = (function() {
     var data = _load();
     var trip = data.trips.find(function(t) { return t.id === _viewing; });
     if (!trip) { backToList(); return; }
+    // A surprise trip can only be opened while a parent is unlocked —
+    // belt-and-suspenders so it can never be reached from a kid session.
+    if (trip.hidden && !_parentUnlocked) { backToList(); return; }
 
     var cd = _countdown(trip);
+    var overviewHtml = _renderOverview(trip);
+    var galleryHtml = _renderGallery(trip);
+    var suggestionsHtml = _renderSuggestions(trip);
     var packingHtml = _renderPacking(trip);
     var itinHtml = _renderItinerary(trip);
     var linksHtml = _learningLinks(trip).map(function(l) {
@@ -346,12 +381,16 @@ var Vacation = (function() {
           '<div class="vc-detail-title">' + _esc(trip.name) + '</div>' +
         '</div>' +
         '<div class="vc-detail-meta">' +
+          (trip.hidden ? '<span class="vc-surprise-badge">🤫 Surprise</span>' : '') +
           (trip.destination ? '<span>📍 ' + _esc(trip.destination) + '</span>' : '') +
           (trip.country ? '<span>' + _esc(trip.country) + '</span>' : '') +
           (trip.startDate ? '<span>📅 ' + _esc(trip.startDate) +
             (trip.endDate && trip.endDate !== trip.startDate ? ' → ' + _esc(trip.endDate) : '') + '</span>' : '') +
           (cd ? '<span class="vc-countdown ' + cd.kind + '">' + _esc(cd.text) + '</span>' : '') +
         '</div>' +
+        overviewHtml +
+        galleryHtml +
+        suggestionsHtml +
         '<div class="vc-section">' +
           '<div class="vc-section-head">🧳 Packing</div>' +
           packingHtml +
@@ -365,6 +404,62 @@ var Vacation = (function() {
           '<div class="vc-trips">' + linksHtml + '</div>' +
         '</div>' : '') +
       '</div>';
+  }
+
+  // Free-text intro. Blank lines split paragraphs; single newlines become
+  // line breaks. Everything is escaped first, so trip data can't inject HTML.
+  function _renderOverview(trip) {
+    var txt = String(trip.overview || '').trim();
+    if (!txt) return '';
+    var paras = txt.split(/\n\s*\n/).map(function(p) {
+      return '<p>' + _esc(p).replace(/\n/g, '<br>') + '</p>';
+    }).join('');
+    return '<div class="vc-section">' +
+      '<div class="vc-section-head">📝 About this trip</div>' +
+      '<div class="vc-overview">' + paras + '</div>' +
+    '</div>';
+  }
+
+  // Photo strip. Images that fail to load (e.g. a bad URL) hide their own
+  // tile via onerror so a broken-image icon never spoils the page.
+  function _renderGallery(trip) {
+    var imgs = Array.isArray(trip.images) ? trip.images : [];
+    if (imgs.length === 0) return '';
+    var tiles = imgs.map(function(im) {
+      var url = String(im && im.url || '');
+      if (!url) return '';
+      var cap = im.caption ? '<span class="vc-photo-cap">' + _esc(im.caption) + '</span>' : '';
+      return '<div class="vc-photo">' +
+        '<img src="' + _esc(url) + '" alt="' + _esc(im.caption || trip.name || '') + '" ' +
+          'loading="lazy" referrerpolicy="no-referrer" ' +
+          'onerror="this.closest(\'.vc-photo\').style.display=\'none\'">' +
+        cap +
+      '</div>';
+    }).join('');
+    return '<div class="vc-section">' +
+      '<div class="vc-section-head">📸 Photos</div>' +
+      '<div class="vc-gallery">' + tiles + '</div>' +
+    '</div>';
+  }
+
+  // Curated ideas / tips for the trip (things to do, good-to-know notes).
+  function _renderSuggestions(trip) {
+    var list = Array.isArray(trip.suggestions) ? trip.suggestions : [];
+    if (list.length === 0) return '';
+    var rows = list.map(function(s) {
+      if (!s || (!s.title && !s.text)) return '';
+      return '<div class="vc-sugg">' +
+        '<span class="vc-sugg-icon">' + _esc(s.icon || '💡') + '</span>' +
+        '<div class="vc-sugg-body">' +
+          (s.title ? '<div class="vc-sugg-title">' + _esc(s.title) + '</div>' : '') +
+          (s.text ? '<div class="vc-sugg-text">' + _esc(s.text) + '</div>' : '') +
+        '</div>' +
+      '</div>';
+    }).join('');
+    return '<div class="vc-section">' +
+      '<div class="vc-section-head">💡 Ideas &amp; tips</div>' +
+      '<div class="vc-suggs">' + rows + '</div>' +
+    '</div>';
   }
 
   function _renderPacking(trip) {


### PR DESCRIPTION
Generic Vacation Planner enhancements. **No trip content is included** — these are reusable features only; actual trip data is loaded separately at runtime.

## Changes
- **Surprise / hidden trips** (`js/vacation.js`): a trip can be flagged `hidden`. Hidden trips are filtered out of the list and blocked from the detail view unless a parent unlocks with the PIN, so kids can't see a planned surprise. A small note appears when a parent is unlocked, and hidden trips get a "🤫 Surprise" badge.
- **Richer detail view** (`js/vacation.js` + `css/vacation.css`): renders an overview/intro, a photo gallery (broken images self-hide via `onerror` so they can't spoil the page), and an "Ideas & tips" section. All data-driven and HTML-escaped.
- **New-trip form**: gains an optional overview field and a "🤫 Surprise" checkbox.
- **Cloud sync** (`js/sync.js`): wire `zs_vacation` into `HOUSEHOLD_KEYS` so trips sync across family devices via the VPS instead of living on a single browser. (Vacation data was previously not synced at all.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjp4R2QzmkTMVoxTQ3egXB)_