### PR TITLE
Make Patrón de Lancha progress per-profile with cloud sync

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -28,6 +28,7 @@ var CloudSync = (function() {
     'zs_routines_': 'routines',
     'zs_money_': 'money',
     'zs_worldcup_': 'worldcup',
+    'zs_patron_': 'patron',
     'littlemaestro_': 'littlemaestro',
   };
 

--- a/patron-lancha.html
+++ b/patron-lancha.html
@@ -257,6 +257,10 @@
 
   <div class="feedback-float" id="pl-feedback"><span id="pl-feedback-emoji"></span></div>
 
+  <!-- Perfiles y sincronización compartidos del proyecto -->
+  <script src="js/auth.js?v=2"></script>
+  <script src="js/sync.js?v=9"></script>
+
   <script>
   /* =====================================================================
      PATRÓN DE LANCHA DEPORTIVA — Contenido y motor de estudio
@@ -853,14 +857,37 @@
   /* ===================================================================
      ESTADO / PERSISTENCIA
      =================================================================== */
-  const STORE_KEY = 'pl_patron_v1';
-  const state = loadState();
+  const STORE_PREFIX = 'zs_patron_';       // clave por perfil: zs_patron_<usuario>
+  const LEGACY_KEY   = 'pl_patron_v1';     // clave global antigua (se migra 1 vez)
+
+  // Clave del perfil activo (auth.js). Sin perfil → bucket "default".
+  function storageKey(){
+    return (typeof getUserAppKey === 'function' && getUserAppKey(STORE_PREFIX)) || (STORE_PREFIX + 'default');
+  }
+  function defaultState(){ return { read:{}, best:{}, examBest:0, examCount:0, answered:0, correct:0 }; }
 
   function loadState(){
-    try{ const s = JSON.parse(localStorage.getItem(STORE_KEY)); if(s) return s; }catch(e){}
-    return { read:{}, best:{}, examBest:0, examCount:0, answered:0, correct:0 };
+    const key = storageKey();
+    try{ const s = JSON.parse(localStorage.getItem(key)); if(s) return Object.assign(defaultState(), s); }catch(e){}
+    // Migración única: el primer perfil que abra la app hereda el progreso
+    // global antiguo; luego se elimina para que otros perfiles empiecen limpios.
+    try{
+      const old = JSON.parse(localStorage.getItem(LEGACY_KEY));
+      if(old){
+        localStorage.setItem(key, JSON.stringify(old));
+        localStorage.removeItem(LEGACY_KEY);
+        return Object.assign(defaultState(), old);
+      }
+    }catch(e){}
+    return defaultState();
   }
-  function saveState(){ try{ localStorage.setItem(STORE_KEY, JSON.stringify(state)); }catch(e){} }
+  function saveState(){
+    const key = storageKey();
+    try{ localStorage.setItem(key, JSON.stringify(state)); }catch(e){}
+    if(typeof CloudSync !== 'undefined' && CloudSync.online){ try{ CloudSync.push(key); }catch(e){} }
+  }
+
+  let state = loadState();
 
   /* ===================================================================
      APP
@@ -1156,8 +1183,8 @@
 
     resetProgress(){
       if(!confirm('¿Reiniciar todo tu progreso de estudio?')) return;
-      localStorage.removeItem(STORE_KEY);
-      Object.assign(state, { read:{}, best:{}, examBest:0, examCount:0, answered:0, correct:0 });
+      Object.assign(state, defaultState());
+      saveState();
       this.renderModules(); this.renderProgress(); this.updateOverall();
     },
 
@@ -1176,6 +1203,15 @@
   }
 
   PL.init();
+
+  // La sincronización con la nube (sync.js) pudo traer progreso de otro
+  // dispositivo: recarga el estado del perfil activo y re-renderiza.
+  window.addEventListener('zs:synced', function(){
+    state = loadState();
+    PL.renderModules();
+    PL.renderProgress();
+    PL.updateOverall();
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Contexto

Revisé cómo la app **Patrón de Lancha** guardaba el progreso: **sí persistía**, pero bajo una **única clave global** de `localStorage`, así que todos los perfiles de un dispositivo compartían (y se pisaban) el mismo avance, y **no se sincronizaba** entre dispositivos — a diferencia del resto de las apps del proyecto.

## Cambios

- **Progreso por perfil**: se guarda bajo `zs_patron_<usuario>` usando `getUserAppKey` de `auth.js`; si no hay perfil activo, usa un bucket `default`.
- **Migración única**: el primer perfil que abre la app hereda el progreso global antiguo (`pl_patron_v1`); luego la clave antigua se elimina para que los demás perfiles empiecen limpios (corrige que cada perfil nuevo heredara datos ajenos).
- **Sincronización en la nube**: `CloudSync.push()` al guardar y recarga/re-render al recibir el evento `zs:synced` (mismo patrón que las otras apps).
- **`sync.js`**: se registra `'zs_patron_': 'patron'` en el `KEY_MAP` para que push/pull/pullAll reconozcan la app.

## Archivos
- `patron-lancha.html` — almacenamiento por perfil + sync + migración.
- `js/sync.js` — nueva entrada en `KEY_MAP`.

## Verificación (Playwright)
- Migración única: Rodrigo hereda el progreso antiguo (5 respuestas) y la clave global se elimina; Ximena arranca **limpia** (0%).
- Perfiles separados: responder como un perfil no afecta al otro.
- `zs:synced`: al llegar datos de otro dispositivo, la vista se recarga y re-renderiza.
- `CloudSync` definido y sin errores de JavaScript (offline muestra la píldora ☁️ como el resto de la suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFcz6FCrvPREhAhQX3bpEv)_