### PR TITLE
docs: add World Cup 2026 update to changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Todo el contenido en este repositorio se adhiere a las [Pautas de Contenido](con
 
 ## 🆕 Novedades de la Semana (What's New This Week)
 
+- **Actualización World Cup 2026**: Solucionados problemas con la asignación de la Bota de Oro, agregado relleno de resultados anteriores completados y ocultamiento de predicciones de eliminatorias pasadas. (Fixed premature Golden Boot assignment, backfilled completed scores, and hid stale KO bids.)
 - **¡Nueva App "Invest Quest"!**: Un simulador de mercado amigable para niños. Aprende sobre riesgo y retorno. (A kid-friendly market simulator. Learn about risk and return).
 - **Refresco de Contenido II (Content Refresh II)**: Más apps con contenido nuevo y más difícil — Chess Quest (tácticas: horquillas, clavadas, jaque mate; finales; aperturas), Money Master (compras múltiples, descuentos, problemas), Bible Explorer (historias y versículos), Guitar Jam (acordes y canciones), Art Studio (obras maestras y lecciones) y más matemáticas (media/mediana/moda, fracciones↔decimales↔porcentajes). (More apps with new, harder content — Chess, Money, Bible, Guitar, Art, and more Math.)
 - **Aprende, no solo respondas (Explain-after-answer)**: Las preguntas ahora muestran una explicación con el dato clave después de responder, en Civics Lab, Descubre Chile, Fe Explorador y el nuevo modo Quiz de World Explorer. (Quizzes now show a short factual explanation after you answer.)


### PR DESCRIPTION
# DAILY DOCS UPDATE [2026-07-05] — Documentation Guardian Agent
# Task completed: Added latest World Cup 2026 updates to changelog

---
*PR created automatically by Jules for task [9080377144691631735](https://jules.google.com/task/9080377144691631735) started by @rozavala*