### PR TITLE
VPS: serve a private, VPN-only static folder for reveal decks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ playwright/.cache/
 .env
 .env.local
 vps/.env
+
+# Private, VPN-only assets served by the VPS (e.g. surprise-reveal decks).
+# Never committed to the public repo.
+private/

--- a/vps/server.js
+++ b/vps/server.js
@@ -19,6 +19,17 @@ app.use(express.json({ limit: '5mb' }));
 
 if (!fs.existsSync(DATA_DIR)) fs.mkdirSync(DATA_DIR, { recursive: true });
 
+// Private static assets (e.g. a surprise-reveal slideshow). Because this
+// server is only reachable over the Tailscale tailnet, anything here is
+// served exclusively to devices on the family VPN — never to the public
+// GitHub Pages site. The folder is gitignored, so private files never
+// reach the repo, and they survive the deploy's `git reset --hard`
+// because they're untracked. Drop files in /opt/zavala-sync/private/ and
+// reach them at https://<vps-tailnet-host>/private/<file>.
+const PRIVATE_DIR = path.join(__dirname, '..', 'private');
+if (!fs.existsSync(PRIVATE_DIR)) fs.mkdirSync(PRIVATE_DIR, { recursive: true });
+app.use('/private', express.static(PRIVATE_DIR));
+
 // Register Book & Movie Check media endpoints
 media.init(app, DATA_DIR);
 


### PR DESCRIPTION
Lets the VPS host private assets (like a surprise-reveal slideshow) that are reachable **only over the Tailscale VPN**, so trip secrets stay off the public GitHub Pages site.

## Change (`vps/server.js`, `.gitignore`)
- `server.js` mounts `/private` → `<repo>/../private` via `express.static`. Since the VPS is only reachable on the tailnet, files here are served exclusively to VPN devices.
- `private/` is gitignored — nothing there enters the public repo — and, being untracked, it survives the deploy workflow's `git reset --hard`.

## How it's used
1. On the droplet: `mkdir -p /opt/zavala-sync/private` and drop `vacation-reveal.html` in it.
2. It's then reachable (on VPN) at `https://<vps-tailnet-host>/private/vacation-reveal.html`.
3. Set the trip's **Reveal slideshow URL** to that absolute URL. The public app shell + VPN gate the private deck exactly like the trip data.

Triggers the `deploy-vps.yml` workflow (touches `vps/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tjp4R2QzmkTMVoxTQ3egXB)_