### PR TITLE
World Cup: sync knockout winners incl. penalty shootouts

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -6497,15 +6497,31 @@
         else if (typeof rm.score1 === 'number' && typeof rm.score2 === 'number') { hs = rm.score1; as = rm.score2; }
         if (flip) { const t = hs; hs = as; as = t; }
         if (hs !== null && as !== null) {
-          if (!local.result || local.result.home !== hs || local.result.away !== as) {
-            const prevPK = local.result && local.result.pkWinner;
-            let pkWinner = prevPK || null;
-            if (rm.score && Array.isArray(rm.score.p)) {
+          // Penalty-shootout / advancing-team winner. Only meaningful when
+          // full time is level — for a decisive score the winner is implied
+          // by the goals. Computed every sync (not just when the score
+          // changes) so a draw that later goes to pens still gets its
+          // winner, and re-derives the bracket cascade.
+          let pkWinner = (local.result && local.result.pkWinner) || null;
+          if (hs === as) {
+            if (rm.winner === 'home' || rm.winner === 'away') {
+              // ESPN's definitive winner flag (flip-aware) — source of truth.
+              const winSide = flip ? (rm.winner === 'home' ? 'away' : 'home') : rm.winner;
+              pkWinner = winSide === 'home' ? local.home : local.away;
+            } else if (rm.score && Array.isArray(rm.score.p)) {
+              // Shootout tally fallback (OpenFootball, or ESPN score.p).
               let p0 = rm.score.p[0], p1 = rm.score.p[1];
               if (flip) { const t = p0; p0 = p1; p1 = t; }
               if (p0 > p1) pkWinner = local.home;
               else if (p1 > p0) pkWinner = local.away;
             }
+          } else {
+            pkWinner = null; // decisive result — no shootout
+          }
+          const prev = local.result;
+          const changed = !prev || prev.home !== hs || prev.away !== as ||
+                          (prev.pkWinner || null) !== (pkWinner || null);
+          if (changed) {
             // Object.assign preserves goals/cards/eventId already attached.
             local.result = Object.assign({}, local.result, { home: hs, away: as, pkWinner });
             updated++;

--- a/vps/wc-scores.js
+++ b/vps/wc-scores.js
@@ -109,6 +109,20 @@ function _normalizeEvent(ev) {
   // like a real 0-0 final.
   if (!isNaN(hs) && !isNaN(as) && (completed || live)) {
     out.score = { ft: [hs, as] };
+    // Penalty shootout: ESPN puts the shootout tally on each competitor
+    // as `shootoutScore`. Surface it as score.p = [home, away] so the
+    // client can record the PK winner for a knockout draw.
+    const hp = parseInt(home.shootoutScore, 10);
+    const ap = parseInt(away.shootoutScore, 10);
+    if (!isNaN(hp) && !isNaN(ap) && (hp || ap)) out.score.p = [hp, ap];
+  }
+  // Definitive advancing side — ESPN flags exactly one competitor with
+  // winner:true on a completed knockout match, however it was decided
+  // (regulation, extra time, or penalties). This is the source of truth
+  // the client uses to set the winner even when full-time is level.
+  if (completed) {
+    if (home.winner === true) out.winner = 'home';
+    else if (away.winner === true) out.winner = 'away';
   }
   if (goals1.length) out.goals1 = goals1;
   if (goals2.length) out.goals2 = goals2;

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=39"></script>
+  <script src="js/world-cup.js?v=40"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Knockout draws decided on penalties weren't advancing — the bracket stalled and "results weren't getting in" for the next round. Two gaps:

1. **Proxy** (`vps/wc-scores.js`) emitted only the regulation score (`score.ft`). It never surfaced the shootout tally or who advanced, so a 1-1 KO draw arrived with no winner.
2. **Client** only set `pkWinner` inside the "score changed" branch — so a draw already recorded as 1-1 never picked up its shootout winner on a later sync — and it ignored ESPN's definitive winner flag entirely.

### Proxy now emits (for completed knockout matches)
- `score.p = [home, away]` shootout tally (from each competitor's `shootoutScore`)
- `winner: 'home' | 'away'` from ESPN's `competitor.winner` flag — **the source of truth** for who advanced, however the tie was decided (regulation, ET, or pens)

### Client now
For a level full-time score, sets `result.pkWinner` from `rm.winner` (flip-aware), with the shootout tally as fallback — computed on **every** sync (not just when the score moves), so a recorded draw still gains its winner. A decisive score clears any stale `pkWinner`. The winner persists/syncs via the result override and re-derives the cascade (`W##` → next round) on every device.

## Verified (Node harness)
- [x] Proxy extracts `ft` / `p` / `winner` from an ESPN event with `shootoutScore` + `winner` flags
- [x] Client sets `pkWinner` for a 1-1 draw and **advances the shootout winner to R16**
- [x] Winner is applied even when the score was already recorded (the core "not getting in" bug)
- [x] Flipped orientation (ESPN lists teams reversed) maps the winner to the correct side
- [x] Decisive score clears a stale `pkWinner`

## To apply
The VPS auto-deploys (`vps/**` → `deploy-vps.yml`). After it deploys, hard-refresh and tap ⟳ Sync scores; KO draws will show the advancing team and the bracket will cascade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_