### PR TITLE
World Cup: fix Round of 16 bracket wiring + stop score loss on storage quota

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -1993,7 +1993,7 @@
     "venue": "nrg",
     "result": null,
     "home_label": "W73",
-    "away_label": "W75"
+    "away_label": "W76"
   },
   {
     "id": "m090",
@@ -2006,8 +2006,8 @@
     "away": null,
     "venue": "lin",
     "result": null,
-    "home_label": "W74",
-    "away_label": "W77"
+    "home_label": "W75",
+    "away_label": "W78"
   },
   {
     "id": "m091",
@@ -2020,8 +2020,8 @@
     "away": null,
     "venue": "met",
     "result": null,
-    "home_label": "W76",
-    "away_label": "W78"
+    "home_label": "W74",
+    "away_label": "W77"
   },
   {
     "id": "m092",
@@ -2077,7 +2077,7 @@
     "venue": "mer",
     "result": null,
     "home_label": "W86",
-    "away_label": "W88"
+    "away_label": "W87"
   },
   {
     "id": "m096",
@@ -2091,7 +2091,7 @@
     "venue": "bc",
     "result": null,
     "home_label": "W85",
-    "away_label": "W87"
+    "away_label": "W88"
   },
   {
     "id": "m097",

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2362,16 +2362,28 @@
       // ones are omitted and re-derived from results on load.
       if (state.koTeams && Object.keys(state.koTeams).length) slim.koTeams = state.koTeams;
 
+      const payload = JSON.stringify(slim);
       try {
-        localStorage.setItem(STORE_KEY, JSON.stringify(slim));
+        localStorage.setItem(STORE_KEY, payload);
       } catch (e) {
-        // Quota exceeded — surface once per minute instead of spamming.
-        const now = Date.now();
-        if (now - _lastQuotaWarn > 60000) {
-          _lastQuotaWarn = now;
-          console.warn('wc save failed', e);
-          if (typeof toast === 'function') {
-            toast('⚠️ Storage full — clear another app\'s data to keep saving picks.');
+        // Quota exceeded would otherwise silently drop the latest scores
+        // and picks — they'd "vanish" on the next open. The squad cache
+        // (wc2026.nominations) is large and fully regenerable, so evict
+        // it (and a couple of other regenerable caches) and retry, so
+        // user data always wins the space.
+        let saved = false;
+        for (const k of ['wc2026.nominations', NOMINATIONS_KEY]) {
+          try { if (k) localStorage.removeItem(k); } catch (e2) {}
+        }
+        try { localStorage.setItem(STORE_KEY, payload); saved = true; } catch (e3) {}
+        if (!saved) {
+          const now = Date.now();
+          if (now - _lastQuotaWarn > 60000) {
+            _lastQuotaWarn = now;
+            console.warn('wc save failed', e);
+            if (typeof toast === 'function') {
+              toast('⚠️ Storage full — clear another app\'s data to keep saving picks.');
+            }
           }
         }
       }

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=40"></script>
+  <script src="js/world-cup.js?v=41"></script>
 </body>
 </html>


### PR DESCRIPTION
Two issues reported: the Round of 16 looking off, and scores appearing to vanish every time the app opens.

## 1. Round of 16 bracket was mis-wired
Our knockout schedule uses internal match IDs (`m073`–`m088`) numbered differently than FIFA's official match numbers, but the R16 `W##` feeder references were copied as if the numbering matched — so **4 of 8 R16 matchups paired the wrong R32 winners**.

Cross-checked against the confirmed official R16, OpenFootball's authoritative tree, and each match's date/venue:

| Match (venue) | before | after | now correctly |
|---|---|---|---|
| m089 (Houston) | W73 v W75 | W73 v **W76** | Canada v Netherlands |
| m090 (Philadelphia) | W74 v W77 | **W75 v W78** | Germany v France |
| m091 (MetLife) | W76 v W78 | **W74 v W77** | Brazil v Norway |
| m095 (Atlanta) | W86 v W88 | W86 v **W87** | Egypt v Argentina |
| m096 (Vancouver) | W85 v W87 | W85 v **W88** | Switzerland v Colombia |

m092/m093/m094 were already right. **QF/SF/Final feeders are unchanged and verified consistent** — each corrected R16 still feeds the same quarterfinal, so the whole tree now matches FIFA's bracket. Verified end-to-end: with reality-matching group standings + R32 winners, all 8 R16 matchups resolve to the official pairings.

## 2. Scores vanishing on open = storage-quota loss
`save()` caught `QuotaExceededError` but only warned, so the latest scores/picks never persisted and were gone on the next open (a local save/load round-trip is otherwise lossless). Most likely on iPad Safari, where the ~5 MB cap is shared across the whole app suite and the large squad cache competes for space.

`save()` now evicts the **fully-regenerable** squad cache (`wc2026.nominations`) and retries the write on a quota error, so user data always wins the space — only warning if it still can't save. Verified: simulated quota throw → squads evicted → data saved, no spurious toast.

Cache bust: `world-cup.js` v40→41.

## To apply
Hard-refresh each device. The R16 (and the QF/SF tree it feeds) will show the correct matchups, and entered/synced scores will persist across opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_