### PR TITLE
World Cup: persist lean match results so scores stop vanishing on open

### DIFF
--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -2240,6 +2240,19 @@
     }
     return null;
   }
+  // Persisted form of a match result: only the fields that matter for
+  // scoring and the bracket. The scorer/card arrays (goals1/goals2/
+  // cards1/cards2) are large and fully regenerable from the feed/summary,
+  // so they're kept in memory for the session but NOT persisted — storing
+  // them bloated the bucket and could blow the localStorage quota, which
+  // silently dropped saves and made scores vanish on the next open.
+  function _leanResult(r) {
+    if (!r || typeof r !== 'object') return r;
+    const out = { home: r.home, away: r.away, pkWinner: r.pkWinner || null };
+    if (r.eventId) out.eventId = r.eventId; // tiny; lets the modal lazy-fetch detail
+    return out;
+  }
+
   function _diffMatches() {
     const overrides = {};
     for (const m of state.matches) {
@@ -2255,9 +2268,10 @@
         // Persisting only `result` makes the bracket a pure function of
         // synced results, so it re-derives identically everywhere.
         if (ko && (k === 'home' || k === 'away')) continue;
-        const mv = m[k] === undefined ? null : m[k];
+        let mv = m[k] === undefined ? null : m[k];
+        if (k === 'result') mv = _leanResult(mv);
         const bv = base[k] === undefined ? null : base[k];
-        if (JSON.stringify(mv) !== JSON.stringify(bv)) diff[k] = m[k];
+        if (JSON.stringify(mv) !== JSON.stringify(bv)) diff[k] = mv;
       }
       if (Object.keys(diff).length > 0) overrides[m.id] = diff;
     }

--- a/world-cup.html
+++ b/world-cup.html
@@ -74,6 +74,6 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=42"></script>
+  <script src="js/world-cup.js?v=43"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Scores would show after a manual sync but disappear again on the next open. Traced the full chain:

- Each match `result` carried full **scorer + card arrays** (`goals1/goals2/cards1/cards2`) — large, and fully regenerable from the feed.
- Persisting them bloated the wc bucket enough to hit the **localStorage quota** on space-tight devices (iPad Safari, shared across the whole app suite).
- `save()` then failed → synced scores never persisted → gone on reopen.
- The quiet auto-sync **no-ops when no match is in a live window**, so the lost scores stayed gone until a manual ⟳ Sync re-fetched them (only to be lost again next open).

## Fix
`_diffMatches` now persists a **lean result** — `{ home, away, pkWinner, eventId }` only. Scorer/card arrays stay in memory for the session and re-attach on the next score sync or when the match modal lazy-fetches the summary. Measured **~75% smaller** per result that has scorers.

## Verified (Node harness)
- [x] Persisted result drops `goals/cards` but keeps score + PK winner + `eventId`
- [x] save → load round-trip preserves the score, PK winner, and re-derived teams
- [x] `node --check` clean

Complements the earlier quota-eviction retry (#409) — together, the bucket is now small enough that saves reliably succeed.

Cache bust: `world-cup.js` v42→43.

## To apply
Hard-refresh each device, then ⟳ Sync scores once to repopulate. From there scores should persist across opens. (Scorer names/cards re-appear after a sync or when you open a match.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_