### PR TITLE
Vacation Planner: cache-bust assets so the Edit screen appears

### DIFF
--- a/vacation.html
+++ b/vacation.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/vacation.css">
+  <link rel="stylesheet" href="css/vacation.css?v=2">
   <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
@@ -30,7 +30,7 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
-  <script src="js/vacation.js"></script>
+  <script src="js/vacation.js?v=2"></script>
   <script src="js/pwa.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes the "I don't see the Edit button" symptom caused by stale PWA caching.

`vacation.html` loaded `js/vacation.js` and `css/vacation.css` with **no version query**. The service worker (`sw.js`) caches same-origin JS/CSS **stale-while-revalidate**, so after a deploy the browser serves the *old* files on first load and only picks up the new Edit-trip UI on a second reload/hard refresh.

This pins both assets to `?v=2` (matching the existing `js/sync.js?v=8` convention). Since the URL changes, the cache is forced to fetch the new files immediately. `vacation.html` itself is served network-first, so the updated tags are picked up on the next visit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjp4R2QzmkTMVoxTQ3egXB)_