### PR TITLE
Vacation Planner: add Reveal slideshow link to a trip

### DIFF
--- a/css/vacation.css
+++ b/css/vacation.css
@@ -385,6 +385,25 @@
   font-size: 0.85rem;
 }
 
+/* Reveal slideshow button */
+.vc-reveal-btn {
+  display: block;
+  text-align: center;
+  text-decoration: none;
+  margin: 4px 0 18px;
+  padding: 14px 18px;
+  border-radius: 14px;
+  font-family: var(--font-display);
+  font-weight: 800;
+  font-size: 1.05rem;
+  color: #fff;
+  background: linear-gradient(135deg, #DB2777, #7C3AED, #2563EB);
+  box-shadow: 0 8px 22px rgba(124,58,237,0.35);
+  transition: transform 0.12s, box-shadow 0.2s;
+}
+.vc-reveal-btn:hover { transform: translateY(-2px); box-shadow: 0 12px 28px rgba(124,58,237,0.45); }
+.vc-reveal-btn:active { transform: translateY(0); }
+
 /* Overview */
 .vc-overview { font-size: 0.92rem; font-weight: 600; color: var(--text); line-height: 1.5; }
 .vc-overview p { margin: 0 0 10px; }

--- a/js/vacation.js
+++ b/js/vacation.js
@@ -165,6 +165,7 @@ var Vacation = (function() {
     var end = document.getElementById('vc-new-end').value;
     var icon = document.getElementById('vc-new-icon').value.trim() || '✈️';
     var overview = document.getElementById('vc-new-overview').value.trim();
+    var slidesUrl = document.getElementById('vc-new-slides').value.trim();
     var hidden = document.getElementById('vc-new-hidden').checked;
 
     if (!name || !start) {
@@ -195,6 +196,7 @@ var Vacation = (function() {
       notes: '',
       hidden: hidden,
       overview: overview,
+      slidesUrl: slidesUrl,
       images: [],
       suggestions: [],
       packing: packing,
@@ -261,6 +263,7 @@ var Vacation = (function() {
     trip.endDate = end || start;
     trip.overview = document.getElementById('vc-edit-overview').value.trim();
     trip.hidden = document.getElementById('vc-edit-hidden').checked;
+    trip.slidesUrl = document.getElementById('vc-edit-slides').value.trim();
     trip.images = _parseImages(document.getElementById('vc-edit-images').value);
     trip.suggestions = _parseSuggestions(document.getElementById('vc-edit-suggestions').value);
 
@@ -415,6 +418,7 @@ var Vacation = (function() {
           '<div class="vc-field"><label>Start date</label><input type="date" id="vc-new-start"></div>' +
           '<div class="vc-field"><label>End date (optional)</label><input type="date" id="vc-new-end"></div>' +
           '<div class="vc-field"><label>Overview (optional)</label><textarea id="vc-new-overview" rows="3" placeholder="A short intro to the trip…" maxlength="2000"></textarea></div>' +
+          '<div class="vc-field"><label>Reveal slideshow URL (optional)</label><input type="text" id="vc-new-slides" placeholder="e.g. vacation-reveal.html"></div>' +
           '<label class="vc-check"><input type="checkbox" id="vc-new-hidden">' +
             '<span>🤫 Surprise — hide from the kids until I reveal it</span></label>' +
           '<div class="vc-form-actions">' +
@@ -459,6 +463,8 @@ var Vacation = (function() {
             '<textarea id="vc-edit-images" rows="5" placeholder="https://example.com/photo.jpg | A sunny beach">' + _esc(imagesText) + '</textarea></div>' +
           '<div class="vc-field"><label>Ideas &amp; tips — one per line: <code>icon | title | text</code></label>' +
             '<textarea id="vc-edit-suggestions" rows="5" placeholder="🛂 | Passports | Check they\'re valid 6+ months out">' + _esc(suggText) + '</textarea></div>' +
+          '<div class="vc-field"><label>Reveal slideshow URL (optional)</label>' +
+            '<input type="text" id="vc-edit-slides" placeholder="e.g. vacation-reveal.html" value="' + _esc(trip.slidesUrl || '') + '"></div>' +
           '<label class="vc-check"><input type="checkbox" id="vc-edit-hidden"' + (trip.hidden ? ' checked' : '') + '>' +
             '<span>🤫 Surprise — hide from the kids until I reveal it</span></label>' +
           '<p class="vc-form-hint">Packing and the day-by-day itinerary are edited on the trip page itself.</p>' +
@@ -515,6 +521,9 @@ var Vacation = (function() {
             (trip.endDate && trip.endDate !== trip.startDate ? ' → ' + _esc(trip.endDate) : '') + '</span>' : '') +
           (cd ? '<span class="vc-countdown ' + cd.kind + '">' + _esc(cd.text) + '</span>' : '') +
         '</div>' +
+        (trip.slidesUrl
+          ? '<a class="vc-reveal-btn" href="' + _esc(trip.slidesUrl) + '" target="_blank" rel="noopener">🎉 Reveal slideshow</a>'
+          : '') +
         overviewHtml +
         galleryHtml +
         suggestionsHtml +

--- a/vacation.html
+++ b/vacation.html
@@ -8,7 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Baloo+2:wght@500;600;700;800&family=Nunito:wght@400;600;700;800;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/common.css">
-  <link rel="stylesheet" href="css/vacation.css?v=2">
+  <link rel="stylesheet" href="css/vacation.css?v=3">
   <link rel="stylesheet" href="css/zs-theme.css">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#7C3AED">
@@ -30,7 +30,7 @@
   <script src="js/sync.js?v=9"></script>
   <script src="js/zs-diag.js?v=3"></script>
   <script src="js/nav.js"></script>
-  <script src="js/vacation.js?v=3"></script>
+  <script src="js/vacation.js?v=4"></script>
   <script src="js/pwa.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Adds an optional **Reveal slideshow** link to a trip — a generic feature for pointing at a surprise-reveal deck hosted alongside the app. No trip content is included here.

## Changes (`js/vacation.js`, `css/vacation.css`, `vacation.html`)
- Trips gain an optional `slidesUrl`. When set, the detail view shows a prominent **🎉 Reveal slideshow** button that opens the URL in a new tab.
- The field is editable from both the new-trip and edit-trip forms.
- Cache-bust bumped to `js/vacation.js?v=4` / `css/vacation.css?v=3` so the new UI is fetched immediately.

Usage: host a self-contained reveal deck (e.g. `vacation-reveal.html`) next to the app on the tailnet, then set the trip's "Reveal slideshow URL" to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjp4R2QzmkTMVoxTQ3egXB)_