### PR TITLE
World Cup: persist + sync confirmed knockout teams (koTeams)

### DIFF
--- a/art-studio.html
+++ b/art-studio.html
@@ -178,7 +178,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/bible-explorer.html
+++ b/bible-explorer.html
@@ -104,7 +104,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/book-movie-check.html
+++ b/book-movie-check.html
@@ -197,7 +197,7 @@
   <script src="js/nav.js?v=2"></script>
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/sounds.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/chess-quest.html
+++ b/chess-quest.html
@@ -130,7 +130,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=8"></script>
+<script src="js/sync.js?v=9"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/civics-lab.html
+++ b/civics-lab.html
@@ -102,7 +102,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/code-cadet.html
+++ b/code-cadet.html
@@ -87,7 +87,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -75,7 +75,7 @@
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>
 <script src="js/auth.js"></script>
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=8"></script>
+<script src="js/sync.js?v=9"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/family.html
+++ b/family.html
@@ -48,7 +48,7 @@
 
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/activity-log.js?v=2"></script>

--- a/fe-explorador.html
+++ b/fe-explorador.html
@@ -160,7 +160,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guess-quest.html
+++ b/guess-quest.html
@@ -98,7 +98,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/guitar-jam.html
+++ b/guitar-jam.html
@@ -152,7 +152,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/home-timer.html
+++ b/home-timer.html
@@ -28,7 +28,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/activity-log.js"></script>

--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@
   ...
   <script src="js/auth.js?v=2"></script>
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/timer.js?v=2"></script>
   <script src="js/chores.js?v=2"></script>

--- a/invest-quest.html
+++ b/invest-quest.html
@@ -29,7 +29,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/js/sync.js
+++ b/js/sync.js
@@ -248,9 +248,24 @@ var CloudSync = (function() {
     // Groups: take whichever side actually has a draw recorded.
     out.groups = (s.groups && Object.keys(s.groups).length) ? s.groups : (l.groups || {});
 
+    // koTeams: confirmed knockout team assignments (official feed or a
+    // manual correction), keyed "matchId.side" -> team code. Union by
+    // key so an official team confirmed on one device propagates to the
+    // rest; on a direct conflict the newer snapshot wins.
+    out.koTeams = {};
+    var koIds = {};
+    Object.keys(l.koTeams || {}).forEach(function(k) { koIds[k] = 1; });
+    Object.keys(s.koTeams || {}).forEach(function(k) { koIds[k] = 1; });
+    Object.keys(koIds).forEach(function(k) {
+      var lv = (l.koTeams || {})[k], sv = (s.koTeams || {})[k];
+      if (!lv) { out.koTeams[k] = sv; return; }
+      if (!sv) { out.koTeams[k] = lv; return; }
+      out.koTeams[k] = localNewer ? lv : sv;
+    });
+
     // Other top-level fields: server wins on conflict, but keep
     // local-only keys (uiSelectedMember, stickers, scorers, etc.).
-    var skip = { members:1, picks:1, matchOverrides:1, groups:1, _syncedAt:1 };
+    var skip = { members:1, picks:1, matchOverrides:1, groups:1, koTeams:1, _syncedAt:1 };
     Object.keys(l).forEach(function(k) { if (!skip[k]) out[k] = l[k]; });
     Object.keys(s).forEach(function(k) { if (!skip[k]) out[k] = s[k]; });
 

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2317,11 +2317,24 @@
       state.members = Array.isArray(saved.members) ? saved.members : [];
       state.picks = (saved.picks && typeof saved.picks === 'object') ? saved.picks : {};
       state.uiSelectedMember = saved.uiSelectedMember || null;
-      // koAuto/koFeed are in-session bookkeeping only — KO teams re-derive
-      // from results each load, so these start empty and are rebuilt by
-      // resolveBracketFromResults() / the feed within the session.
+      // koAuto is in-session bookkeeping only (provisional resolver fills).
       state.koAuto = {};
+      // koTeams = CONFIRMED knockout team assignments (official feed or a
+      // manual correction) that persist + sync. Apply them onto the
+      // matches and mirror into koFeed so the provisional resolver won't
+      // overwrite a confirmed team. Provisional teams are NOT stored here
+      // — they re-derive from results each load.
+      state.koTeams = (saved.koTeams && typeof saved.koTeams === 'object') ? saved.koTeams : {};
       state.koFeed = {};
+      for (const key of Object.keys(state.koTeams)) {
+        const dot = key.lastIndexOf('.');
+        const id = key.slice(0, dot), side = key.slice(dot + 1);
+        const m = state.matches.find(x => x.id === id);
+        if (m && (side === 'home' || side === 'away') && state.koTeams[key]) {
+          m[side] = state.koTeams[key];
+          state.koFeed[key] = true;
+        }
+      }
     } catch (e) { console.warn('wc load failed', e); }
     // Re-derive the knockout bracket from whatever results we loaded so
     // resolved teams persist across reloads and self-correct.
@@ -2345,6 +2358,9 @@
       if (gd) slim.groups = gd;
       const md = _diffMatches();
       if (md) slim.matchOverrides = md;
+      // Confirmed knockout teams (feed/manual) persist + sync; provisional
+      // ones are omitted and re-derived from results on load.
+      if (state.koTeams && Object.keys(state.koTeams).length) slim.koTeams = state.koTeams;
 
       try {
         localStorage.setItem(STORE_KEY, JSON.stringify(slim));
@@ -5473,12 +5489,14 @@
     if (!confirm('Reset the knockout bracket?\n\nThis clears any manually-set teams in the Round of 32 onward and re-derives them from results and the official feed. Match scores and your bracket picks are NOT affected.')) return;
     state.koAuto = state.koAuto || {};
     state.koFeed = state.koFeed || {};
+    state.koTeams = state.koTeams || {};
     for (const m of state.matches) {
       if (m.stage === 'group') continue;
       m.home = null;
       m.away = null;
       delete state.koAuto[m.id + '.home']; delete state.koAuto[m.id + '.away'];
       delete state.koFeed[m.id + '.home']; delete state.koFeed[m.id + '.away'];
+      delete state.koTeams[m.id + '.home']; delete state.koTeams[m.id + '.away'];
     }
     resolveBracketFromResults();
     save();
@@ -5495,12 +5513,24 @@
     const dateEl  = document.getElementById('ed-date');
     const timeEl  = document.getElementById('ed-time');
     const venueEl = document.getElementById('ed-venue');
-    // A manual team edit on a KO match overrides auto-resolution for
-    // that side — drop its auto flag so the resolver won't clobber it.
+    // A manual team edit on a KO match is a confirmed assignment: record
+    // it in koTeams so it persists + syncs (and mark koFeed so the
+    // provisional resolver won't overwrite it). Blanking a side clears
+    // the confirmation, letting it re-derive.
     state.koAuto = state.koAuto || {};
     state.koFeed = state.koFeed || {};
-    if (homeEl)  { m.home  = homeEl.value || null; delete state.koAuto[m.id + '.home']; delete state.koFeed[m.id + '.home']; }
-    if (awayEl)  { m.away  = awayEl.value || null; delete state.koAuto[m.id + '.away']; delete state.koFeed[m.id + '.away']; }
+    state.koTeams = state.koTeams || {};
+    const _setKoManual = (side, el) => {
+      if (!el) return;
+      const isKo = m.stage !== 'group';
+      m[side] = el.value || null;
+      const key = m.id + '.' + side;
+      delete state.koAuto[key];
+      if (isKo && el.value) { state.koTeams[key] = el.value; state.koFeed[key] = true; }
+      else { delete state.koTeams[key]; delete state.koFeed[key]; }
+    };
+    _setKoManual('home', homeEl);
+    _setKoManual('away', awayEl);
     if (dateEl  && dateEl.value)  m.date  = dateEl.value;
     if (timeEl  && timeEl.value)  m.time  = timeEl.value;
     if (venueEl && venueEl.value) m.venue = venueEl.value;
@@ -6353,12 +6383,13 @@
       const isCode = x => COUNTRIES.some(c => c.code === x);
       state.koAuto = state.koAuto || {};
       state.koFeed = state.koFeed || {};
+      state.koTeams = state.koTeams || {};
 
       // Fill/override a knockout side from the authoritative feed. The
       // feed wins over an empty side, a provisional resolver value
-      // (koAuto), or a prior feed value (koFeed) — but never over a true
-      // manual edit. Marks the side koFeed so the local resolver won't
-      // clobber the official team with its provisional guess.
+      // (koAuto), or a prior confirmed value (koFeed). Records the team
+      // in koTeams so it persists + syncs to every device, and marks
+      // koFeed so the provisional resolver won't overwrite it.
       function fillKoSide(m, side, code) {
         if (!isCode(code)) return false;
         const key = m.id + '.' + side;
@@ -6368,8 +6399,9 @@
         const wasFeed = state.koFeed[key];
         state.koFeed[key] = true;
         delete state.koAuto[key];
-        if (cur === code) return false;
+        if (cur === code && state.koTeams[key] === code) return false;
         m[side] = code;
+        state.koTeams[key] = code;
         if (side === 'home') m.home_label = null; else m.away_label = null;
         if (!wasFeed) teamsResolved++;
         return true;

--- a/lab-explorer.html
+++ b/lab-explorer.html
@@ -68,7 +68,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/little-maestro.html
+++ b/little-maestro.html
@@ -16162,7 +16162,7 @@ document.addEventListener('DOMContentLoaded', () => {
 <script src="js/auth.js?v=2"></script>
 
 <script src="js/a11y.js?v=2"></script>
-<script src="js/sync.js?v=8"></script>
+<script src="js/sync.js?v=9"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/timer.js?v=2"></script>
 <script src="js/learning-checks.js?v=2"></script>

--- a/math-galaxy.html
+++ b/math-galaxy.html
@@ -143,7 +143,7 @@
   <script src="js/auth.js?v=2"></script>
 
   <script src="js/a11y.js?v=2"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js?v=2"></script>
   <script src="js/sounds.js?v=2"></script>

--- a/menu.html
+++ b/menu.html
@@ -28,7 +28,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/menu.js"></script>

--- a/money-master.html
+++ b/money-master.html
@@ -29,7 +29,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/quest-adventure.html
+++ b/quest-adventure.html
@@ -44,7 +44,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/shopping-list.html
+++ b/shopping-list.html
@@ -74,7 +74,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/shopping-list.js"></script>

--- a/sports-arena.html
+++ b/sports-arena.html
@@ -265,7 +265,7 @@
 <script src="js/auth.js"></script>
 
 <script src="js/a11y.js"></script>
-<script src="js/sync.js?v=8"></script>
+<script src="js/sync.js?v=9"></script>
 <script src="js/zs-diag.js?v=3"></script>
 <script src="js/nav.js"></script>
 <script src="js/sounds.js"></script>

--- a/story-explorer.html
+++ b/story-explorer.html
@@ -87,7 +87,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/sunday-report.html
+++ b/sunday-report.html
@@ -28,7 +28,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/activity-log.js"></script>
   <script src="js/routines.js"></script>

--- a/trophy-room.html
+++ b/trophy-room.html
@@ -47,7 +47,7 @@
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/trophy-room.js"></script>

--- a/vacation.html
+++ b/vacation.html
@@ -27,7 +27,7 @@
 
   <script src="js/debug.js"></script>
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/vacation.js?v=3"></script>

--- a/vocabulario-vivo.html
+++ b/vocabulario-vivo.html
@@ -109,7 +109,7 @@
 
   <script src="js/auth.js"></script>
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>

--- a/world-cup.html
+++ b/world-cup.html
@@ -71,9 +71,9 @@
   </div>
 
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=37"></script>
+  <script src="js/world-cup.js?v=38"></script>
 </body>
 </html>

--- a/world-explorer.html
+++ b/world-explorer.html
@@ -76,7 +76,7 @@
   <script src="js/auth.js"></script>
 
   <script src="js/a11y.js"></script>
-  <script src="js/sync.js?v=8"></script>
+  <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
   <script src="js/sounds.js"></script>


### PR DESCRIPTION
## Summary
Fixes the "US shows Algeria but actually plays Bosnia" report. Two linked problems:

1. **Provisional third-place seeding.** The US's R32 slot is `1D v 3B/E/F/I/J` — it takes a third-placed team, and both **Bosnia (3B)** and **Algeria (3J)** are valid candidates. The offline constraint matcher guessed Algeria; FIFA's official table seats Bosnia (confirmed via ESPN/FIFA: USA vs Bosnia, July 1). The ESPN feed knows the official answer.
2. **The fix didn't stick.** After making KO teams derived-only (the prior cross-device reset fix), even a correct feed/manual answer re-derived back to the provisional guess on every reload, and didn't propagate to other devices.

## Fix — `koTeams`
A new map (`'matchId.side' -> code`) holds **only confirmed** knockout assignments (official feed or manual edit) — the single piece of KO team state that persists + syncs:

- `fillKoSide` (feed) and `saveResult` (manual) write `koTeams`.
- `save()` persists it; `load()` applies it and mirrors into `koFeed` so the provisional resolver won't overwrite a confirmed team.
- **Provisional teams are still never persisted** — they re-derive from synced results, so no stale/wrong value can resurrect (the reset-doesn't-sync fix stays intact).
- `_mergeWorldCup` **unions `koTeams`** across devices (newer wins on conflict), so an official team confirmed on one device propagates to all — without each having to sync the feed.
- `resetBracket` clears `koTeams` too.

**Net effect:** sync once on any tailnet device (or hand-fix one match) and the correct knockout team sticks across reloads and appears on every family device.

## Verified (Node harness)
- [x] Feed sets official third → persists → **survives reload** (provisional QAT → official BIH holds)
- [x] Other slots still re-derive from results
- [x] Manual edit persists to `koTeams`
- [x] `_mergeWorldCup` unions `koTeams` and resolves conflicts by recency
- [x] `node --check` on both files

Cache bust: `world-cup.js` v37→38, `sync.js` v8→9 across all html.

## To apply
Hard-refresh on a tailnet device and tap **⟳ Sync scores** → the US match should flip to Bosnia and stay, syncing to the other devices. (If the feed is briefly unavailable, you can also hand-set it in the match editor and it'll persist/propagate the same way.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_