### PR TITLE
Vacation Planner: push edits to the VPS so they persist

### DIFF
--- a/js/vacation.js
+++ b/js/vacation.js
@@ -64,7 +64,16 @@ var Vacation = (function() {
   }
 
   function _save(data) {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(data)); }
+    try {
+      // Bump our own sync stamp so a later pull doesn't treat the
+      // server's (pre-edit) copy as newer and clobber this change, then
+      // push to the VPS like every other household-synced module. Without
+      // this, edits live only in this browser and get overwritten on the
+      // next household pull.
+      data._syncedAt = Date.now();
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+      if (typeof CloudSync !== 'undefined' && CloudSync.push) CloudSync.push(STORAGE_KEY);
+    }
     catch (e) {}
   }
 

--- a/vacation.html
+++ b/vacation.html
@@ -30,7 +30,7 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
-  <script src="js/vacation.js?v=2"></script>
+  <script src="js/vacation.js?v=3"></script>
   <script src="js/pwa.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes edits to a trip (or its packing/itinerary) not persisting.

## Root cause
`js/vacation.js` `_save()` only wrote to `localStorage` — it never called `CloudSync.push` or refreshed `_syncedAt`. Every other household-synced module does (e.g. `js/shopping-list.js:32`, `js/summer-todos.js:66`).

Consequence: an edited trip lived only in the local browser. On the next household pull, the server's pre-edit copy — which carries a marginally newer receipt timestamp (the server stamps `_syncedAt` on every PUT) — was treated as authoritative and **overwrote the local edit**, so changes appeared not to save.

## Fix
- `_save()` now bumps `_syncedAt = Date.now()` (so a later pull won't treat the server copy as newer) and calls `CloudSync.push(STORAGE_KEY)`, matching the other modules. Edits now reach the VPS immediately and survive reloads / propagate across devices.
- Bumped `js/vacation.js` cache-bust to `?v=3` so the new code is fetched rather than served stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjp4R2QzmkTMVoxTQ3egXB)_