### PR TITLE
feat(descubre-chile): add Map Drag Quiz module

### DIFF
--- a/css/descubre-chile.css
+++ b/css/descubre-chile.css
@@ -76,6 +76,20 @@
     .memory-stats{display:flex;gap:16px;justify-content:center;margin:16px 0;font-family:var(--font-display);font-weight:700;color:var(--text-muted);font-size:0.9rem}
     .memory-stats span{color:var(--andes-gold)}
     .memory-msg{text-align:center;font-family:var(--font-display);font-size:1.1rem;font-weight:700;min-height:28px;margin:8px 0}
+
+    .drag-stats{display:flex;gap:16px;justify-content:center;margin:8px 0;font-family:var(--font-display);font-weight:700;color:var(--text-muted);font-size:0.9rem}
+    .drag-stats span{color:var(--andes-gold)}
+    .map-drag-wrap{display:flex;flex-direction:row;align-items:center;justify-content:center;gap:16px;margin-top:10px}
+    .map-drag-wrap .map-svg{height:300px;width:auto;border:1px dashed var(--border-subtle);border-radius:8px;background:rgba(255,255,255,0.05)}
+    .drop-zone{fill:var(--bg-elevated);stroke:var(--border-subtle);stroke-width:2;transition:fill 0.2s}
+    .drop-zone.active-target{fill:rgba(255,255,255,0.2);stroke:var(--chile-red);stroke-width:3}
+    .drop-zone.filled{fill:var(--andes-gold);stroke:#fff}
+    .drag-tokens-container{display:flex;flex-direction:column;gap:10px;width:120px}
+    .drag-token{background:var(--bg-card);border:2px solid var(--border-subtle);border-radius:12px;padding:8px 4px;text-align:center;font-weight:700;font-size:0.8rem;color:var(--text);cursor:grab;user-select:none;touch-action:none;transition:transform 0.1s;box-shadow:0 2px 4px rgba(0,0,0,0.2)}
+    .drag-token:active{cursor:grabbing;transform:scale(1.05)}
+    .drag-token.dragging{position:fixed;z-index:100;opacity:0.9;box-shadow:0 8px 16px rgba(0,0,0,0.3)}
+    .drag-token.placed{visibility:hidden}
+
     .quiz-progress-wrap{width:100%;height:10px;background:var(--bg-card);border-radius:99px;overflow:hidden;margin-bottom:20px;border:1px solid var(--border-subtle)}
     .quiz-progress-fill{height:100%;border-radius:99px;background:linear-gradient(90deg,var(--chile-red),var(--atacama-orange));transition:width 0.5s cubic-bezier(0.34,1.56,0.64,1);box-shadow:0 0 12px var(--chile-red-glow)}
     .quiz-top{width:100%;display:flex;align-items:center;justify-content:space-between;margin-bottom:12px}

--- a/descubre-chile.html
+++ b/descubre-chile.html
@@ -29,6 +29,7 @@
     <button class="tab-btn" data-tab="historia">📖 Historia</button>
     <button class="tab-btn" data-tab="juegos">🎮 Juegos</button>
     <button class="tab-btn" data-tab="quiz">⭐ Quiz</button>
+    <button class="tab-btn" data-tab="mapa-drag">📍 Ubica</button>
   </div>
   <!-- MAPA -->
   <div class="tab-content active" id="tab-mapa">
@@ -70,6 +71,23 @@
   </div>
   <!-- QUIZ -->
   <div class="tab-content" id="tab-quiz"><div id="quizArea"></div></div>
+  <!-- DRAG MAPA -->
+  <div class="tab-content" id="tab-mapa-drag">
+    <p style="text-align:center;font-family:var(--font-display);font-size:1.1rem;font-weight:700;margin-bottom:4px">📍 Ubica la Región</p>
+    <p style="text-align:center;color:var(--text-muted);font-size:0.82rem;font-weight:600;margin-bottom:12px">Arrastra los nombres al lugar correcto</p>
+    <div class="drag-stats">Tiempo: <span id="dragTime">60</span>s &nbsp;|&nbsp; Zonas: <span id="dragScore">0</span>/5</div>
+    <div class="map-drag-wrap">
+      <svg viewBox="0 0 200 600" class="map-svg" id="dragMapSvg">
+        <path class="drop-zone" id="dz-norte" data-id="norte" d="M70,10 L130,10 L135,50 L140,100 L130,140 L110,150 L90,145 L75,130 L65,90 L60,50 Z"/>
+        <path class="drop-zone" id="dz-centro" data-id="centro" d="M90,145 L110,150 L130,140 L125,200 L120,250 L105,260 L85,255 L80,220 L78,180 Z"/>
+        <path class="drop-zone" id="dz-sur" data-id="sur" d="M85,255 L105,260 L120,250 L115,330 L108,370 L95,380 L80,365 L75,320 L78,280 Z"/>
+        <path class="drop-zone" id="dz-patagonia" data-id="patagonia" d="M80,365 L95,380 L108,370 L105,440 L100,500 L95,540 L85,555 L78,530 L72,480 L70,430 L75,390 Z"/>
+        <ellipse class="drop-zone" id="dz-pascua" data-id="pascua" cx="170" cy="280" rx="22" ry="18"/>
+      </svg>
+      <div class="drag-tokens-container" id="dragTokens"></div>
+    </div>
+    <div style="text-align:center;margin-top:12px"><button class="btn-red" id="dragStartBtn" onclick="initDragQuiz()">▶️ Comenzar Reto</button></div>
+  </div>
 </div>
 <div class="region-modal" id="regionModal" onclick="if(event.target===this)closeRegion()"><div class="region-card"><button class="close-modal" aria-label="Close" onclick="closeRegion()">✕</button><h2 id="rmTitle"></h2><div class="region-sub" id="rmSub"></div><div id="rmFacts"></div><div style="text-align:center;margin-top:16px"><button class="btn-red" onclick="closeRegion()">¡Entendido! ✓</button></div></div></div>
 <div class="feedback-float" id="feedback"><span id="feedbackEmoji"></span></div>

--- a/js/descubre-chile.js
+++ b/js/descubre-chile.js
@@ -626,6 +626,115 @@ function finishQ(){
   }
 }
 
+// ── MAP DRAG QUIZ ──
+let dragTimer=null, dragTime=60, dragScore=0;
+const dragRegions = [
+  {id:'norte', name:'Norte', color:'#E87040'},
+  {id:'centro', name:'Centro', color:'#D93636'},
+  {id:'sur', name:'Sur', color:'#2CB5A0'},
+  {id:'patagonia', name:'Patagonia', color:'#0039A6'},
+  {id:'pascua', name:'Rapa Nui', color:'#E8A838'}
+];
+let activeDragEl=null, offsetX=0, offsetY=0;
+
+function initDragQuiz(){
+  clearInterval(dragTimer);
+  dragTime=60; dragScore=0;
+  document.getElementById('dragTime').textContent=dragTime;
+  document.getElementById('dragScore').textContent='0';
+  document.getElementById('dragStartBtn').style.display='none';
+
+  const container = document.getElementById('dragTokens');
+  container.innerHTML='';
+  // reset zones
+  document.querySelectorAll('.drop-zone').forEach(z => {
+    z.classList.remove('filled');
+    z.style.fill='';
+  });
+
+  // Create tokens
+  const shuffled = dragRegions.slice().sort(()=>Math.random()-0.5);
+  shuffled.forEach(r => {
+    const t = document.createElement('div');
+    t.className='drag-token';
+    t.textContent=r.name;
+    t.dataset.id=r.id;
+    t.dataset.color=r.color;
+    container.appendChild(t);
+
+    // Pointer events for drag
+    t.addEventListener('pointerdown', e => {
+      activeDragEl=t;
+      t.classList.add('dragging');
+      t.style.width = t.offsetWidth+'px';
+      const rect = t.getBoundingClientRect();
+      offsetX = e.clientX - rect.left;
+      offsetY = e.clientY - rect.top;
+      t.style.left = (e.clientX - offsetX)+'px';
+      t.style.top = (e.clientY - offsetY)+'px';
+      t.setPointerCapture(e.pointerId);
+    });
+    t.addEventListener('pointermove', e => {
+      if(activeDragEl!==t) return;
+      t.style.left = (e.clientX - offsetX)+'px';
+      t.style.top = (e.clientY - offsetY)+'px';
+      // hit test
+      document.querySelectorAll('.drop-zone').forEach(z=>z.classList.remove('active-target'));
+      t.hidden = true;
+      const elemBelow = document.elementFromPoint(e.clientX, e.clientY);
+      t.hidden = false;
+      if(elemBelow && elemBelow.classList.contains('drop-zone') && !elemBelow.classList.contains('filled')){
+        elemBelow.classList.add('active-target');
+      }
+    });
+    t.addEventListener('pointerup', e => {
+      if(activeDragEl!==t) return;
+      activeDragEl=null;
+      t.classList.remove('dragging');
+      t.releasePointerCapture(e.pointerId);
+      t.hidden = true;
+      const elemBelow = document.elementFromPoint(e.clientX, e.clientY);
+      t.hidden = false;
+
+      document.querySelectorAll('.drop-zone').forEach(z=>z.classList.remove('active-target'));
+
+      if(elemBelow && elemBelow.classList.contains('drop-zone') && elemBelow.dataset.id === t.dataset.id){
+        elemBelow.classList.add('filled');
+        elemBelow.style.fill = t.dataset.color;
+        t.classList.add('placed');
+        if(typeof playSound==='function') playSound('click');
+        dragScore++;
+        document.getElementById('dragScore').textContent=dragScore;
+
+        if(dragScore===dragRegions.length){
+          clearInterval(dragTimer);
+          showFeedback('🏆');
+          if(typeof playSound==='function') playSound('success');
+          saveTopicProgress('dragquiz', 3, 100);
+          document.getElementById('dragStartBtn').style.display='inline-block';
+          document.getElementById('dragStartBtn').textContent='Jugar de nuevo';
+          if(typeof ActivityLog!=='undefined') ActivityLog.log('Descubre Chile','📍','Completó el Reto de Ubicación');
+        }
+      } else {
+        t.style.left=''; t.style.top=''; t.style.width='';
+        if(typeof playSound==='function') playSound('error');
+      }
+    });
+  });
+
+  dragTimer = setInterval(()=>{
+    dragTime--;
+    document.getElementById('dragTime').textContent=dragTime;
+    if(dragTime<=0){
+      clearInterval(dragTimer);
+      document.getElementById('dragStartBtn').style.display='inline-block';
+      document.getElementById('dragStartBtn').textContent='Intentar de nuevo';
+      container.innerHTML=''; // clear tokens
+      if(typeof playSound==='function') playSound('error');
+    }
+  }, 1000);
+}
+
 // ── INIT (safe — runs after DOM ready) ──
 function dcInit(){
   // Auto-pull sync
@@ -644,6 +753,10 @@ function dcInit(){
       const target=document.getElementById('tab-'+e.target.dataset.tab);
       if(target)target.classList.add('active');
       e.target.classList.add('active');
+
+      if(e.target.dataset.tab === 'mapa-drag' && document.getElementById('dragScore').textContent === '0') {
+        // Ready to start
+      }
     });
   }
 


### PR DESCRIPTION
This pull request implements the first available Tier 2 backlog item: **Descubre Chile: Map Drag Quiz**.

*   **New Feature:** Added a "📍 Ubica" (Map Drag) tab to the `descubre-chile.html` module.
*   **Gameplay:** Kids must drag region names (Norte, Centro, Sur, Patagonia, Rapa Nui) onto the correct zones of a blank Chile map.
*   **Time Limit:** There is a 60-second timer to complete the challenge.
*   **Tech Stack:** Uses pure vanilla JavaScript (pointer events for drag-and-drop, `elementFromPoint` for drop zone hit-testing), inline SVG for the map, and CSS for styling.
*   **Integration:**
    *   Awards stars and records completion via `saveTopicProgress`.
    *   Logs the activity to the dashboard via `ActivityLog.log`.
    *   Provides audio feedback using the shared `SFX` system (`playSound`).
*   **Testing:** Passed all compliance checks, existing unit tests, and Playwright verification scripts.

---
*PR created automatically by Jules for task [13668828829417909814](https://jules.google.com/task/13668828829417909814) started by @rozavala*