### PR TITLE
World Cup: hardcode official third-place slotting (fixes US v Algeria)

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -3401,15 +3401,40 @@
     return out;
   }
 
-  // Assign each qualifying group to a distinct third-place slot within
-  // its allowed set (most-constrained slot first, backtracking). Returns
-  // { 'matchId.side': group } or null if no valid assignment. This is a
-  // VALID bracket but not guaranteed to match FIFA's official Annex C
-  // table when multiple assignments are possible — flagged provisional
-  // in the UI; the host can correct via the match editor.
+  // Official FIFA third-place allocation (Annex C), keyed by the sorted
+  // set of groups whose third-placed team qualified -> { matchId: group }.
+  // The full 495-row table isn't reproducible offline (every combination
+  // admits many valid matchings), so we encode the rows that actually
+  // occur. 2026: the eight qualifying thirds came from B,D,E,F,I,J,K,L,
+  // and FIFA seated them as below — this is the authoritative slotting,
+  // used in preference to the constraint-matching fallback.
+  const OFFICIAL_THIRD_TABLE = {
+    BDEFIJKL: { m075: 'D', m078: 'F', m079: 'E', m080: 'K', m081: 'I', m082: 'B', m085: 'J', m088: 'L' },
+  };
+
+  // Assign each qualifying group to a distinct third-place slot. Uses the
+  // official table when the qualifying combination is known; otherwise
+  // falls back to constraint matching (most-constrained slot first), which
+  // yields a VALID — but possibly non-official — bracket. Returns
+  // { 'matchId.side': group } or null.
   function _assignThirds(qualGroups) {
     const slots = _thirdSlots();
     if (slots.length !== 8 || qualGroups.length !== 8) return null;
+
+    // Official table fast-path.
+    const comboKey = qualGroups.slice().sort().join('');
+    const official = OFFICIAL_THIRD_TABLE[comboKey];
+    if (official) {
+      const assign = {};
+      let ok = true;
+      for (const slot of slots) {
+        const grp = official[slot.id];
+        if (grp && slot.allowed.includes(grp)) assign[slot.id + '.' + slot.side] = grp;
+        else { ok = false; break; }
+      }
+      if (ok && Object.keys(assign).length === slots.length) return assign;
+    }
+
     const order = slots.slice().sort((a, b) =>
       a.allowed.filter(g => qualGroups.includes(g)).length -
       b.allowed.filter(g => qualGroups.includes(g)).length);

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=38"></script>
+  <script src="js/world-cup.js?v=39"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
The provisional constraint matcher seated **Algeria** in the US's R32 slot (`1D v 3B/E/F/I/J`), but FIFA's official table puts **Bosnia (3B)** there — Algeria (3J) goes to Switzerland's slot. The ESPN feed override meant to correct this isn't reaching devices reliably, so the wrong third persisted (the repeated report).

Since the group stage is over, the bracket is fixed — so this encodes FIFA's actual Annex C allocation for the 2026 qualifying combination directly. The eight qualifying thirds came from groups **B,D,E,F,I,J,K,L** and seat as:

| Slot | Third | | Slot | Third |
|---|---|---|---|---|
| m075 (Germany 1E) | Paraguay 3D | | m082 (USA 1D) | **Bosnia 3B** |
| m078 (France 1I) | Sweden 3F | | m085 (Switzerland 1B) | Algeria 3J |
| m079 (Mexico 1A) | Ecuador 3E | | m088 (Colombia 1K) | Ghana 3L |
| m080 (England 1L) | DR Congo 3K | | m081 (Belgium 1G) | Senegal 3I |

`_assignThirds` now consults `OFFICIAL_THIRD_TABLE` keyed by the sorted qualifying-group set and returns the official assignment when known, falling back to constraint matching otherwise. **The bracket is now correct fully offline — no dependency on the live feed** — and flows through the existing resolver so every device converges on reload.

## Verified (Node harness)
- [x] End-to-end with engineered standings reproducing the real qualifier set (`BDEFIJKL`): all 8 third-place matchups resolve to the official teams, incl. **USA v Bosnia** and **Switzerland v Algeria**
- [x] Direct `_assignThirds(['B','D','E','F','I','J','K','L'])` returns the official mapping
- [x] `node --check` clean

## To apply
Hard-refresh on each device — no sync required. On load the bracket re-derives from the synced group results using the official table, so the US match shows Bosnia everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_