### PR TITLE
World Cup: fix premature Golden Boot, backfill completed scores, hide stale KO bids

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -162,7 +162,12 @@ var CloudSync = (function() {
       champion:          nonEmpty(newer.champion,   older.champion)   || null,
       runnerUp:          nonEmpty(newer.runnerUp,   older.runnerUp)   || null,
       goldenBoot:        nonEmpty(newer.goldenBoot, older.goldenBoot) || '',
-      goldenBootCorrect: !!(older.goldenBootCorrect || newer.goldenBootCorrect),
+      // Admin "golden boot correct" flag: newer side wins rather than an
+      // OR-merge, so an admin un-checking it (or a stale true from before
+      // the award existed) can actually propagate and clear instead of
+      // being stuck true forever across devices.
+      goldenBootCorrect: (newer.goldenBootCorrect !== undefined
+        ? !!newer.goldenBootCorrect : !!older.goldenBootCorrect),
       mode:              nonEmpty(newer.mode, older.mode) || 'buildup',
       // Score predictions: union by match id. On direct conflict
       // (same match, two predictions), newer side wins so the most

--- a/js/world-cup.js
+++ b/js/world-cup.js
@@ -3677,7 +3677,11 @@
     const { champion, runnerUp } = getChampionAndRunnerUp();
     if (champion && picks.champion && picks.champion === champion) { total += SCORING.champion; breakdown.champion = SCORING.champion; }
     if (runnerUp && picks.runnerUp && picks.runnerUp === runnerUp) { total += SCORING.runnerUp; breakdown.runnerUp = SCORING.runnerUp; }
-    if (picks.goldenBootCorrect) { total += SCORING.goldenBoot; breakdown.goldenBoot = SCORING.goldenBoot; }
+    // Golden Boot is awarded only at the end of the tournament, so its
+    // points can't count until the Final has been played — otherwise the
+    // admin "correct" checkbox (and its OR-merge across devices) awarded
+    // 10 pts prematurely.
+    if (picks.goldenBootCorrect && champion) { total += SCORING.goldenBoot; breakdown.goldenBoot = SCORING.goldenBoot; }
 
     return { total, breakdown };
   }
@@ -5385,7 +5389,15 @@
         // Knockout match: show who they think advances.
         const stagePicks = (picks.ko || {})[m.stage] || {};
         const pickedCode = stagePicks[m.id];
-        if (!pickedCode) {
+        // Only honor a bid if the picked team is actually one of the two
+        // teams in this match. KO picks are keyed by match id, so a pick
+        // made before the bracket wiring was corrected can otherwise show
+        // against the wrong game (e.g. "Brazil" surfacing on a
+        // Paraguay–France tie). Once both sides are resolved, an out-of-
+        // match bid is stale — treat it as no pick rather than mislead.
+        const koSides = [m.home, m.away].filter(Boolean);
+        const bothResolved = koSides.length === 2;
+        if (!pickedCode || (bothResolved && !koSides.includes(pickedCode))) {
           return `<div class="pool-pick"><div>${who}</div><div class="muted" style="font-size:0.8rem;">— no pick —</div><div></div></div>`;
         }
         const c = countryByCode(pickedCode);
@@ -6255,6 +6267,15 @@
       if (document.visibilityState === 'visible') autoSyncTick();
     });
     autoSyncTick();
+    // One-time backfill on open: the interval tick only runs during a
+    // live match window, so a completed result that never persisted (or
+    // was entered on another device) would otherwise need a manual sync
+    // every time. Run one sync ~2s after load — the overwrite gate makes
+    // it add-only for matches that are already over, so it just fills
+    // gaps without touching recorded scores.
+    setTimeout(() => {
+      if (navigator.onLine !== false) syncScores({ quiet: true });
+    }, 2000);
     // refresh countdown every second on home
     setInterval(() => {
       if (document.querySelector('.tab.active')?.dataset.tab === 'home') {

--- a/world-cup.html
+++ b/world-cup.html
@@ -71,9 +71,9 @@
   </div>
 
   <script src="js/auth.js"></script>
-  <script src="js/sync.js?v=9"></script>
+  <script src="js/sync.js?v=10"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/lz-string.js?v=1"></script>
-  <script src="js/world-cup.js?v=45"></script>
+  <script src="js/world-cup.js?v=46"></script>
 </body>
 </html>


### PR DESCRIPTION
Three fixes surfaced from the pool storage readout:

## 1. Golden Boot no longer scores prematurely
Participants were showing 10 Golden Boot points before the award exists. Now:
- Its points require a `champion` (only set once the **Final** has a result).
- The cross-device merge of the admin "correct" flag is **newer-wins** instead of an OR-merge, so a premature or un-checked `true` can actually clear instead of sticking `true` forever across devices.

## 2. Completed scores backfill on open
Finished matches (e.g. **Belgium–Senegal**, **England–DR Congo**) needed a manual "Sync scores" every time. The interval auto-sync only runs during a live match window, so a completed result entered on another device never backfilled on load. Added a one-time quiet sync ~2s after load; the overwrite gate keeps it **add-only** for matches already over, so it fills gaps without touching recorded scores.

## 3. Round-of-16 family picks only show for teams actually in the match
KO picks are keyed by match id, so a bid made before the bracket wiring was corrected could surface against the wrong game (e.g. a "Brazil" bid showing on a Paraguay–France tie). A pick now only displays when the picked team is one of the two resolved teams in that match; an out-of-match bid on a resolved tie is hidden. Scoring was already safe (a stale pick can't match the actual winner of a match it isn't in) — this is a display fix.

Cache-bust bumped: `world-cup.js` → v46, `sync.js` → v10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp

---
_Generated by [Claude Code](https://claude.ai/code/session_01437n4w7iYzACfT9QjSgrpp)_