### PR TITLE
World Cup: stop live auto-sync from zeroing out completed games

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -6533,7 +6533,17 @@
           const prev = local.result;
           const changed = !prev || prev.home !== hs || prev.away !== as ||
                           (prev.pkWinner || null) !== (pkWinner || null);
-          if (changed) {
+          // Guard against a background poll wiping a recorded result. A
+          // quiet auto-sync may ADD a result for a match that has none, or
+          // update one that's genuinely in its live window right now — but
+          // it must NOT rewrite a result whose match is already over. That
+          // was zeroing out completed games on open (e.g. a match the
+          // feed momentarily reports 0-0/in-progress, or the lagging
+          // fallback). Manual "Sync scores" (not quiet) is always allowed.
+          const kt = kickoffDate(local).getTime();
+          const inLiveWindow = Date.now() >= kt - 5 * 60000 && Date.now() <= kt + LIVE_WINDOW_MS;
+          const overwriteOk = !prev || !quiet || inLiveWindow;
+          if (changed && overwriteOk) {
             // Object.assign preserves goals/cards/eventId already attached.
             local.result = Object.assign({}, local.result, { home: hs, away: as, pkWinner });
             updated++;

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=41"></script>
+  <script src="js/world-cup.js?v=42"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Pinpointed the disappearing-scores issue: open the app, scores are fine, then a few seconds later the quiet auto-sync runs ("Live — 21 scores updated") and some finished games flip to **0-0**. The background poll was *rewriting results of matches that are already over* — when the feed momentarily reports a match in-progress/0-0, or the lagging OpenFootball fallback (used at open before CloudSync is online) disagrees with a recorded score.

## Fix
A recorded result for a match that's already over should never change from a background poll. `syncScores` now gates result **overwrites** on a quiet sync — allowed only when:
- the match has **no result yet** (add), or
- the match is **genuinely within its live window right now** (live progression / finalization)

Manual **⟳ Sync scores** (not quiet) is unchanged and can still correct anything.

## Verified (Node harness)
- [x] Quiet sync leaves a completed, out-of-window game untouched even when the feed reports 0-0
- [x] Manual (non-quiet) sync can still change it
- [x] Quiet sync still **adds** results for matches that have none
- [x] `node --check` clean

This complements the prior quota fix (#409): together, scores both persist reliably and are no longer clobbered by the background poll.

Cache bust: `world-cup.js` v41→42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_