### PR TITLE
World Cup: query all knockout dates so the official bracket resolves at once

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -6196,17 +6196,23 @@
     ? 'https://all-options-dev.tail57521e.ts.net/api/wc-scores'
     : null;
 
-  // Dates the proxy should query — every distinct match date through today
-  // plus a one-day buffer either side. Tournament size is bounded (~40
-  // match-days), so the URL stays compact.
+  // Dates the proxy should query. Group-stage matches are limited to the
+  // live window (recent + within 24h) so routine polling stays lean —
+  // but EVERY knockout date is always included so the official bracket
+  // resolves the moment ESPN publishes it, instead of trickling in ~24h
+  // before each KO match. The tournament has 34 distinct match-days, so
+  // the union stays under the proxy's 40-date cap; we trim oldest as a
+  // defensive backstop if the schedule ever grows.
   function _vpsQueryDates() {
     const cutoff = Date.now() + 24 * 3600 * 1000;
     const dates = new Set();
     for (const m of state.matches) {
-      const kt = kickoffDate(m).getTime();
-      if (kt <= cutoff) dates.add(m.date.replace(/-/g, ''));
+      if (m.stage !== 'group' || kickoffDate(m).getTime() <= cutoff) {
+        dates.add(m.date.replace(/-/g, ''));
+      }
     }
-    return Array.from(dates).sort();
+    const sorted = Array.from(dates).sort();
+    return sorted.length > 40 ? sorted.slice(sorted.length - 40) : sorted;
   }
 
   async function _fetchEspn() {

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=8"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=34"></script>
+  <script src="js/world-cup.js?v=35"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Follow-up to the feed-override PR. `_vpsQueryDates()` previously gated **every** match (group and knockout) to a 24h live window, so the ESPN feed only resolved each KO fixture ~a day before kickoff — the full official Round of 32 wouldn't appear until it trickled in match by match.

Now **every knockout date is always queried** (group matches still limited to the live window to keep routine polling lean), so a single sync resolves the entire official bracket the moment ESPN publishes it.

- Tournament has **34 distinct match-days** — under the proxy's 40-date cap.
- Defensive trim keeps the most recent 40 if the schedule ever grows.

## Verified
- [x] Query set includes all 17 knockout dates
- [x] Totals 34 (≤ 40 cap)
- [x] `node --check` clean

## Note
Still can't exercise against the live VPS proxy from the build container (no Tailscale, curl blocked). Validated the date-set logic in a Node harness. Real check: on a tailnet device, tap ⟳ Sync scores after R32 is published → the whole bracket should populate with official teams.

Cache bust: `world-cup.js` v34→35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_