### PR TITLE
World Cup: stop wiping match scorers + clearer sync toast

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2943,7 +2943,13 @@
     let resultsApplied = 0;
     for (const id of Object.keys(payload.results || {})) {
       const m = state.matches.find(x => x.id === id);
-      if (m) { m.result = payload.results[id]; resultsApplied++; }
+      if (!m) continue;
+      // Merge incoming result into the existing one so scorer/card/event
+      // detail attached by sync (goals1, goals2, cards1, cards2, eventId)
+      // survives a pool import — the snapshot only carries home/away/
+      // pkWinner, and overwriting would clear everything else.
+      m.result = Object.assign({}, m.result || {}, payload.results[id] || {});
+      resultsApplied++;
     }
     save();
     return { added, updated, results: resultsApplied };
@@ -5050,12 +5056,21 @@
       // Overlay onto local result so the static scorer renderer picks
       // it up — and so it sticks through subsequent navigations.
       if (detail.scorers) {
-        if (Array.isArray(detail.scorers.home)) m.result.goals1 = detail.scorers.home;
-        if (Array.isArray(detail.scorers.away)) m.result.goals2 = detail.scorers.away;
+        // Only overlay scorer lists when the summary actually has them.
+        // Empty arrays from ESPN (older match with no detail published)
+        // would otherwise wipe goals attached by the scoreboard sync.
+        if (Array.isArray(detail.scorers.home) && detail.scorers.home.length) {
+          m.result.goals1 = detail.scorers.home;
+        }
+        if (Array.isArray(detail.scorers.away) && detail.scorers.away.length) {
+          m.result.goals2 = detail.scorers.away;
+        }
       }
       if (detail.cards) {
-        m.result.cards1 = Array.isArray(detail.cards.home) ? detail.cards.home : [];
-        m.result.cards2 = Array.isArray(detail.cards.away) ? detail.cards.away : [];
+        // Cards only ever come from the summary endpoint, so an empty
+        // array is the authoritative "no cards" — safe to write.
+        if (Array.isArray(detail.cards.home)) m.result.cards1 = detail.cards.home;
+        if (Array.isArray(detail.cards.away)) m.result.cards2 = detail.cards.away;
       }
       save();
       const inner = document.querySelector('#match-modal.open .modal-inner');
@@ -6169,8 +6184,12 @@
         if (cur) activateTab(cur);
       }
       if (!quiet) {
-        const scorersNote = state.scorers.length ? `, ${state.scorers.length} scorer${state.scorers.length===1?'':'s'} tracked` : '';
-        toast(`Synced from ${sourceLabel} — ${updated} score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
+        // Two distinct numbers — match-result deltas vs. cumulative Golden
+        // Boot leaderboard size — were getting misread as a fraction.
+        // Spell each out so "8 scores updated, 88 scorers tracked" reads
+        // as two unrelated counts.
+        const scorersNote = state.scorers.length ? ` · 👟 ${state.scorers.length} scorer${state.scorers.length===1?'':'s'} on Golden Boot board` : '';
+        toast(`Synced from ${sourceLabel} — ${updated} match score${updated===1?'':'s'} updated${teamsResolved?`, ${teamsResolved} team${teamsResolved===1?'':'s'} resolved`:''}${scorersNote}`);
       } else if (changed) {
         toast(`⚽ Live — ${updated} score${updated===1?'':'s'} updated`);
       }

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=31"></script>
+  <script src="js/world-cup.js?v=32"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Two regressions and a UI confusion, surfaced together.

### 1. Pool import wiped match scorers
`importPool` overwrote `m.result` wholesale:
```js
m.result = payload.results[id];
```
Pool snapshots only carry `home`/`away`/`pkWinner`, so this dropped any `goals1`/`goals2`/`cards1`/`cards2`/`eventId` attached by previous syncs. Importing a v=3 share link wiped every match's scorer history.

**Fix:** `m.result = Object.assign({}, m.result || {}, payload.results[id])` — merge incoming `home`/`away`/`pk` over the existing detail.

### 2. Empty summary arrays wiped good scoreboard data
`_hydrateMatchDetail` wrote `m.result.goals1 = []` whenever ESPN's summary returned empty scorer arrays (older matches with no published detail), wiping good scoreboard-derived goals. Cards only come from the summary endpoint so an empty cards array is authoritative ("no cards in this match") and still safe to write.

**Fix:** only overlay scorer arrays when non-empty; cards still write on empty.

### 3. Toast misread as a fraction
"8 scores updated, 88 scorers tracked" was reading as "8 out of 88". Reworded to:

> Synced from ESPN — **8 match scores updated** · 👟 **88 scorers on Golden Boot board**

…so the two distinct metrics can't blur into a single percentage.

### Verified in Node
- `importPool` merge: pre-existing `goals1` (1 entry) + `eventId` survive a pool import that carries only `{home, away, pkWinner}`.
- hydrate empty-overlay: `m.result.goals1` (1 entry) survives a detail fetch that returns `scorers: { home: [], away: [] }`.

Cache bust: `world-cup.js` v31→32.

## Test plan
- [ ] Open a match that previously had scorers — they're back after one ⟳ Sync scores tap (scoreboard repopulates) or one modal open (summary back-fills).
- [ ] Import a v=3 pool link from yourself → scorer/card detail on matches you already had is preserved (only home/away/pk gets merged in).
- [ ] Open an older match where ESPN summary returns no scorer detail → the scoreboard-derived goals remain visible.
- [ ] Tap ⟳ Sync scores → toast reads "X match scores updated · 👟 Y scorers on Golden Boot board" without ambiguity.

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_