### PR TITLE
Docs: Add World Cup update to README changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Todo el contenido en este repositorio se adhiere a las [Pautas de Contenido](con
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Actualización World Cup 2026 (World Cup 2026 Update)**: Se corrigió el cálculo de la Bota de Oro, se rellenaron puntajes y se ocultaron pronósticos obsoletos. (Fixed Golden Boot calculation, backfilled scores, and hid stale knockout bids.)
 - **¡Nueva App "Invest Quest"!**: Un simulador de mercado amigable para niños. Aprende sobre riesgo y retorno. (A kid-friendly market simulator. Learn about risk and return).
 - **Refresco de Contenido II (Content Refresh II)**: Más apps con contenido nuevo y más difícil — Chess Quest (tácticas: horquillas, clavadas, jaque mate; finales; aperturas), Money Master (compras múltiples, descuentos, problemas), Bible Explorer (historias y versículos), Guitar Jam (acordes y canciones), Art Studio (obras maestras y lecciones) y más matemáticas (media/mediana/moda, fracciones↔decimales↔porcentajes). (More apps with new, harder content — Chess, Money, Bible, Guitar, Art, and more Math.)
 - **Aprende, no solo respondas (Explain-after-answer)**: Las preguntas ahora muestran una explicación con el dato clave después de responder, en Civics Lab, Descubre Chile, Fe Explorador y el nuevo modo Quiz de World Explorer. (Quizzes now show a short factual explanation after you answer.)


### PR DESCRIPTION
Added a new bullet point to the "What's New This Week" section in the README.md describing the latest repository commit regarding the World Cup 2026 app (fixing the Golden Boot, backfilling completed scores, and hiding stale KO bids), in compliance with content-guidelines.md.

---
*PR created automatically by Jules for task [5157067759258720869](https://jules.google.com/task/5157067759258720869) started by @rozavala*