### PR TITLE
Fix runtime errors surfaced by diag logs (math-galaxy, art-studio)

### DIFF
--- a/js/art-studio.js
+++ b/js/art-studio.js
@@ -450,6 +450,9 @@ const ArtStudio = (() => {
   }
 
   function floodFill(ctx, canvas, startX, startY, fillColor) {
+    // Guard against an unsized/hidden canvas: getImageData with a 0-width or
+    // 0-height rect throws IndexSizeError ("index is not in the allowed range").
+    if (!canvas || canvas.width === 0 || canvas.height === 0) return;
     const dpr = window.devicePixelRatio || 1;
     const x = Math.floor(startX * dpr);
     const y = Math.floor(startY * dpr);

--- a/js/math-galaxy.js
+++ b/js/math-galaxy.js
@@ -621,7 +621,7 @@ function genCommander() {
   if (type === 'blackhole_sub') { const a = rand(100, 500), b = rand(50, a - 1); return { label: 'Big Subtraction', text: `${a} 🕳️ - ${b} 🕳️ = ?`, hint: 'Subtract', answer: a - b, options: generateDistractors(a - b, 3, 10, 450), mode: 'choice' }; }
   if (type === 'galaxy_pct_2') { const p = [10, 20, 25, 50][rand(0, 3)]; const base = rand(10, 50) * (100/p); const ans = base * p/100; return { label: 'Percentages', text: `${p}% of ${base} 🌌`, hint: 'Calculate', answer: ans, options: generateDistractors(ans, 3, 5, 200), mode: 'choice' }; }
   if (type === 'gravity_ops') { const a=rand(5,10), b=rand(2,5); const ans=a+(b*b); return { label: 'Gravity Math', text: `${a} + ${b}² = ?`, hint: 'Square first!', answer: ans, options: generateDistractors(ans, 3, 5, 50), mode: 'choice' }; }
-  if (type === 'orbit_dec') { const a=(rand(10,50)/10).toFixed(1); const b=(rand(10,50)/10).toFixed(1); const ans=(parseFloat(a)-parseFloat(b)).toFixed(1); return { label: 'Decimals', text: `${a} - ${b} = ?`, hint: '', answer: ans, options: generateDistractors(ans, 3, -5, 5).map(x=>x.toFixed(1)), mode: 'choice' }; }
+  if (type === 'orbit_dec') { const a=(rand(10,50)/10).toFixed(1); const b=(rand(10,50)/10).toFixed(1); const ans=(parseFloat(a)-parseFloat(b)).toFixed(1); return { label: 'Decimals', text: `${a} - ${b} = ?`, hint: '', answer: ans, options: generateDistractors(parseFloat(ans), 3, -5, 5).map(x=>x.toFixed(1)), mode: 'choice' }; }
   if (type === 'blackhole_div') {
     const b = rand(10, 20), ans = rand(5, 15);
     return { label: 'Black Hole Division', text: `${b * ans} 🕳️ ÷ ${b} = ?`, hint: 'Divide the black holes', answer: ans, options: generateDistractors(ans, 3, 2, 25), mode: 'choice' };


### PR DESCRIPTION
Fixes two runtime errors that showed up in the `diag` branch error digests.

## math-galaxy — `TypeError: x.toFixed is not a function` (`js/math-galaxy.js:624`)
The `orbit_dec` question generator built `ans` with `.toFixed(1)`, which returns a **string**, then passed it into `generateDistractors`. Inside that function `correct + rand(...)` becomes string concatenation, so the returned distractors were strings — and the trailing `.map(x => x.toFixed(1))` threw because strings have no `toFixed`.

Fix: pass `parseFloat(ans)` so the distractors are numbers, matching the pattern already used by the other decimal generators in the same file. The deployed line number (`?v=2:624`) matched exactly, so this was the live, recurring error (seen through 2026-06-30).

## art-studio — `IndexSizeError: The index is not in the allowed range.`
`floodFill` called `getImageData(0, 0, canvas.width, canvas.height)` with no guard. On an unsized/hidden canvas (`width`/`height === 0`) that call throws the logged `IndexSizeError`. Added the same zero-size guard already used by `drawGrid` in this file.

## Not changed (intentionally)
The world-cup entries in the digests (`ESPN scoreboard fetch failed, falling back to OpenFootball`, `Sync failed: Load failed`, `match detail fetch failed`) are transient network failures already handled by graceful fallbacks, not code defects.

## Validation
- `node --check js/math-galaxy.js` ✓
- `node --check js/art-studio.js` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014pfNR2Nza9Twnh4rBMUPu7

---
_Generated by [Claude Code](https://claude.ai/code/session_014pfNR2Nza9Twnh4rBMUPu7)_